### PR TITLE
Add healthcheck ordering to simple failover mode

### DIFF
--- a/proxyd/integration_tests/failover_test.go
+++ b/proxyd/integration_tests/failover_test.go
@@ -87,7 +87,7 @@ func TestFailover(t *testing.T) {
 		})
 	}
 
-	// the bad endpoint has had 10 requests with 8 error (3xx/4xx/5xx) responses, it should be marked as unhealthy
+	// the bad endpoint has had 10 requests with 8 error (3xx/4xx/5xx) responses, it should be marked as unhealthy and deprioritized
 	t.Run("bad endpoint marked as unhealthy", func(t *testing.T) {
 		badBackend.SetHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			time.Sleep(2 * time.Second)

--- a/proxyd/integration_tests/failover_test.go
+++ b/proxyd/integration_tests/failover_test.go
@@ -87,7 +87,7 @@ func TestFailover(t *testing.T) {
 		})
 	}
 
-	// the bad endpoint has had 10 requests with 8 4xx/5xx responses, it should be marked as unhealthy
+	// the bad endpoint has had 10 requests with 8 error (3xx/4xx/5xx) responses, it should be marked as unhealthy
 	t.Run("bad endpoint marked as unhealthy", func(t *testing.T) {
 		badBackend.SetHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			time.Sleep(2 * time.Second)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Currently for the vanilla setting (simple failover), it doesn't do any health checks. However it still makes sense to order the endpoints in a way such that the ones that are experiencing high error/high latency should be deprioritized. 

**Tests**
Added a unit test to prove that when an endpoint is experiencing high errors, it would reorder the endpoints so that the good endpoint would be put in front of the bad one.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
