### PR TITLE
feat: add fallback rate limiter and cache to fallback to memory if redis fails

### DIFF
--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -55,10 +55,6 @@ func newFallbackCache(primaryCache Cache, secondaryCache Cache) *fallbackCache {
 
 func (c *fallbackCache) Get(ctx context.Context, key string) (string, error) {
 	val, err := c.primaryCache.Get(ctx, key)
-	// if context is cancelled, return immediately
-	if err == context.Canceled {
-		return "", err
-	}
 	if err != nil {
 		return c.secondaryCache.Get(ctx, key)
 	}

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -44,6 +44,31 @@ func (c *cache) Put(ctx context.Context, key string, value string) error {
 	return nil
 }
 
+type fallbackCache struct {
+	primaryCache   Cache
+	secondaryCache Cache
+}
+
+func newFallbackCache(primaryCache Cache, secondaryCache Cache) *fallbackCache {
+	return &fallbackCache{primaryCache: primaryCache, secondaryCache: secondaryCache}
+}
+
+func (c *fallbackCache) Get(ctx context.Context, key string) (string, error) {
+	val, err := c.primaryCache.Get(ctx, key)
+	if err != nil {
+		return c.secondaryCache.Get(ctx, key)
+	}
+	return val, nil
+}
+
+func (c *fallbackCache) Put(ctx context.Context, key string, value string) error {
+	err := c.primaryCache.Put(ctx, key, value)
+	if err != nil {
+		return c.secondaryCache.Put(ctx, key, value)
+	}
+	return nil
+}
+
 type redisCache struct {
 	redisClient     *redis.Client
 	redisReadClient *redis.Client

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -55,6 +55,10 @@ func newFallbackCache(primaryCache Cache, secondaryCache Cache) *fallbackCache {
 
 func (c *fallbackCache) Get(ctx context.Context, key string) (string, error) {
 	val, err := c.primaryCache.Get(ctx, key)
+	// if context is cancelled, return immediately
+	if err == context.Canceled {
+		return "", err
+	}
 	if err != nil {
 		return c.secondaryCache.Get(ctx, key)
 	}

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -37,9 +37,10 @@ type CacheConfig struct {
 }
 
 type RedisConfig struct {
-	URL       string `toml:"url"`
-	Namespace string `toml:"namespace"`
-	ReadURL   string `toml:"read_url"`
+	URL              string `toml:"url"`
+	Namespace        string `toml:"namespace"`
+	ReadURL          string `toml:"read_url"`
+	FallbackToMemory bool   `toml:"fallback_to_memory"`
 }
 
 type MetricsConfig struct {

--- a/proxyd/frontend_rate_limiter.go
+++ b/proxyd/frontend_rate_limiter.go
@@ -157,10 +157,6 @@ func NewFallbackRateLimiter(primary FrontendRateLimiter, secondary FrontendRateL
 
 func (r *FallbackRateLimiter) Take(ctx context.Context, key string) (bool, error) {
 	if ok, err := r.primary.Take(ctx, key); err != nil {
-		// if context is cancelled, return immediately
-		if err == context.Canceled {
-			return ok, err
-		}
 		return r.secondary.Take(ctx, key)
 	} else {
 		return ok, err

--- a/proxyd/frontend_rate_limiter.go
+++ b/proxyd/frontend_rate_limiter.go
@@ -157,6 +157,10 @@ func NewFallbackRateLimiter(primary FrontendRateLimiter, secondary FrontendRateL
 
 func (r *FallbackRateLimiter) Take(ctx context.Context, key string) (bool, error) {
 	if ok, err := r.primary.Take(ctx, key); err != nil {
+		// if context is cancelled, return immediately
+		if err == context.Canceled {
+			return ok, err
+		}
 		return r.secondary.Take(ctx, key)
 	} else {
 		return ok, err

--- a/proxyd/frontend_rate_limiter_test.go
+++ b/proxyd/frontend_rate_limiter_test.go
@@ -52,3 +52,35 @@ func TestFrontendRateLimiter(t *testing.T) {
 		})
 	}
 }
+
+type errorFrontend struct{}
+
+func (e *errorFrontend) Take(ctx context.Context, key string) (bool, error) {
+	return false, fmt.Errorf("test error")
+}
+
+var _ FrontendRateLimiter = &errorFrontend{}
+
+func TestFallbackRateLimiter(t *testing.T) {
+	shouldSucceed := []FrontendRateLimiter{
+		NewFallbackRateLimiter(NoopFrontendRateLimiter, NoopFrontendRateLimiter),
+		NewFallbackRateLimiter(NoopFrontendRateLimiter, &errorFrontend{}),
+		NewFallbackRateLimiter(&errorFrontend{}, NoopFrontendRateLimiter),
+	}
+
+	shouldFail := []FrontendRateLimiter{
+		NewFallbackRateLimiter(&errorFrontend{}, &errorFrontend{}),
+	}
+
+	ctx := context.Background()
+	for _, frl := range shouldSucceed {
+		ok, err := frl.Take(ctx, "foo")
+		require.NoError(t, err)
+		require.True(t, ok)
+	}
+	for _, frl := range shouldFail {
+		ok, err := frl.Take(ctx, "foo")
+		require.Error(t, err)
+		require.False(t, ok)
+	}
+}

--- a/proxyd/frontend_rate_limiter_test.go
+++ b/proxyd/frontend_rate_limiter_test.go
@@ -27,6 +27,7 @@ func TestFrontendRateLimiter(t *testing.T) {
 	}{
 		{"memory", NewMemoryFrontendRateLimit(2*time.Second, max)},
 		{"redis", NewRedisFrontendRateLimiter(redisClient, 2*time.Second, max, "")},
+		{"fallback", NewFallbackRateLimiter(NewMemoryFrontendRateLimit(2*time.Second, max), NewRedisFrontendRateLimiter(redisClient, 2*time.Second, max, ""))},
 	}
 
 	for _, cfg := range lims {

--- a/proxyd/redis.go
+++ b/proxyd/redis.go
@@ -13,10 +13,15 @@ func NewRedisClient(url string) (*redis.Client, error) {
 		return nil, err
 	}
 	client := redis.NewClient(opts)
+	return client, nil
+}
+
+func CheckRedisConnection(client *redis.Client) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := client.Ping(ctx).Err(); err != nil {
-		return nil, wrapErr(err, "error connecting to redis")
+		return wrapErr(err, "error connecting to redis")
 	}
-	return client, nil
+
+	return nil
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds a new config to proxyd: `redis.fallback_to_memory`.

This allows falling back to a memory implementation of Redis features if they fail instead of falling back to an error (in the case of rate limiting) or a no-op (in the case of caching).

I also moved redis connection testing which will warn if we're not able to connect with the new flag is enabled, but still error if the fallback is disabled.

If the context is cancelled for the cache, we don't retry with the secondary source because this indicates a 

**Tests**

Added test for rate limiter fallback and cache fallback.