### PR TITLE
op-conductor-ops: usability improvements and cert config path fix

### DIFF
--- a/op-conductor-ops/README.md
+++ b/op-conductor-ops/README.md
@@ -10,6 +10,11 @@ Requires [poetry](https://github.com/python-poetry/poetry).
 
 Install python dependencies with `poetry install`.
 
+Recommended updates to your .bashrc/zshrc:
+
+1. `export PATH="export PATH="<path-to-infra-repo>/op-conductor-ops:$PATH""`
+2. `export CONDUCTOR_CONFIG="<path-to-op-conductor-ops-config.toml>"`
+
 ## Usage
 
 After installing dependencies with `poetry`, the tool can be invoked with `./op-conductor-ops`,

--- a/op-conductor-ops/config.py
+++ b/op-conductor-ops/config.py
@@ -7,6 +7,9 @@ def read_config(config_path: str) -> tuple[dict[str, Sequencer], str]:
     config = toml.load(config_path)
 
     cert_path = config.get('cert_path', "")
+    # if cert path is relative, pre-pend the config path
+    if not cert_path.startswith('/'):
+        cert_path = f"{config_path.rsplit('/', 1)[0]}/{cert_path}"
 
     # load sequencers into a map
     sequencers = {}

--- a/op-conductor-ops/op-conductor-ops
+++ b/op-conductor-ops/op-conductor-ops
@@ -1,3 +1,7 @@
 #!/bin/sh
+set -e
 
+# cd to the directory of the script
+cd "$(dirname "$0")"
+poetry install --no-interaction --quiet
 poetry run python op-conductor-ops.py "${@}"


### PR DESCRIPTION
**Description**

* Makes cert path in config relative to config path
* Adds docs about setting CONDUCTOR_CONFIG and adding it to PATH