### PR TITLE
op-txproxy: enable auth checks + jsonrpc responses when auth fails

### DIFF
--- a/op-txproxy/auth_handler.go
+++ b/op-txproxy/auth_handler.go
@@ -34,7 +34,7 @@ type authHandler struct {
 // requests and leaves it up to the request handler to do so.
 //  1. Missing Auth Header: AuthContext is missing from context
 //  2. Failed Validation: AuthContext is set with a populated Err
-//  3. Passed Validation: AuthContext is set with the authentication calleErr
+//  3. Passed Validation: AuthContext is set with the authenticated caller
 //
 // note: only up to the default body limit (5MB) is read when constructing the text hash
 func AuthMiddleware(headerKey string) func(next http.Handler) http.Handler {


### PR DESCRIPTION
**Description**

Now that #68 is closed, op-txproxy can conduct auth checks again.

If a backend for proxyd doesn't return a valid jsonrpc response, proxyd returns with a 503, "unhealthy". With the prior implementation of the auth middleware, the caller would not have context into what is wrong.

In order to fix this, we change the middleware to never reject at the http layer (unless it fails to read the request body), and instead thread through errors in the context so that the request handler can instead decide what to do. This allows to craft a json-rpc response for auth failures