### PR TITLE
proxyd: add Redis cluster support

### DIFF
--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -70,13 +70,13 @@ func (c *fallbackCache) Put(ctx context.Context, key string, value string) error
 }
 
 type redisCache struct {
-	redisClient     *redis.Client
-	redisReadClient *redis.Client
+	redisClient     redis.UniversalClient
+	redisReadClient redis.UniversalClient
 	prefix          string
 	ttl             time.Duration
 }
 
-func newRedisCache(redisClient *redis.Client, redisReadClient *redis.Client, prefix string, ttl time.Duration) *redisCache {
+func newRedisCache(redisClient redis.UniversalClient, redisReadClient redis.UniversalClient, prefix string, ttl time.Duration) *redisCache {
 	return &redisCache{redisClient, redisReadClient, prefix, ttl}
 }
 

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -36,8 +36,6 @@ type CacheConfig struct {
 	TTL     TOMLDuration `toml:"ttl"`
 }
 
-type RedisClientChoice string
-
 type RedisConfig struct {
 	// If `redis_cluster = true`, you can specify url string for multi-node cluster:
 	//    "redis://<user>:<password>@<host>:<port>?addr=<host2>:<port2>&addr=<host3>:<port3>"

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -36,11 +36,24 @@ type CacheConfig struct {
 	TTL     TOMLDuration `toml:"ttl"`
 }
 
+type RedisClientChoice string
+
+const (
+	DefaultChoice RedisClientChoice = "default" // single node
+	ClusterChoice RedisClientChoice = "cluster"
+)
+
 type RedisConfig struct {
-	URL              string `toml:"url"`
-	Namespace        string `toml:"namespace"`
-	ReadURL          string `toml:"read_url"`
-	FallbackToMemory bool   `toml:"fallback_to_memory"`
+	// If choice = "cluster" is specified (toml), you can specify url string for multi-node cluster:
+	//    "redis://<user>:<password>@<host>:<port>?addr=<host2>:<port2>&addr=<host3>:<port3>"
+	// OR "rediss://<user>:<password>@<host>:<port>?addr=<host2>:<port2>&addr=<host3>:<port3>"
+	//
+	// Otherwise, it is also possible to specify single url for Redis cluster with proxy support.
+	URL              string            `toml:"url"`
+	Namespace        string            `toml:"namespace"`
+	ReadURL          string            `toml:"read_url"`
+	FallbackToMemory bool              `toml:"fallback_to_memory"`
+	Choice           RedisClientChoice `toml:"choice"`
 }
 
 type MetricsConfig struct {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -38,22 +38,17 @@ type CacheConfig struct {
 
 type RedisClientChoice string
 
-const (
-	DefaultChoice RedisClientChoice = "default" // single node
-	ClusterChoice RedisClientChoice = "cluster"
-)
-
 type RedisConfig struct {
-	// If choice = "cluster" is specified (toml), you can specify url string for multi-node cluster:
+	// If `redis_cluster = true`, you can specify url string for multi-node cluster:
 	//    "redis://<user>:<password>@<host>:<port>?addr=<host2>:<port2>&addr=<host3>:<port3>"
 	// OR "rediss://<user>:<password>@<host>:<port>?addr=<host2>:<port2>&addr=<host3>:<port3>"
 	//
 	// Otherwise, it is also possible to specify single url for Redis cluster with proxy support.
-	URL              string            `toml:"url"`
-	Namespace        string            `toml:"namespace"`
-	ReadURL          string            `toml:"read_url"`
-	FallbackToMemory bool              `toml:"fallback_to_memory"`
-	Choice           RedisClientChoice `toml:"choice"`
+	URL              string `toml:"url"`
+	Namespace        string `toml:"namespace"`
+	ReadURL          string `toml:"read_url"`
+	FallbackToMemory bool   `toml:"fallback_to_memory"`
+	RedisCluster     bool   `toml:"redis_cluster"`
 }
 
 type MetricsConfig struct {

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -112,7 +112,7 @@ func (ct *InMemoryConsensusTracker) SetFinalizedBlockNumber(blockNumber hexutil.
 // RedisConsensusTracker store and retrieve in a shared Redis cluster, with leader election
 type RedisConsensusTracker struct {
 	ctx          context.Context
-	client       *redis.Client
+	client       redis.UniversalClient
 	namespace    string
 	backendGroup *BackendGroup
 
@@ -145,7 +145,7 @@ func WithHeartbeatInterval(heartbeatInterval time.Duration) RedisConsensusTracke
 	}
 }
 func NewRedisConsensusTracker(ctx context.Context,
-	redisClient *redis.Client,
+	redisClient redis.UniversalClient,
 	bg *BackendGroup,
 	namespace string,
 	opts ...RedisConsensusTrackerOpt) ConsensusTracker {

--- a/proxyd/frontend_rate_limiter.go
+++ b/proxyd/frontend_rate_limiter.go
@@ -93,13 +93,13 @@ func (m *MemoryFrontendRateLimiter) Take(ctx context.Context, key string) (bool,
 // It uses the basic rate limiter pattern described on the Redis best
 // practices website: https://redis.com/redis-best-practices/basic-rate-limiting/.
 type RedisFrontendRateLimiter struct {
-	r      *redis.Client
+	r      redis.UniversalClient
 	dur    time.Duration
 	max    int
 	prefix string
 }
 
-func NewRedisFrontendRateLimiter(r *redis.Client, dur time.Duration, max int, prefix string) FrontendRateLimiter {
+func NewRedisFrontendRateLimiter(r redis.UniversalClient, dur time.Duration, max int, prefix string) FrontendRateLimiter {
 	return &RedisFrontendRateLimiter{
 		r:      r,
 		dur:    dur,

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -46,7 +46,7 @@ func Start(config *Config) (*Server, func(), error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		redisClient, err = NewRedisClient(rURL, config.Redis.Choice)
+		redisClient, err = NewRedisClient(rURL, config.Redis.RedisCluster)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -70,7 +70,7 @@ func Start(config *Config) (*Server, func(), error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		redisReadClient, err = NewRedisClient(rURL, config.Redis.Choice)
+		redisReadClient, err = NewRedisClient(rURL, config.Redis.RedisCluster)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -464,7 +464,7 @@ func Start(config *Config) (*Server, func(), error) {
 				if bgcfg.ConsensusHAHeartbeatInterval > 0 {
 					topts = append(topts, WithHeartbeatInterval(time.Duration(bgcfg.ConsensusHAHeartbeatInterval)))
 				}
-				consensusHARedisClient, err := NewRedisClient(bgcfg.ConsensusHARedis.URL, bgcfg.ConsensusHARedis.Choice)
+				consensusHARedisClient, err := NewRedisClient(bgcfg.ConsensusHARedis.URL, bgcfg.ConsensusHARedis.RedisCluster)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -40,13 +40,13 @@ func Start(config *Config) (*Server, func(), error) {
 	}
 
 	// redis primary client
-	var redisClient *redis.Client
+	var redisClient redis.UniversalClient
 	if config.Redis.URL != "" {
 		rURL, err := ReadFromEnvOrConfig(config.Redis.URL)
 		if err != nil {
 			return nil, nil, err
 		}
-		redisClient, err = NewRedisClient(rURL)
+		redisClient, err = NewRedisClient(rURL, config.Redis.Choice)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -70,7 +70,7 @@ func Start(config *Config) (*Server, func(), error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		redisReadClient, err = NewRedisClient(rURL)
+		redisReadClient, err = NewRedisClient(rURL, config.Redis.Choice)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -464,7 +464,7 @@ func Start(config *Config) (*Server, func(), error) {
 				if bgcfg.ConsensusHAHeartbeatInterval > 0 {
 					topts = append(topts, WithHeartbeatInterval(time.Duration(bgcfg.ConsensusHAHeartbeatInterval)))
 				}
-				consensusHARedisClient, err := NewRedisClient(bgcfg.ConsensusHARedis.URL)
+				consensusHARedisClient, err := NewRedisClient(bgcfg.ConsensusHARedis.URL, bgcfg.ConsensusHARedis.Choice)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/proxyd/redis.go
+++ b/proxyd/redis.go
@@ -8,19 +8,16 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-func NewRedisClient(url string, choice RedisClientChoice) (redis.UniversalClient, error) {
-	switch choice {
-	case ClusterChoice:
+func NewRedisClient(url string, enable_cluster bool) (redis.UniversalClient, error) {
+	if enable_cluster {
 		log.Info("Using cluster redis client.")
 		opts, err := redis.ParseClusterURL(url)
 		if err != nil {
 			return nil, err
 		}
 		return redis.NewClusterClient(opts), nil
-	case DefaultChoice:
-		fallthrough
-	default:
-		log.Info("Using default redis client.", "choice", choice)
+	} else {
+		log.Info("Using default redis client.")
 		opts, err := redis.ParseURL(url)
 		if err != nil {
 			return nil, err

--- a/proxyd/redis.go
+++ b/proxyd/redis.go
@@ -4,19 +4,32 @@ import (
 	"context"
 	"time"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/redis/go-redis/v9"
 )
 
-func NewRedisClient(url string) (*redis.Client, error) {
-	opts, err := redis.ParseURL(url)
-	if err != nil {
-		return nil, err
+func NewRedisClient(url string, choice RedisClientChoice) (redis.UniversalClient, error) {
+	switch choice {
+	case ClusterChoice:
+		log.Info("Using cluster redis client.")
+		opts, err := redis.ParseClusterURL(url)
+		if err != nil {
+			return nil, err
+		}
+		return redis.NewClusterClient(opts), nil
+	case DefaultChoice:
+		fallthrough
+	default:
+		log.Info("Using default redis client.", "choice", choice)
+		opts, err := redis.ParseURL(url)
+		if err != nil {
+			return nil, err
+		}
+		return redis.NewClient(opts), nil
 	}
-	client := redis.NewClient(opts)
-	return client, nil
 }
 
-func CheckRedisConnection(client *redis.Client) error {
+func CheckRedisConnection(client redis.UniversalClient) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := client.Ping(ctx).Err(); err != nil {


### PR DESCRIPTION
**Description**

Main motivation is to able to connect to Redis cluster using `redis.NewClusterClient`  that will be use with consensus feature. But since go-redis supports `redis.UniversalClient`, we can also retype some params to allow this option in places like cache and rate limiting.

**Tests**

Ran a local Redis cluster (x3 instances) and ran local build of proxyd on test config. Used nginx to round robin between 2 local proxyd instances connected to the same Redis cluster to test the consensus mechanism (using local script).

**Metadata**
Added discussion in #99.