### PR TITLE
Multicall testcase improvements

### DIFF
--- a/proxyd/integration_tests/multicall_test.go
+++ b/proxyd/integration_tests/multicall_test.go
@@ -3,7 +3,6 @@ package integration_tests
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -58,7 +57,6 @@ func setupMulticall(t *testing.T) (map[string]nodeContext, *proxyd.BackendGroup,
 
 	// setup proxyd
 	config := ReadConfig("multicall")
-	fmt.Printf("[SetupMulticall] Using Timeout of %d \n", config.Server.TimeoutSeconds)
 	svr, shutdown, err := proxyd.Start(config)
 	require.NoError(t, err)
 
@@ -93,6 +91,7 @@ func setupMulticall(t *testing.T) (map[string]nodeContext, *proxyd.BackendGroup,
 
 	handlers := []*ms.MockedHandler{&h1, &h2, &h3}
 
+	// Default Handler configurations
 	nodes["node1"].mockBackend.SetHandler(SingleResponseHandler(200, txAccepted))
 	nodes["node2"].mockBackend.SetHandler(http.HandlerFunc(handlers[1].Handler))
 	//Node 3 has no handler empty handler never respondes should always context timeout
@@ -194,29 +193,29 @@ func TestMulticall(t *testing.T) {
 		defer nodes["node3"].mockBackend.Close()
 		defer shutdown()
 
-		shutdownChan1 := make(chan struct{})
-		shutdownChan2 := make(chan struct{})
-		shutdownChan3 := make(chan struct{})
+		triggerHandlerChan1 := make(chan struct{})
+		triggerHandlerChan2 := make(chan struct{})
+		triggerHandlerChan3 := make(chan struct{})
 
-		nodes["node1"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(200, txAccepted, shutdownChan1, 3*time.Second))
-		nodes["node2"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(200, txAccepted, shutdownChan2, 0*time.Second))
-		nodes["node3"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(200, txAccepted, shutdownChan3, 3*time.Second))
-
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			shutdownChan2 <- struct{}{}
-			shutdownChan1 <- struct{}{}
-			shutdownChan3 <- struct{}{}
-			wg.Done()
-		}()
+		nodes["node1"].mockBackend.SetHandler(TriggerResponseHandler(200, txAccepted, triggerHandlerChan1))
+		nodes["node2"].mockBackend.SetHandler(TriggerResponseHandler(200, txAccepted, triggerHandlerChan2))
+		nodes["node3"].mockBackend.SetHandler(TriggerResponseHandler(200, txAccepted, triggerHandlerChan3))
 
 		localSvr := setServerBackend(svr, nodes)
-
 		body := makeSendRawTransaction(txHex1)
 		req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body))
 		req.Header.Set("X-Forwarded-For", "203.0.113.1")
 		rr := httptest.NewRecorder()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			triggerHandlerChan2 <- struct{}{}
+			time.Sleep(2 * time.Second)
+			triggerHandlerChan1 <- struct{}{}
+			triggerHandlerChan3 <- struct{}{}
+			wg.Done()
+		}()
 
 		localSvr.HandleRPC(rr, req)
 
@@ -247,20 +246,12 @@ func TestMulticall(t *testing.T) {
 
 		defer shutdown()
 
-		shutdownChan1 := make(chan struct{})
-		shutdownChan2 := make(chan struct{})
+		triggerHandlerChan1 := make(chan struct{})
+		triggerHandlerChan2 := make(chan struct{})
 
-		nodes["node1"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(200, nonceErrorResponse, shutdownChan1, 4*time.Second))
-		nodes["node2"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(200, nonceErrorResponse, shutdownChan2, 1*time.Second))
+		nodes["node1"].mockBackend.SetHandler(TriggerResponseHandler(200, nonceErrorResponse, triggerHandlerChan1))
+		nodes["node2"].mockBackend.SetHandler(TriggerResponseHandler(200, nonceErrorResponse, triggerHandlerChan2))
 		nodes["node3"].mockBackend.SetHandler(SingleResponseHandler(403, dummyRes))
-
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			shutdownChan2 <- struct{}{}
-			shutdownChan1 <- struct{}{}
-			wg.Done()
-		}()
 
 		localSvr := setServerBackend(svr, nodes)
 
@@ -268,6 +259,15 @@ func TestMulticall(t *testing.T) {
 		req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body))
 		req.Header.Set("X-Forwarded-For", "203.0.113.1")
 		rr := httptest.NewRecorder()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			triggerHandlerChan2 <- struct{}{}
+			time.Sleep(3 * time.Second)
+			triggerHandlerChan1 <- struct{}{}
+			wg.Done()
+		}()
 
 		localSvr.HandleRPC(rr, req)
 
@@ -296,8 +296,10 @@ func TestMulticall(t *testing.T) {
 		defer nodes["node3"].mockBackend.Close()
 		defer shutdown()
 
+		triggerHandlerChan1 := make(chan struct{})
+
 		// We should ignore node2 first response cause 429, and return node 1 because 200
-		nodes["node1"].mockBackend.SetHandler(SingleResponseHandlerWithSleep(200, txAccepted, 3*time.Second))
+		nodes["node1"].mockBackend.SetHandler(TriggerResponseHandler(200, txAccepted, triggerHandlerChan1))
 		nodes["node2"].mockBackend.SetHandler(SingleResponseHandler(429, txAccepted))
 
 		localSvr := setServerBackend(svr, nodes)
@@ -306,6 +308,14 @@ func TestMulticall(t *testing.T) {
 		req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body))
 		req.Header.Set("X-Forwarded-For", "203.0.113.1")
 		rr := httptest.NewRecorder()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			time.Sleep(2 * time.Second)
+			triggerHandlerChan1 <- struct{}{}
+			wg.Done()
+		}()
 
 		localSvr.HandleRPC(rr, req)
 
@@ -320,6 +330,7 @@ func TestMulticall(t *testing.T) {
 		require.Equal(t, "2.0", rpcRes.JSONRPC)
 
 		require.Equal(t, resp.Header["X-Served-By"], []string{"node/node1"})
+		wg.Wait()
 		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
 		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
 		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node3"))
@@ -332,9 +343,9 @@ func TestMulticall(t *testing.T) {
 		defer nodes["node3"].mockBackend.Close()
 		defer shutdown()
 
-		shutdownChan := make(chan struct{})
+		triggerHandlerChan := make(chan struct{})
 		nodes["node1"].mockBackend.SetHandler(SingleResponseHandler(200, dummyRes))
-		nodes["node2"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(200, dummyRes, shutdownChan, 7*time.Second))
+		nodes["node2"].mockBackend.SetHandler(TriggerResponseHandler(200, dummyRes, triggerHandlerChan))
 
 		localSvr := setServerBackend(svr, nodes)
 
@@ -344,8 +355,14 @@ func TestMulticall(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		localSvr.HandleRPC(rr, req)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			time.Sleep(7 * time.Second)
+			triggerHandlerChan <- struct{}{}
+			wg.Done()
+		}()
 		resp := rr.Result()
-		shutdownChan <- struct{}{}
 		defer resp.Body.Close()
 
 		require.NotNil(t, resp.Body)
@@ -370,10 +387,10 @@ func TestMulticall(t *testing.T) {
 		defer nodes["node3"].mockBackend.Close()
 		defer shutdown()
 
-		shutdownChan1 := make(chan struct{})
-		shutdownChan2 := make(chan struct{})
-		nodes["node1"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(200, dummyRes, shutdownChan1, 7*time.Second))
-		nodes["node2"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(200, dummyRes, shutdownChan2, 7*time.Second))
+		triggerHandlerChan1 := make(chan struct{})
+		triggerHandlerChan2 := make(chan struct{})
+		nodes["node1"].mockBackend.SetHandler(TriggerResponseHandler(200, dummyRes, triggerHandlerChan1))
+		nodes["node2"].mockBackend.SetHandler(TriggerResponseHandler(200, dummyRes, triggerHandlerChan2))
 
 		localSvr := setServerBackend(svr, nodes)
 
@@ -385,12 +402,12 @@ func TestMulticall(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
-			shutdownChan1 <- struct{}{}
-			shutdownChan2 <- struct{}{}
+			time.Sleep(7 * time.Second)
+			triggerHandlerChan1 <- struct{}{}
+			triggerHandlerChan2 <- struct{}{}
 			wg.Done()
 		}()
 
-		fmt.Println("sending request")
 		localSvr.HandleRPC(rr, req)
 
 		resp := rr.Result()
@@ -403,7 +420,6 @@ func TestMulticall(t *testing.T) {
 		require.True(t, rpcRes.IsError())
 		require.Equal(t, rpcRes.Error.Code, proxyd.ErrNoBackends.Code)
 
-		// Wait for test response to complete before checking query count
 		wg.Wait()
 		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
 		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
@@ -418,24 +434,24 @@ func TestMulticall(t *testing.T) {
 		defer shutdown()
 
 		for i := 1; i < 4; i++ {
-			shutdownChan1 := make(chan struct{})
-			shutdownChan2 := make(chan struct{})
-			shutdownChan3 := make(chan struct{})
+			triggerHandlerChan1 := make(chan struct{})
+			triggerHandlerChan2 := make(chan struct{})
+			triggerHandlerChan3 := make(chan struct{})
 
 			switch {
 			case i == 1:
-				nodes["node1"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(200, txAccepted, shutdownChan1, 1*time.Second))
-				nodes["node2"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(429, dummyRes, shutdownChan2, 1*time.Second))
-				nodes["node3"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(503, dummyRes, shutdownChan3, 1*time.Second))
+				nodes["node1"].mockBackend.SetHandler(TriggerResponseHandler(200, txAccepted, triggerHandlerChan1))
+				nodes["node2"].mockBackend.SetHandler(TriggerResponseHandler(429, dummyRes, triggerHandlerChan2))
+				nodes["node3"].mockBackend.SetHandler(TriggerResponseHandler(503, dummyRes, triggerHandlerChan3))
 			case i == 2:
-				nodes["node1"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(404, dummyRes, shutdownChan1, 1*time.Second))
-				nodes["node2"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(200, nonceErrorResponse, shutdownChan2, 1*time.Second))
-				nodes["node3"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(405, dummyRes, shutdownChan3, 1*time.Second))
+				nodes["node1"].mockBackend.SetHandler(TriggerResponseHandler(404, dummyRes, triggerHandlerChan1))
+				nodes["node2"].mockBackend.SetHandler(TriggerResponseHandler(200, nonceErrorResponse, triggerHandlerChan2))
+				nodes["node3"].mockBackend.SetHandler(TriggerResponseHandler(405, dummyRes, triggerHandlerChan3))
 			case i == 3:
 				// Return the quickest response
-				nodes["node1"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(404, dummyRes, shutdownChan1, 1*time.Second))
-				nodes["node2"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(500, dummyRes, shutdownChan2, 1*time.Second))
-				nodes["node3"].mockBackend.SetHandler(SingleResponseHandlerWithSleepShutdown(200, nonceErrorResponse, shutdownChan3, 1*time.Second))
+				nodes["node1"].mockBackend.SetHandler(TriggerResponseHandler(404, dummyRes, triggerHandlerChan1))
+				nodes["node2"].mockBackend.SetHandler(TriggerResponseHandler(500, dummyRes, triggerHandlerChan2))
+				nodes["node3"].mockBackend.SetHandler(TriggerResponseHandler(200, nonceErrorResponse, triggerHandlerChan3))
 			}
 
 			localSvr := setServerBackend(svr, nodes)
@@ -448,9 +464,9 @@ func TestMulticall(t *testing.T) {
 			var wg sync.WaitGroup
 			wg.Add(1)
 			go func() {
-				shutdownChan1 <- struct{}{}
-				shutdownChan2 <- struct{}{}
-				shutdownChan3 <- struct{}{}
+				triggerHandlerChan1 <- struct{}{}
+				triggerHandlerChan2 <- struct{}{}
+				triggerHandlerChan3 <- struct{}{}
 				wg.Done()
 			}()
 
@@ -490,27 +506,13 @@ func TestMulticall(t *testing.T) {
 			require.Equal(t, i, nodeBackendRequestCount(nodes, "node3"))
 		}
 	})
-
 }
 
-func SingleResponseHandlerWithSleep(code int, response string, duration time.Duration) http.HandlerFunc {
+// TriggerResponseHandler uses a channel to control when a backend returns
+// test cases can add an element to the triggerResponse channel to control the when a specific backend returns
+func TriggerResponseHandler(code int, response string, triggerResponse chan struct{}) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		fmt.Println("sleeping")
-		time.Sleep(duration)
-		fmt.Println("Shutting down Single Response Handler")
-		w.WriteHeader(code)
-		_, _ = w.Write([]byte(response))
-	}
-}
-
-// SingleResponseHandlerWithSleepShutdown uses a channel to control that a backend was requested and returned.
-// Test cases can add an element to the shutdown channel to control the when a specific backend returns
-func SingleResponseHandlerWithSleepShutdown(code int, response string, shutdownServer chan struct{}, duration time.Duration) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		fmt.Println("sleeping")
-		time.Sleep(duration)
-		<-shutdownServer
-		fmt.Println("Shutting down Single Response Handler")
+		<-triggerResponse
 		w.WriteHeader(code)
 		_, _ = w.Write([]byte(response))
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
* This PR will improve the reliability of the multicall test cases. In the old version of the test cases time.Sleep was used to control when an individual backend would respond; ex. backend 1 and 2 each sleeps 3 seconds, and backend 3 sleeps for 7 seconds. 

* This PR improves upon this design by explicitly adding ordering to the backend responses by using channels to trigger when a response occurs. By using channels we can define the orderin expliclity in the code, rather than relying on time.sleep to execute correctly. In the new example shown below we can now define that backend 2 should respond first, then 2 seconds later 1, and 3 should response. 

* We can also now use wg.Wait() later in the code to ensure that all backends have been queried by the multicall

```
go func() {
	triggerBackendChan2 <- struct{}{}
	time.Sleep(2 * time.Second)
	triggerBackendChan1 <- struct{}{}
	triggerBackendChan3 <- struct{}{}
	wg.Done()
}()
```

**Tests**
* No new tests have been added since no new features have been added. Existing tests are passing with new test implementation

**Additional context**
* Flakey tests reported in CircleCI [here](https://app.circleci.com/pipelines/github/ethereum-optimism/infra/332/workflows/9a217d8b-f71f-47ec-a11e-baebb9a4b7c8/jobs/1770/tests)

**Metadata**

- Fixes #[Link to Issue]
