### PR TITLE
fix: Mutlicall goroutine memory leak 

### DIFF
--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -445,6 +445,7 @@ var (
 	}, []string{
 		"backend_group",
 		"backend_name",
+		"error",
 	})
 )
 
@@ -615,8 +616,8 @@ func RecordBackendGroupMulticallRequest(bg *BackendGroup, backendName string) {
 	backendGroupMulticallCounter.WithLabelValues(bg.Name, backendName).Inc()
 }
 
-func RecordBackendGroupMulticallCompletion(bg *BackendGroup, backendName string) {
-	backendGroupMulticallCompletionCounter.WithLabelValues(bg.Name, backendName).Inc()
+func RecordBackendGroupMulticallCompletion(bg *BackendGroup, backendName string, error string) {
+	backendGroupMulticallCompletionCounter.WithLabelValues(bg.Name, backendName, error).Inc()
 }
 
 func boolToFloat64(b bool) float64 {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
* This PR fixes a memory leak within the Mutlicall logic.  The bug occured when goroutines within ExecuteMutlicall were unable to place responses into the the multicall channel. This happened because after the first result was processed and returned, subsequent mutlicall results were only put onto the channel but never taken off an unbuffered channel, which resulted in hanging goroutines.  This PR creates the channel a buffered channel the length of the multicall backend group. This allows all goroutines to successfully place their results onto the channel and successfully exit.

**Tests**
* Tesed locally. 

**Additional context**
* In the below context we can see after executing 80+ multicall transactions, the go number of goroutines is will remain steadily at its baseline of ~24. 

```
curl localhost:7300/metrics | grep -e "goroutine" -e "multicall"

 HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 24

# HELP proxyd_backend_group_multicall_completion_counter Record the amount of completed multicall requests
# TYPE proxyd_backend_group_multicall_completion_counter counter
proxyd_backend_group_multicall_completion_counter{backend_group="main",backend_name="alchemy",error="nil"} 88
proxyd_backend_group_multicall_completion_counter{backend_group="main",backend_name="bad",error="no backends available for method"} 88
proxyd_backend_group_multicall_completion_counter{backend_group="main",backend_name="infura",error="nil"} 88

# HELP proxyd_backend_group_multicall_request_counter Record the amount of multicall requests
# TYPE proxyd_backend_group_multicall_request_counter counter
proxyd_backend_group_multicall_request_counter{backend_group="main",backend_name="alchemy"} 88
proxyd_backend_group_multicall_request_counter{backend_group="main",backend_name="bad"} 88
proxyd_backend_group_multicall_request_counter{backend_group="main",backend_name="infura"} 88
```

**Metadata**

- Fixes #[208](https://github.com/ethereum-optimism/devinfra-pod/issues/208)
