### PR TITLE
feat: add docker registry image tagging to release workflow

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -247,7 +247,7 @@ jobs:
           name: Tag
           command: |
             gcloud auth configure-docker <<parameters.registry>>
-            ./ops/scripts/ci-docker-tag-op-stack-release.sh <<parameters.registry>>/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
+            ./ops/ci-tag-docker-release/ci-docker-tag-op-stack-release.sh <<parameters.registry>>/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
 
   go-lint:
     parameters:
@@ -476,6 +476,17 @@ workflows:
             - oplabs-gcr-release
           requires:
             - op-ufm-docker-build
+      - docker-tag-op-stack-release:
+          name: docker-tag-op-ufm-release
+          filters:
+            tags:
+              only: /^op-ufm\/v.*/
+            branches:
+              ignore: /.*/
+          context:
+            - oplabs-gcr-release
+          requires:
+            - op-ufm-docker-publish
       - docker-build:
           name: proxyd-docker-build
           filters:
@@ -500,7 +511,17 @@ workflows:
             - oplabs-gcr-release
           requires:
             - proxyd-docker-build
-
+      - docker-tag-op-stack-release:
+          name: docker-tag-op-stack-release
+          filters:
+            tags:
+              only: /^proxyd\/v.*/
+            branches:
+              ignore: /.*/
+          context:
+            - oplabs-gcr-release
+          requires:
+            - proxyd-docker-release
       - docker-build:
           name: op-conductor-mon-docker-build
           filters:
@@ -522,3 +543,14 @@ workflows:
             - oplabs-gcr-release
           requires:
             - op-conductor-mon-docker-build
+      - docker-tag-op-stack-release:
+          name: docker-tag-op-stack-release
+          filters:
+            tags:
+              only: /^op-conductor-mon\/v.*/
+            branches:
+              ignore: /.*/
+          context:
+            - oplabs-gcr-release
+          requires:
+            - op-conductor-mon-docker-publish

--- a/ops/ci-tag-docker-release/ci-docker-tag-op-stack-release.sh
+++ b/ops/ci-tag-docker-release/ci-docker-tag-op-stack-release.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DOCKER_REPO=$1
+GIT_TAG=$2
+GIT_SHA=$3
+
+IMAGE_NAME=$(echo "$GIT_TAG" | grep -Eow '^(proxyd|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)' || true)
+if [ -z "$IMAGE_NAME" ]; then
+  echo "image name could not be parsed from git tag '$GIT_TAG'"
+  exit 1
+fi
+IMAGE_TAG=$(echo "$GIT_TAG" | grep -Eow 'v.*' || true)
+if [ -z "$IMAGE_TAG" ]; then
+  echo "image tag could not be parsed from git tag '$GIT_TAG'"
+  exit 1
+fi
+
+SOURCE_IMAGE_TAG="$DOCKER_REPO/$IMAGE_NAME:$GIT_SHA"
+TARGET_IMAGE_TAG="$DOCKER_REPO/$IMAGE_NAME:$IMAGE_TAG"
+TARGET_IMAGE_TAG_LATEST="$DOCKER_REPO/$IMAGE_NAME:latest"
+
+echo "Checking if docker images exist for '$IMAGE_NAME'"
+echo ""
+tags=$(gcloud container images list-tags "$DOCKER_REPO/$IMAGE_NAME" --limit 1 --format json)
+if [ "$tags" = "[]" ]; then
+  echo "No existing docker images were found for '$IMAGE_NAME'. The code tagged with '$GIT_TAG' may not have an associated dockerfile or docker build job."
+  echo "If this service has a dockerfile, add a docker-publish job for it in the circleci config."
+  echo ""
+  echo "Exiting"
+  exit 0
+fi
+
+echo "Tagging $SOURCE_IMAGE_TAG with '$IMAGE_TAG'"
+gcloud container images add-tag -q "$SOURCE_IMAGE_TAG" "$TARGET_IMAGE_TAG"
+
+# Do not tag with latest if the release is a release candidate.
+if [[ "$IMAGE_TAG" == *"rc"* ]]; then
+  echo "Not tagging with 'latest' because the release is a release candidate."
+  exit 0
+fi
+
+echo "Tagging $SOURCE_IMAGE_TAG with 'latest'"
+gcloud container images add-tag -q "$SOURCE_IMAGE_TAG" "$TARGET_IMAGE_TAG_LATEST"


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
* Add docker image tagging to release workflow

**Tests**
* Test Runs available in CI

Working [CI Runs](https://app.circleci.com/pipelines/github/ethereum-optimism/infra/311/workflows/584dc402-8362-4dcb-8bf2-4b1b156c8ecf/jobs/1678) and [image Registry](https://console.cloud.google.com/artifacts/docker/oplabs-tools-artifacts/us/images/proxyd)

**Metadata**

- Fixes #[Link to Issue]
