### PR TITLE
Option to disable shuffle

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -151,6 +151,7 @@ type BackendGroupConfig struct {
 	Backends []string `toml:"backends"`
 
 	WeightedRouting bool `toml:"weighted_routing"`
+	DisableShuffle  bool `toml:"disable_shuffle"`
 
 	RoutingStrategy RoutingStrategy `toml:"routing_strategy"`
 

--- a/proxyd/integration_tests/consensus_disable_shuffle_test.go
+++ b/proxyd/integration_tests/consensus_disable_shuffle_test.go
@@ -1,0 +1,65 @@
+package integration_tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsensusDisableShuffle(t *testing.T) {
+	nodes, bg, client, shutdown := setupConsensusTest(t, "consensus_disable_shuffle")
+	defer nodes["node1"].mockBackend.Close()
+	defer nodes["node2"].mockBackend.Close()
+	defer shutdown()
+
+	ctx := context.Background()
+
+	// poll for updated consensus
+	update := func() {
+		for _, be := range bg.Backends {
+			bg.Consensus.UpdateBackend(ctx, be)
+		}
+		bg.Consensus.UpdateBackendGroupConsensus(ctx)
+	}
+
+	// convenient methods to manipulate state and mock responses
+	reset := func() {
+		for _, node := range nodes {
+			node.handler.ResetOverrides()
+			node.mockBackend.Reset()
+			node.backend.ClearSlidingWindows()
+		}
+		bg.Consensus.ClearListeners()
+		bg.Consensus.Reset()
+
+	}
+
+	t.Run("test shuffling is disabled in consensus mode", func(t *testing.T) {
+		reset()
+		update()
+
+		// reset request counts
+		nodes["node1"].mockBackend.Reset()
+		nodes["node2"].mockBackend.Reset()
+
+		require.Equal(t, 0, len(nodes["node1"].mockBackend.Requests()))
+		require.Equal(t, 0, len(nodes["node2"].mockBackend.Requests()))
+
+		numberReqs := 20
+		for numberReqs > 0 {
+			_, statusCode, err := client.SendRPC("eth_getBlockByNumber", []interface{}{"0x101", false})
+			require.NoError(t, err)
+			require.Equal(t, 200, statusCode)
+			numberReqs--
+		}
+
+		msg := fmt.Sprintf("n1 %d, n2 %d",
+			len(nodes["node1"].mockBackend.Requests()), len(nodes["node2"].mockBackend.Requests()))
+
+		// odds of 20 requests going to one node is 1 in 2^20 if shuffling is enabled, thus must be not shuffling
+		require.Equal(t, 20, len(nodes["node1"].mockBackend.Requests()), msg)
+		require.Equal(t, 0, len(nodes["node2"].mockBackend.Requests()), msg)
+	})
+}

--- a/proxyd/integration_tests/consensus_test.go
+++ b/proxyd/integration_tests/consensus_test.go
@@ -23,7 +23,7 @@ type nodeContext struct {
 	handler     *ms.MockedHandler // this is where we control the state of mocked responses
 }
 
-func setup(t *testing.T) (map[string]nodeContext, *proxyd.BackendGroup, *ProxydHTTPClient, func()) {
+func setupConsensusTest(t *testing.T, configName string) (map[string]nodeContext, *proxyd.BackendGroup, *ProxydHTTPClient, func()) {
 	// setup mock servers
 	node1 := NewMockBackend(nil)
 	node2 := NewMockBackend(nil)
@@ -51,7 +51,7 @@ func setup(t *testing.T) (map[string]nodeContext, *proxyd.BackendGroup, *ProxydH
 	node2.SetHandler(http.HandlerFunc(h2.Handler))
 
 	// setup proxyd
-	config := ReadConfig("consensus")
+	config := ReadConfig(configName)
 	svr, shutdown, err := proxyd.Start(config)
 	require.NoError(t, err)
 
@@ -82,7 +82,7 @@ func setup(t *testing.T) (map[string]nodeContext, *proxyd.BackendGroup, *ProxydH
 }
 
 func TestConsensus(t *testing.T) {
-	nodes, bg, client, shutdown := setup(t)
+	nodes, bg, client, shutdown := setupConsensusTest(t, "consensus")
 	defer nodes["node1"].mockBackend.Close()
 	defer nodes["node2"].mockBackend.Close()
 	defer shutdown()

--- a/proxyd/integration_tests/testdata/consensus_disable_shuffle.toml
+++ b/proxyd/integration_tests/testdata/consensus_disable_shuffle.toml
@@ -1,0 +1,31 @@
+[server]
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 1
+max_degraded_latency_threshold = "30ms"
+
+[backends]
+[backends.node1]
+rpc_url = "$NODE1_URL"
+
+[backends.node2]
+rpc_url = "$NODE2_URL"
+
+[backend_groups]
+[backend_groups.node]
+backends = ["node1", "node2"]
+routing_strategy = "consensus_aware"
+disable_shuffle = true
+consensus_handler = "noop" # allow more control over the consensus poller for tests
+consensus_ban_period = "1m"
+consensus_max_update_threshold = "2m"
+consensus_max_block_lag = 8
+consensus_min_peer_count = 4
+
+[rpc_method_mappings]
+eth_call = "node"
+eth_chainId = "node"
+eth_blockNumber = "node"
+eth_getBlockByNumber = "node"
+consensus_getReceipts = "node"

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -227,6 +227,7 @@ func Start(config *Config) (*Server, func(), error) {
 			Name:             bgName,
 			Backends:         backends,
 			WeightedRouting:  bg.WeightedRouting,
+			DisableShuffle:   bg.DisableShuffle,
 			FallbackBackends: fallbackBackends,
 			routingStrategy:  bg.RoutingStrategy,
 		}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
In consensus aware mode, it currently always does shuffling/round robin among the healthy nodes. However it doesn't quite fit with our use case given that we'd like to always route the request to the main node if the main node is healthy. Because of this we have to run the vanilla settings and can't leverage the health checks consensus aware mode provides.

Thus, I'd like to add an option to disable shuffling so that the main node is always attempted first unless it's unhealthy/banned in consensus aware mode.

**Tests**
Added an integration test to test `disable_shuffle: true`.

**Additional context**
N/A

**Metadata**

- Fixes #[Link to Issue]
