### PR TITLE
proxyd: Support Redis read endpoint for caching

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -39,6 +39,7 @@ type CacheConfig struct {
 type RedisConfig struct {
 	URL       string `toml:"url"`
 	Namespace string `toml:"namespace"`
+	ReadURL   string `toml:"read_url"`
 }
 
 type MetricsConfig struct {

--- a/proxyd/integration_tests/testdata/caching_replica.toml
+++ b/proxyd/integration_tests/testdata/caching_replica.toml
@@ -1,0 +1,37 @@
+[server]
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 1
+
+[redis]
+url = "$REDIS_URL"
+read_url = "$REDIS_READ_URL"
+namespace = "proxyd"
+
+[cache]
+enabled = true
+
+[backends]
+[backends.good]
+rpc_url = "$GOOD_BACKEND_RPC_URL"
+ws_url = "$GOOD_BACKEND_RPC_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["good"]
+
+[rpc_method_mappings]
+eth_chainId = "main"
+net_version = "main"
+eth_getBlockByNumber = "main"
+eth_blockNumber = "main"
+eth_call = "main"
+eth_getBlockTransactionCountByHash = "main"
+eth_getUncleCountByBlockHash = "main"
+eth_getBlockByHash = "main"
+eth_getTransactionByHash = "main"
+eth_getTransactionByBlockHashAndIndex = "main"
+eth_getUncleByBlockHashAndIndex = "main"
+eth_getTransactionReceipt = "main"
+debug_getRawReceipts = "main"

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -39,6 +39,7 @@ func Start(config *Config) (*Server, func(), error) {
 		}
 	}
 
+	// redis primary client
 	var redisClient *redis.Client
 	if config.Redis.URL != "" {
 		rURL, err := ReadFromEnvOrConfig(config.Redis.URL)
@@ -46,6 +47,23 @@ func Start(config *Config) (*Server, func(), error) {
 			return nil, nil, err
 		}
 		redisClient, err = NewRedisClient(rURL)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// redis read replica client
+	// if read endpoint is not set, use primary endpoint
+	var redisReadClient = redisClient
+	if config.Redis.ReadURL != "" {
+		if redisClient == nil {
+			return nil, nil, errors.New("must specify a Redis primary URL. only read endpoint is set")
+		}
+		rURL, err := ReadFromEnvOrConfig(config.Redis.ReadURL)
+		if err != nil {
+			return nil, nil, err
+		}
+		redisReadClient, err = NewRedisClient(rURL)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -276,7 +294,7 @@ func Start(config *Config) (*Server, func(), error) {
 			if config.Cache.TTL != 0 {
 				ttl = time.Duration(config.Cache.TTL)
 			}
-			cache = newRedisCache(redisClient, config.Redis.Namespace, ttl)
+			cache = newRedisCache(redisClient, redisReadClient, config.Redis.Namespace, ttl)
 		}
 		rpcCache = newRPCCache(newCacheWithCompression(cache))
 	}


### PR DESCRIPTION
**Description**

- Implements Redis read endpoint support for Proxyd caching to utilize Redis read replica instances.
- Only supports simple RPC caching purpose other than consensus tracking or rate limit for now.
- Added New config `read_url`.

**Tests**

Add a simple integration test `TestCachingWithReadReplica`. This test case creates two miniredis instances and mocks replication behavior.

**Additional context**

We may create a new Redis client abstraction with read endpoint support. But now we uses only `GET` and `PUT` commands for simple caching purpose, so I don't want to make a bunch of new lines. But please feel free give me any feedback about the code design!
