### PR TITLE
feat(proxyd): add filter polling support via RPC

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -29,6 +29,9 @@ type ServerConfig struct {
 	EnablePprof           bool `toml:"enable_pprof"`
 	EnableXServedByHeader bool `toml:"enable_served_by_header"`
 	AllowAllOrigins       bool `toml:"allow_all_origins"`
+
+	// FilterTimeoutSeconds specifies the maximum time to keep a filter for that has not been polled for changes.
+	FilterTimeoutSeconds int `toml:"filter_timeout_seconds"`
 }
 
 type CacheConfig struct {

--- a/proxyd/integration_tests/filter_rpc_routing_test.go
+++ b/proxyd/integration_tests/filter_rpc_routing_test.go
@@ -1,0 +1,67 @@
+package integration_tests
+
+import (
+	"fmt"
+	"github.com/ethereum-optimism/infra/proxyd"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestFilterRpcRouting(t *testing.T) {
+	backend1 := NewMockBackend(nil)
+	backend2 := NewMockBackend(nil)
+	defer backend1.Close()
+	defer backend2.Close()
+
+	require.NoError(t, os.Setenv("NODE1_URL", backend1.URL()))
+	require.NoError(t, os.Setenv("NODE2_URL", backend2.URL()))
+
+	config := ReadConfig("filter_rpc_routing")
+	client := NewProxydClient("http://127.0.0.1:8545")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	filterId := "0x11414222354634635214124"
+	newFilterResponse := fmt.Sprintf(`{"jsonrpc":"2.0","result":"%s","id":1}`, filterId)
+	getFilterChangesResponse1 := `{"jsonrpc":"2.0","result":["0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],"id":1}`
+	getFilterChangesResponse2 := `{"jsonrpc":"2.0","result":["0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"],"id":1}`
+
+	responseQueue := make(chan string, 3)
+	responseQueue <- newFilterResponse
+	responseQueue <- getFilterChangesResponse1
+	responseQueue <- getFilterChangesResponse2
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		SingleResponseHandler(200, <-responseQueue)(w, r)
+	})
+
+	backend1.SetHandler(handler)
+	backend2.SetHandler(handler)
+
+	res, statusCode, err := client.SendRPC("eth_newBlockFilter", nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, statusCode)
+
+	var selectedBackend *MockBackend
+	if len(backend1.Requests()) > 0 {
+		selectedBackend = backend1
+	} else {
+		selectedBackend = backend2
+	}
+
+	require.Equal(t, 1, len(selectedBackend.Requests()))
+	RequireEqualJSON(t, []byte(newFilterResponse), res)
+
+	res, statusCode, err = client.SendRPC("eth_getFilterChanges", []interface{}{filterId})
+
+	require.Equal(t, 2, len(selectedBackend.Requests()))
+	RequireEqualJSON(t, []byte(getFilterChangesResponse1), res)
+
+	res, statusCode, err = client.SendRPC("eth_getFilterChanges", []interface{}{filterId})
+
+	require.Equal(t, 3, len(selectedBackend.Requests()))
+	RequireEqualJSON(t, []byte(getFilterChangesResponse2), res)
+}

--- a/proxyd/integration_tests/filter_rpc_routing_test.go
+++ b/proxyd/integration_tests/filter_rpc_routing_test.go
@@ -2,11 +2,12 @@ package integration_tests
 
 import (
 	"fmt"
-	"github.com/ethereum-optimism/infra/proxyd"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/ethereum-optimism/infra/proxyd"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFilterRpcRouting(t *testing.T) {
@@ -58,10 +59,14 @@ func TestFilterRpcRouting(t *testing.T) {
 	res, statusCode, err = client.SendRPC("eth_getFilterChanges", []interface{}{filterId})
 
 	require.Equal(t, 2, len(selectedBackend.Requests()))
+	require.NoError(t, err)
+	require.Equal(t, 200, statusCode)
 	RequireEqualJSON(t, []byte(getFilterChangesResponse1), res)
 
 	res, statusCode, err = client.SendRPC("eth_getFilterChanges", []interface{}{filterId})
 
 	require.Equal(t, 3, len(selectedBackend.Requests()))
+	require.NoError(t, err)
+	require.Equal(t, 200, statusCode)
 	RequireEqualJSON(t, []byte(getFilterChangesResponse2), res)
 }

--- a/proxyd/integration_tests/testdata/filter_rpc_routing.toml
+++ b/proxyd/integration_tests/testdata/filter_rpc_routing.toml
@@ -1,0 +1,20 @@
+[server]
+rpc_port = 8545
+
+[backends]
+[backends.first]
+rpc_url = "$NODE1_URL"
+
+[backends.second]
+rpc_url = "$NODE1_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["first", "second"]
+
+[rpc_method_mappings]
+eth_newFilter = "main"
+eth_newBlockFilter = "main"
+eth_uninstallFilter = "main"
+eth_getFilterChanges = "main"
+eth_getFilterLogs = "main"

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -353,6 +353,7 @@ func Start(config *Config) (*Server, func(), error) {
 		config.Server.MaxRequestBodyLogLen,
 		config.BatchConfig.MaxSize,
 		limiterFactory,
+		secondsToDuration(config.Server.FilterTimeoutSeconds),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Currently, the backend on which the filter was created at can be different than the backend being polled for changes (due to load balancing), resulting in `filter not found` errors. 

This PR adds support for creating filters and polling its changes via RPC calls when there are multiple backends defined. For each new filter, the server now stores which backend served the request. When filter changes are requested, the server correctly routes the request to the same backend where the filter was created at.

**Tests**

Added an integration test that verifies that the filter requests are being routed to the same backend.

**Additional context**

WS works fine because it keeps open the connection to the correct backend.
