### PR TITLE
fix: exclude context canccel error from forward error counting

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1333,6 +1333,9 @@ type LimitedHTTPClient struct {
 
 func (c *LimitedHTTPClient) DoLimited(req *http.Request) (*http.Response, error) {
 	if err := c.sem.Acquire(req.Context(), 1); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 		tooManyRequestErrorsTotal.WithLabelValues(c.backendName).Inc()
 		return nil, wrapErr(err, "too many requests")
 	}

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1415,7 +1415,7 @@ func (bg *BackendGroup) ForwardRequestToBackendGroup(
 		if len(rpcReqs) > 0 {
 
 			res, err = back.Forward(ctx, rpcReqs, isBatch)
-			if err != nil && errors.Is(err, context.Canceled) {
+			if errors.Is(err, context.Canceled) {
 				log.Info("context canceled", "req_id", GetReqID(ctx), "auth", GetAuthCtx(ctx))
 				return &BackendGroupRPCResponse{
 					RPCRes:   nil,

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -804,7 +804,12 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 	backendResp := <-ch
 
 	if backendResp.error != nil {
-		log.Error("error serving requests",
+		logfn := log.Error
+		// If the context was canceled, downgrade the log level to debug.
+		if errors.Is(backendResp.error, context.Canceled) {
+			logfn = log.Debug
+		}
+		logfn("error serving requests",
 			"req_id", GetReqID(ctx),
 			"auth", GetAuthCtx(ctx),
 			"err", backendResp.error,

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -532,7 +532,12 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 					errors.Is(err, ErrConsensusGetReceiptsInvalidTarget) {
 					return nil, false, "", err
 				}
-				log.Error(
+				logfn := log.Error
+				// If the context was canceled, downgrade the log level to debug.
+				if errors.Is(err, context.Canceled) {
+					logfn = log.Debug
+				}
+				logfn(
 					"error forwarding RPC batch",
 					"batch_size", len(elems),
 					"backend_group", group,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Proxyd bans backends based on its error rate.
But it even counts context canceled error as a forwarding error,
while the cancellation is actually triggered by incomplete HTTP requests from the client.

This means hackers can make DoS attacks by just sendinga bunch of requests and closing without waiting for a response.

**Tests**

We have an environment that client sends a lot this kind of requests to test connection or some thing.
**Before this patch:**
  the proxy will have no backends to serve in a very short time.
**After:**
  works like a charm.

BTW:
`wrapErr()` will strip the error's type.
It's recommended to use [this package](https://github.com/pkg/errors) to do error wrapping and assertion.