### PR TITLE
Move base rate rate limit check inside handleBatchRPC()

### DIFF
--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -455,9 +455,8 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			continue
 		}
 
-		// Take global rate limit first
+		// Take base rate limit first
 		if isLimited("") {
-			fmt.Println("HERERERERE")
 			log.Info(
 				"rate limited individual RPC in a batch request",
 				"source", "rpc",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
At Base we recently experienced batch requests spam, and we found out that batch requests aren't rate limited by `base_rate` but only `method_overrides`. Thus introducing this change so that batch requests would be rate limited by `base_rate` too.

The reason why moving this inside `handleBatchRPC()` is because both batch and non-batch requests go to this method, thus it makes sense to just do the check there instead. This also excludes the batch request itself which is even more ideal.


**Tests**
Added a test in `rate_limit_test.go` to check that batch requests are indeed rate limited by base rate too, and other functionalities function as usual.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
