### PR TITLE
op-conductor-ops: halt-sequencer command and pre-flight checks to force-active-sequencer

### DIFF
--- a/op-conductor-ops/op-conductor-ops.py
+++ b/op-conductor-ops/op-conductor-ops.py
@@ -363,12 +363,19 @@ def halt_sequencer(network: str, force: bool = False):
 
 
 @app.command()
-def force_active_sequencer(network: str, sequencer_id: str):
+def force_active_sequencer(network: str, sequencer_id: str, force: bool = False):
     """Forces a sequencer to become active using stop/start."""
     network_obj = get_network(network)
     sequencer = network_obj.get_sequencer_by_id(sequencer_id)
     if sequencer is None:
         typer.echo(f"sequencer ID {sequencer_id} not found in network {network}")
+        raise typer.Exit(code=1)
+
+    # Pre-flight check: Ensure all conductors are paused
+    sequencers = network_obj.sequencers
+    all_paused = all(not sequencer.conductor_active for sequencer in sequencers)
+    if not all_paused and not force:
+        print_error("Not all conductors are paused. Run 'pause' command first.")
         raise typer.Exit(code=1)
 
     hash = sequencer.unsafe_l2_hash


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR introduces a halt-sequencer command to op-conductor-ops to Halt the currently active sequencer.

Also it introduces the enforcement of having all the conductors paused when running the `force-active-sequencer` command of op-conductor-ops to prevent causing two active sequencers.

**Tests**

Halting the sequencer

```
❯ ./op-conductor-ops halt-sequencer dev-client-sepolia
ERROR! Not all conductors were found to be paused. Please run the `pause` command or use --force to override this behaviour

❯ ./op-conductor-ops pause dev-client-sepolia         
Successfully paused dev-client-sepolia-devnet-0-sequencer-0
Successfully paused dev-client-sepolia-devnet-0-sequencer-1
Successfully paused dev-client-sepolia-devnet-0-sequencer-2

~/OPLabs/Projects/infra/op-conductor-ops op-conductor-ops-halt-sequencer*                                                                                              
❯ ./op-conductor-ops halt-sequencer dev-client-sepolia 
Successfully halted the active sequencer: dev-client-sepolia-devnet-0-sequencer-0
```

Pre-flight check for force-active-sequencer for having all the conductors as paused

```
❯ ./op-conductor-ops resume dev-client-sepolia
Successfully resumed dev-client-sepolia-devnet-0-sequencer-0
Successfully resumed dev-client-sepolia-devnet-0-sequencer-1
Successfully resumed dev-client-sepolia-devnet-0-sequencer-2

~/OPLabs/Projects/infra/op-conductor-ops op-conductor-ops-halt-sequencer*                                                                                           5s op-conductor-ops 03:26:45
❯ ./op-conductor-ops force-active-sequencer dev-client-sepolia dev-client-sepolia-devnet-0-sequencer-0
ERROR! Not all conductors are paused. Run 'pause' command first.
```

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes ethereum-optimism/platforms-team#467
