### PR TITLE
feat: rename op-ufm circle ci modules

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -359,14 +359,6 @@ workflows:
           docker_name: op-conductor-mon
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           docker_context: .
-      - docker-publish:
-          name: op-conductor-mon-docker-publish
-          docker_name: op-conductor-mon
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          context:
-            - oplabs-gcr
-          requires:
-            - op-conductor-mon-docker-build
   op-ufm:
     when:
       or: [<< pipeline.parameters.run-build-op-ufm >>, << pipeline.parameters.run-all >>]
@@ -434,6 +426,7 @@ workflows:
             - oplabs-gcr
           requires:
             - op-ufm-docker-build
+
       - docker-build:
           name: proxyd-docker-build
           filters:
@@ -462,3 +455,18 @@ workflows:
             - oplabs-gcr-release
           requires:
             - proxyd-docker-build
+
+      - docker-build:
+          name: op-conductor-mon-docker-build
+          docker_file: op-conductor-mon/Dockerfile
+          docker_name: op-conductor-mon
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          docker_context: .
+      - docker-publish:
+          name: op-conductor-mon-docker-publish
+          docker_name: op-conductor-mon
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          context:
+            - oplabs-gcr
+          requires:
+            - op-conductor-mon-docker-build

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -372,10 +372,10 @@ workflows:
       or: [<< pipeline.parameters.run-build-op-ufm >>, << pipeline.parameters.run-all >>]
     jobs:
       - go-lint:
-          name: op-conductor-mon-lint
+          name: op-ufm-lint
           module: op-ufm
       - go-test:
-          name: op-conductor-mon-tests
+          name: op-ufm-tests
           module: op-ufm
       - docker-build:
           name: op-ufm-docker-build


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The duplicates are removed, the op-ufm flow had incorrect names. Also I removed the publish from op-conductor-mon pr flow. and added build and publish for op-conductor-mon into release

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
