### PR TITLE
Use not healthy as error msg

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1451,7 +1451,7 @@ func (bg *BackendGroup) ForwardRequestToBackendGroup(
 	return &BackendGroupRPCResponse{
 		RPCRes:   nil,
 		ServedBy: "",
-		error:    ErrNoBackends,
+		error:    ErrNotHealthy,
 	}
 
 }

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -56,7 +56,7 @@ var (
 	}
 	ErrNoBackends = &RPCErr{
 		Code:          JSONRPCErrorInternal - 11,
-		Message:       "no backends available for method",
+		Message:       "no backend is currently healthy to serve traffic",
 		HTTPErrorCode: 503,
 	}
 	ErrBackendOverCapacity = &RPCErr{
@@ -1451,7 +1451,7 @@ func (bg *BackendGroup) ForwardRequestToBackendGroup(
 	return &BackendGroupRPCResponse{
 		RPCRes:   nil,
 		ServedBy: "",
-		error:    ErrNotHealthy,
+		error:    ErrNoBackends,
 	}
 
 }

--- a/proxyd/integration_tests/batching_test.go
+++ b/proxyd/integration_tests/batching_test.go
@@ -66,8 +66,8 @@ func TestBatching(t *testing.T) {
 				NewRPCReq("2", "eth_chainId", nil),
 			},
 			expectedRes: asArray(
-				`{"error":{"code":-32018,"message":"backend is currently not healthy to serve traffic"},"id":1,"jsonrpc":"2.0"}`,
-				`{"error":{"code":-32018,"message":"backend is currently not healthy to serve traffic"},"id":2,"jsonrpc":"2.0"}`,
+				`{"error":{"code":-32011,"message":"no backend is currently healthy to serve traffic"},"id":1,"jsonrpc":"2.0"}`,
+				`{"error":{"code":-32011,"message":"no backend is currently healthy to serve traffic"},"id":2,"jsonrpc":"2.0"}`,
 			),
 			maxUpstreamBatchSize: 10,
 			numExpectedForwards:  1,
@@ -80,8 +80,8 @@ func TestBatching(t *testing.T) {
 				NewRPCReq("2", "eth_chainId", nil),
 			},
 			expectedRes: asArray(
-				`{"error":{"code":-32018,"message":"backend is currently not healthy to serve traffic"},"id":1,"jsonrpc":"2.0"}`,
-				`{"error":{"code":-32018,"message":"backend is currently not healthy to serve traffic"},"id":2,"jsonrpc":"2.0"}`,
+				`{"error":{"code":-32011,"message":"no backend is currently healthy to serve traffic"},"id":1,"jsonrpc":"2.0"}`,
+				`{"error":{"code":-32011,"message":"no backend is currently healthy to serve traffic"},"id":2,"jsonrpc":"2.0"}`,
 			),
 			maxUpstreamBatchSize: 1,
 			numExpectedForwards:  2,

--- a/proxyd/integration_tests/batching_test.go
+++ b/proxyd/integration_tests/batching_test.go
@@ -66,8 +66,8 @@ func TestBatching(t *testing.T) {
 				NewRPCReq("2", "eth_chainId", nil),
 			},
 			expectedRes: asArray(
-				`{"error":{"code":-32011,"message":"no backends available for method"},"id":1,"jsonrpc":"2.0"}`,
-				`{"error":{"code":-32011,"message":"no backends available for method"},"id":2,"jsonrpc":"2.0"}`,
+				`{"error":{"code":-32018,"message":"backend is currently not healthy to serve traffic"},"id":1,"jsonrpc":"2.0"}`,
+				`{"error":{"code":-32018,"message":"backend is currently not healthy to serve traffic"},"id":2,"jsonrpc":"2.0"}`,
 			),
 			maxUpstreamBatchSize: 10,
 			numExpectedForwards:  1,
@@ -80,8 +80,8 @@ func TestBatching(t *testing.T) {
 				NewRPCReq("2", "eth_chainId", nil),
 			},
 			expectedRes: asArray(
-				`{"error":{"code":-32011,"message":"no backends available for method"},"id":1,"jsonrpc":"2.0"}`,
-				`{"error":{"code":-32011,"message":"no backends available for method"},"id":2,"jsonrpc":"2.0"}`,
+				`{"error":{"code":-32018,"message":"backend is currently not healthy to serve traffic"},"id":1,"jsonrpc":"2.0"}`,
+				`{"error":{"code":-32018,"message":"backend is currently not healthy to serve traffic"},"id":2,"jsonrpc":"2.0"}`,
 			),
 			maxUpstreamBatchSize: 1,
 			numExpectedForwards:  2,

--- a/proxyd/integration_tests/failover_test.go
+++ b/proxyd/integration_tests/failover_test.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	goodResponse       = `{"jsonrpc": "2.0", "result": "hello", "id": 999}`
-	notHealthyResponse = `{"error":{"code":-32018,"message":"backend is currently not healthy to serve traffic"},"id":999,"jsonrpc":"2.0"}`
+	noBackendsResponse = `{"error":{"code":-32011,"message":"no backend is currently healthy to serve traffic"},"id":999,"jsonrpc":"2.0"}`
 	unexpectedResponse = `{"error":{"code":-32011,"message":"some error"},"id":999,"jsonrpc":"2.0"}`
 )
 
@@ -110,7 +110,7 @@ func TestFailover(t *testing.T) {
 		}))
 		res, statusCode, _ := client.SendRPC("eth_chainId", nil)
 		require.Equal(t, 503, statusCode)
-		RequireEqualJSON(t, []byte(notHealthyResponse), res) // return currently not healthy since both failed
+		RequireEqualJSON(t, []byte(noBackendsResponse), res) // return currently not healthy since both failed
 		require.Equal(t, 1, len(goodBackend.Requests()))
 		require.Equal(t, 1, len(badBackend.Requests())) // bad backend is still called
 		goodBackend.Reset()
@@ -201,7 +201,7 @@ func TestRetries(t *testing.T) {
 	res, statusCode, err = client.SendRPC("eth_chainId", nil)
 	require.NoError(t, err)
 	require.Equal(t, 503, statusCode)
-	RequireEqualJSON(t, []byte(notHealthyResponse), res)
+	RequireEqualJSON(t, []byte(noBackendsResponse), res)
 	require.Equal(t, 4, len(backend.Requests()))
 }
 

--- a/proxyd/integration_tests/failover_test.go
+++ b/proxyd/integration_tests/failover_test.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	goodResponse       = `{"jsonrpc": "2.0", "result": "hello", "id": 999}`
-	noBackendsResponse = `{"error":{"code":-32011,"message":"no backends available for method"},"id":999,"jsonrpc":"2.0"}`
+	notHealthyResponse = `{"error":{"code":-32018,"message":"backend is currently not healthy to serve traffic"},"id":999,"jsonrpc":"2.0"}`
 	unexpectedResponse = `{"error":{"code":-32011,"message":"some error"},"id":999,"jsonrpc":"2.0"}`
 )
 
@@ -110,7 +110,7 @@ func TestFailover(t *testing.T) {
 		}))
 		res, statusCode, _ := client.SendRPC("eth_chainId", nil)
 		require.Equal(t, 503, statusCode)
-		RequireEqualJSON(t, []byte(noBackendsResponse), res) // return no backend available since both failed
+		RequireEqualJSON(t, []byte(notHealthyResponse), res) // return currently not healthy since both failed
 		require.Equal(t, 1, len(goodBackend.Requests()))
 		require.Equal(t, 1, len(badBackend.Requests())) // bad backend is still called
 		goodBackend.Reset()
@@ -201,7 +201,7 @@ func TestRetries(t *testing.T) {
 	res, statusCode, err = client.SendRPC("eth_chainId", nil)
 	require.NoError(t, err)
 	require.Equal(t, 503, statusCode)
-	RequireEqualJSON(t, []byte(noBackendsResponse), res)
+	RequireEqualJSON(t, []byte(notHealthyResponse), res)
 	require.Equal(t, 4, len(backend.Requests()))
 }
 

--- a/proxyd/integration_tests/multicall_test.go
+++ b/proxyd/integration_tests/multicall_test.go
@@ -179,8 +179,8 @@ func TestMulticall(t *testing.T) {
 		rpcRes := &proxyd.RPCRes{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(rpcRes))
 		require.True(t, rpcRes.IsError())
-		require.Equal(t, proxyd.ErrNoBackends.Code, rpcRes.Error.Code)
-		require.Equal(t, proxyd.ErrNoBackends.Message, rpcRes.Error.Message)
+		require.Equal(t, proxyd.ErrNotHealthy.Code, rpcRes.Error.Code)
+		require.Equal(t, proxyd.ErrNotHealthy.Message, rpcRes.Error.Message)
 
 		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
 		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
@@ -386,7 +386,7 @@ func TestMulticall(t *testing.T) {
 		rpcRes := &proxyd.RPCRes{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(rpcRes))
 		require.True(t, rpcRes.IsError())
-		require.Equal(t, rpcRes.Error.Code, proxyd.ErrNoBackends.Code)
+		require.Equal(t, rpcRes.Error.Code, proxyd.ErrNotHealthy.Code)
 
 		// Wait for test response to complete before checking query count
 		wg.Wait()

--- a/proxyd/integration_tests/multicall_test.go
+++ b/proxyd/integration_tests/multicall_test.go
@@ -179,8 +179,8 @@ func TestMulticall(t *testing.T) {
 		rpcRes := &proxyd.RPCRes{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(rpcRes))
 		require.True(t, rpcRes.IsError())
-		require.Equal(t, proxyd.ErrNotHealthy.Code, rpcRes.Error.Code)
-		require.Equal(t, proxyd.ErrNotHealthy.Message, rpcRes.Error.Message)
+		require.Equal(t, proxyd.ErrNoBackends.Code, rpcRes.Error.Code)
+		require.Equal(t, proxyd.ErrNoBackends.Message, rpcRes.Error.Message)
 
 		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
 		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
@@ -386,7 +386,7 @@ func TestMulticall(t *testing.T) {
 		rpcRes := &proxyd.RPCRes{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(rpcRes))
 		require.True(t, rpcRes.IsError())
-		require.Equal(t, rpcRes.Error.Code, proxyd.ErrNotHealthy.Code)
+		require.Equal(t, rpcRes.Error.Code, proxyd.ErrNoBackends.Code)
 
 		// Wait for test response to complete before checking query count
 		wg.Wait()


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Currently when the backends all fail, it return `no backend is available`, which is quite unclear for the end user. Making a change here to use `no backend is currently healthy to serve traffic` instead which is a lot more clear.

**Tests**
Fixed the impacted tests

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
