### PR TITLE
add goreleaser jobs to release workflow

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -348,6 +348,43 @@ jobs:
       - store_test_results:
           path: /tmp/test-results
 
+  # TODO: this should be in an orb to improve reusability.
+  go-release:
+    parameters:
+      module:
+        description: Go Module Name
+        type: string
+      filename:
+        description: Goreleaser config file
+        default: .goreleaser.yaml
+        type: string
+    docker:
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+    resource_class: large
+    steps:
+      - setup_remote_docker
+      - gcp-cli/install
+      - gcp-oidc-authenticate:
+          gcp_cred_config_file_path: /root/gcp_cred_config.json
+          oidc_token_file_path: /root/oidc_token.json
+      - checkout
+      - run:
+          name: Install goreleaser pro
+          command: |
+            mkdir -p /tmp/goreleaser
+            cd /tmp/goreleaser
+            curl -L -o goreleaser.tgz https://github.com/goreleaser/goreleaser-pro/releases/download/v2.4.3-pro/goreleaser-pro_Linux_x86_64.tar.gz
+            tar -xzvf goreleaser.tgz
+            mv goreleaser /usr/local/bin/goreleaser
+      - run:
+          name: Configure Docker
+          command: |
+            gcloud auth configure-docker us-docker.pkg.dev
+      - run:
+          name: Run goreleaser
+          command: |
+            goreleaser release --clean -f ./<<parameters.module>>/<<parameters.filename>>
+
 workflows:
   logging:
     jobs:
@@ -518,7 +555,7 @@ workflows:
                 - proxyd
                 - op-conductor-mon
                 - peer-mgmt-service
-          name: <<matrix.module>>-docker-tag
+          name: <<matrix.docker_name>>-docker-tag
           filters:
             tags:
               only: /^<<matrix.docker_name>>\/v.*/
@@ -528,3 +565,22 @@ workflows:
             - oplabs-gcr-release
           requires:
             - <<matrix.docker_name>>-docker-publish
+      - go-release:
+          matrix:
+            parameters:
+              module:
+                - op-signer
+                - op-txproxy
+                - op-ufm
+                - proxyd
+                - op-conductor-mon
+                - peer-mgmt-service
+          name: <<matrix.module>>-go-release
+          filters:
+            tags:
+              only: /^<<matrix.module>>.*/
+            branches:
+              ignore: /.*/
+          module: <<matrix.module>>
+          context:
+            - oplabs-gcr-release

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -258,6 +258,9 @@ jobs:
 
   docker-tag-op-stack-release:
     parameters:
+      docker_name:
+        description: Docker image name
+        type: string
       registry:
         description: Docker registry
         type: string
@@ -466,212 +469,62 @@ workflows:
             branches:
               ignore: /.*/
       - docker-build:
-          name: op-signer-docker-build
+          matrix:
+            parameters:
+              docker_name:
+                - op-signer
+                - op-txproxy
+                - op-ufm
+                - proxyd
+                - op-conductor-mon
+                - peer-mgmt-service
+          name: <<matrix.docker_name>>-docker-build
           filters:
             tags:
-              only: /^op-signer\/v.*/
-          docker_name: op-signer
+              only: /^<<matrix.docker_name>>\/v.*/
           docker_tags: <<pipeline.git.revision>>
           docker_context: .
-          docker_file: op-signer/Dockerfile
+          docker_file: <<matrix.docker_name>>/Dockerfile
           context:
             - oplabs-gcr-release
           requires:
             - hold
       - docker-publish:
-          name: op-signer-docker-publish
+          matrix:
+            parameters:
+              docker_name:
+                - op-signer
+                - op-txproxy
+                - op-ufm
+                - proxyd
+                - op-conductor-mon
+                - peer-mgmt-service
+          name: <<matrix.docker_name>>-docker-publish
           filters:
             tags:
-              only: /^op-signer\/v.*/
-          docker_name: op-signer
+              only: /^<<matrix.docker_name>>\/v.*/
           docker_tags: <<pipeline.git.revision>>
           context:
             - oplabs-gcr-release
           requires:
-            - op-signer-docker-build
+            - <<matrix.docker_name>>-docker-build
       - docker-tag-op-stack-release:
-          name: op-signer-docker-tag
+          matrix:
+            parameters:
+              docker_name:
+                - op-signer
+                - op-txproxy
+                - op-ufm
+                - proxyd
+                - op-conductor-mon
+                - peer-mgmt-service
+          name: <<matrix.module>>-docker-tag
           filters:
             tags:
-              only: /^op-signer\/v.*/
+              only: /^<<matrix.docker_name>>\/v.*/
             branches:
               ignore: /.*/
           context:
             - oplabs-gcr-release
           requires:
-            - op-signer-docker-publish
-      - docker-build:
-          name: op-txproxy-docker-build
-          filters:
-            tags:
-              only: /^op-txproxy\/v.*/
-          docker_name: op-txproxy
-          docker_tags: <<pipeline.git.revision>>
-          docker_context: .
-          docker_file: op-txproxy/Dockerfile
-          context:
-            - oplabs-gcr-release
-          requires:
-            - hold
-      - docker-publish:
-          name: op-txproxy-docker-publish
-          filters:
-            tags:
-              only: /^op-txproxy\/v.*/
-          docker_name: op-txproxy
-          docker_tags: <<pipeline.git.revision>>
-          context:
-            - oplabs-gcr-release
-          requires:
-            - op-txproxy-docker-build
-      - docker-tag-op-stack-release:
-          name: op-txproxy-docker-tag
-          filters:
-            tags:
-              only: /^op-txproxy\/v.*/
-            branches:
-              ignore: /.*/
-          context:
-            - oplabs-gcr-release
-          requires:
-            - op-txproxy-docker-publish
-      - docker-build:
-          name: op-ufm-docker-build
-          filters:
-            tags:
-              only: /^op-ufm\/v.*/
-          docker_name: op-ufm
-          docker_tags: <<pipeline.git.revision>>
-          docker_context: .
-          docker_file: op-ufm/Dockerfile
-          context:
-            - oplabs-gcr-release
-          requires:
-            - hold
-      - docker-publish:
-          name: op-ufm-docker-publish
-          filters:
-            tags:
-              only: /^op-ufm\/v.*/
-          docker_name: op-ufm
-          docker_tags: <<pipeline.git.revision>>
-          context:
-            - oplabs-gcr-release
-          requires:
-            - op-ufm-docker-build
-      - docker-tag-op-stack-release:
-          name: op-ufm-docker-tag
-          filters:
-            tags:
-              only: /^op-ufm\/v.*/
-            branches:
-              ignore: /.*/
-          context:
-            - oplabs-gcr-release
-          requires:
-            - op-ufm-docker-publish
-      - docker-build:
-          name: proxyd-docker-build
-          filters:
-            tags:
-              only: /^proxyd\/v.*/
-          docker_name: proxyd
-          docker_tags: <<pipeline.git.revision>>
-          docker_context: .
-          docker_file: proxyd/Dockerfile
-          context:
-            - oplabs-gcr-release
-          requires:
-            - hold
-      - docker-publish:
-          name: proxyd-docker-publish
-          filters:
-            tags:
-              only: /^proxyd\/v.*/
-          docker_name: proxyd
-          docker_tags: <<pipeline.git.revision>>
-          context:
-            - oplabs-gcr-release
-          requires:
-            - proxyd-docker-build
-      - docker-tag-op-stack-release:
-          name: proxyd-docker-tag
-          filters:
-            tags:
-              only: /^proxyd\/v.*/
-            branches:
-              ignore: /.*/
-          context:
-            - oplabs-gcr-release
-          requires:
-            - proxyd-docker-publish
-      - docker-build:
-          name: pms-docker-build
-          filters:
-            tags:
-              only: /^peer-mgmt-service\/v.*/
-          docker_name: peer-mgmt-service
-          docker_tags: <<pipeline.git.revision>>
-          docker_context: .
-          docker_file: peer-mgmt-service/Dockerfile
-          context:
-            - oplabs-gcr-release
-          requires:
-            - hold
-      - docker-publish:
-          name: pms-docker-publish
-          filters:
-            tags:
-              only: /^peer-mgmt-service\/v.*/
-          docker_name: peer-mgmt-service
-          docker_tags: <<pipeline.git.revision>>
-          context:
-            - oplabs-gcr-release
-          requires:
-            - pms-docker-build
-      - docker-tag-op-stack-release:
-          name: pms-docker-tag
-          filters:
-            tags:
-              only: /^peer-mgmt-service\/v.*/
-            branches:
-              ignore: /.*/
-          context:
-            - oplabs-gcr-release
-          requires:
-            - pms-docker-publish
-      - docker-build:
-          name: op-conductor-mon-docker-build
-          filters:
-            tags:
-              only: /^op-conductor-mon\/v.*/
-          docker_file: op-conductor-mon/Dockerfile
-          docker_name: op-conductor-mon
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: .
-          context:
-            - oplabs-gcr-release
-          requires:
-            - hold
-      - docker-publish:
-          name: op-conductor-mon-docker-publish
-          filters:
-            tags:
-              only: /^op-conductor-mon\/v.*/
-          docker_name: op-conductor-mon
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          context:
-            - oplabs-gcr-release
-          requires:
-            - op-conductor-mon-docker-build
-      - docker-tag-op-stack-release:
-          name: op-conductor-mon-docker-tag
-          filters:
-            tags:
-              only: /^op-conductor-mon\/v.*/
-            branches:
-              ignore: /.*/
-          context:
-            - oplabs-gcr-release
-          requires:
-            - op-conductor-mon-docker-publish
+            - <<matrix.docker_name>>-docker-publish

--- a/op-conductor-mon/.goreleaser.yaml
+++ b/op-conductor-mon/.goreleaser.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: op-conductor-mon
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+
+builds:
+  - id: main
+    main: ./cmd/monitor
+    binary: op-conductor-mon
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: linux
+        goarch: arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - -X main.GitCommit={{ .FullCommit }}
+      - -X main.GitDate={{ .CommitDate }}
+      - -X main.Version={{ .Version }}
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: "{{ .ProjectName }}-{{.Version}}-{{ tolower .Os }}-{{ .Arch }}"
+    # use zip for windows archives
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+
+release:
+  github:
+    owner: ethereum-optimism
+    name: infra
+  make_latest: false
+
+monorepo:
+  tag_prefix: op-conductor-mon/
+  dir: op-conductor-mon

--- a/op-signer/.goreleaser.yaml
+++ b/op-signer/.goreleaser.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: op-signer
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+
+builds:
+  - id: main
+    main: ./cmd
+    binary: op-signer
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: linux
+        goarch: arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - -X main.GitCommit={{ .FullCommit }}
+      - -X main.GitDate={{ .CommitDate }}
+      - -X main.Version={{ .Version }}
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: "{{ .ProjectName }}-{{.Version}}-{{ tolower .Os }}-{{ .Arch }}"
+    # use zip for windows archives
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+
+release:
+  github:
+    owner: ethereum-optimism
+    name: infra
+  make_latest: false
+
+monorepo:
+  tag_prefix: op-signer/
+  dir: op-signer

--- a/op-txproxy/.goreleaser.yaml
+++ b/op-txproxy/.goreleaser.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: op-txproxy
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+
+builds:
+  - id: main
+    main: ./cmd
+    binary: op-txproxy
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: linux
+        goarch: arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - -X main.GitCommit={{ .FullCommit }}
+      - -X main.GitDate={{ .CommitDate }}
+      - -X main.Version={{ .Version }}
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: "{{ .ProjectName }}-{{.Version}}-{{ tolower .Os }}-{{ .Arch }}"
+    # use zip for windows archives
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+
+release:
+  github:
+    owner: ethereum-optimism
+    name: infra
+  make_latest: false
+
+monorepo:
+  tag_prefix: op-txproxy/
+  dir: op-txproxy

--- a/op-ufm/.goreleaser.yaml
+++ b/op-ufm/.goreleaser.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: op-ufm
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+
+builds:
+  - id: main
+    main: ./cmd/ufm
+    binary: op-ufm
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: linux
+        goarch: arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - -X main.GitCommit={{ .FullCommit }}
+      - -X main.GitDate={{ .CommitDate }}
+      - -X main.Version={{ .Version }}
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: "{{ .ProjectName }}-{{.Version}}-{{ tolower .Os }}-{{ .Arch }}"
+    # use zip for windows archives
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+
+release:
+  github:
+    owner: ethereum-optimism
+    name: infra
+  make_latest: false
+
+monorepo:
+  tag_prefix: op-ufm/
+  dir: op-ufm

--- a/peer-mgmt-service/.goreleaser.yaml
+++ b/peer-mgmt-service/.goreleaser.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: peer-mgmt-service
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+
+builds:
+  - id: main
+    main: ./cmd/pms
+    binary: peer-mgmt-service
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: linux
+        goarch: arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - -X main.GitCommit={{ .FullCommit }}
+      - -X main.GitDate={{ .CommitDate }}
+      - -X main.Version={{ .Version }}
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: "{{ .ProjectName }}-{{.Version}}-{{ tolower .Os }}-{{ .Arch }}"
+    # use zip for windows archives
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+
+release:
+  github:
+    owner: ethereum-optimism
+    name: infra
+  make_latest: false
+
+monorepo:
+  tag_prefix: peer-mgmt-service/
+  dir: peer-mgmt-service

--- a/proxyd/.goreleaser.yaml
+++ b/proxyd/.goreleaser.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: proxyd
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+
+builds:
+  - id: main
+    main: ./cmd/proxyd
+    binary: proxyd
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: linux
+        goarch: arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - -X main.GitCommit={{ .FullCommit }}
+      - -X main.GitDate={{ .CommitDate }}
+      - -X main.Version={{ .Version }}
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: "{{ .ProjectName }}-{{.Version}}-{{ tolower .Os }}-{{ .Arch }}"
+    # use zip for windows archives
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+
+release:
+  github:
+    owner: ethereum-optimism
+    name: infra
+  make_latest: false
+
+monorepo:
+  tag_prefix: proxyd/
+  dir: proxyd


### PR DESCRIPTION
**Description**

This change factorizes the logic behind the release workflow by
leveraging a matrix, then adds goreleaser jobs to handle each
component release tag.

**Metadata**

- Fixes ethereum-optimism/platforms-team#403
