### PR TITLE
Update tag-service.yml

### DIFF
--- a/.github/workflows/tag-service.yml
+++ b/.github/workflows/tag-service.yml
@@ -1,5 +1,8 @@
 name: Tag Service
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Was broken because of the global reduction in GitHub token permissions.