### PR TITLE
Make proxyd error handling more generic for different backend impleme…

### DIFF
--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -203,6 +203,17 @@ var (
 		"gas price too high",
 		"gas price too low",
 		"invalid parameters",
+		"txpool is full",
+		"pool is full",
+		"pool overflow",
+		"transaction pool is full",
+		"insufficient funds",
+		"replacement underpriced",
+		"already known",
+		"max initcode size exceeded",
+		"insufficient balance",
+		"gas limit exceeded",
+		"intrinsic gas too low",
 	}
 
 	redisCacheDurationSumm = promauto.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Currently proxyd's special error categorization is too specific to geth-based implementations and misses important error cases from other backend implementations (reth, nethermind, etc). This limits proxyd's ability to properly monitor and alert on important error conditions across different backend types.

**Solution**
Expand proxyd's error pattern matching to cover more error cases and variations in how different backends report them