### PR TITLE
feat: add short-lived cache handlers

### DIFF
--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -100,6 +101,7 @@ func (c *redisCache) Get(ctx context.Context, key string) (string, error) {
 	start := time.Now()
 	val, err := c.redisReadClient.Get(ctx, c.namespaced(key)).Result()
 	redisCacheDurationSumm.WithLabelValues("GET").Observe(float64(time.Since(start).Milliseconds()))
+	fmt.Println("val", val)
 
 	if err == redis.Nil {
 		return "", nil
@@ -114,8 +116,11 @@ func (c *redisCache) Put(ctx context.Context, key string, value string, shortLiv
 	ttl := c.defaultTTL
 
 	// disable PUT on short lived key if shortLivedTTL is not set
-	if shortLived && c.shortLivedTTL == 0 {
-		return nil
+	if shortLived {
+		if c.shortLivedTTL == 0 {
+			return nil
+		}
+		ttl = c.shortLivedTTL
 	}
 
 	start := time.Now()

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -110,8 +110,13 @@ func (c *redisCache) Get(ctx context.Context, key string) (string, error) {
 }
 
 func (c *redisCache) Put(ctx context.Context, key string, value string, shortLived bool) error {
+	ttl := c.defaultTTL
+	if shortLived {
+		ttl = c.shortLivedTTL
+	}
+
 	start := time.Now()
-	err := c.redisClient.SetEx(ctx, c.namespaced(key), value, c.defaultTTL).Err()
+	err := c.redisClient.SetEx(ctx, c.namespaced(key), value, ttl).Err()
 	redisCacheDurationSumm.WithLabelValues("SETEX").Observe(float64(time.Since(start).Milliseconds()))
 
 	if err != nil {

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -3,7 +3,6 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
@@ -101,7 +100,6 @@ func (c *redisCache) Get(ctx context.Context, key string) (string, error) {
 	start := time.Now()
 	val, err := c.redisReadClient.Get(ctx, c.namespaced(key)).Result()
 	redisCacheDurationSumm.WithLabelValues("GET").Observe(float64(time.Since(start).Milliseconds()))
-	fmt.Printf("GET key: %s, val: %s\n", key, val)
 
 	if err == redis.Nil {
 		return "", nil
@@ -119,7 +117,6 @@ func (c *redisCache) Put(ctx context.Context, key string, value string, shortLiv
 	}
 
 	start := time.Now()
-	fmt.Printf("PUT key: %s, value: %s, ttl: %s\n", key, value, ttl)
 	err := c.redisClient.SetEx(ctx, c.namespaced(key), value, ttl).Err()
 	redisCacheDurationSumm.WithLabelValues("SETEX").Observe(float64(time.Since(start).Milliseconds()))
 

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -96,9 +97,11 @@ func (c *redisCache) namespaced(key string) string {
 }
 
 func (c *redisCache) Get(ctx context.Context, key string) (string, error) {
+
 	start := time.Now()
 	val, err := c.redisReadClient.Get(ctx, c.namespaced(key)).Result()
 	redisCacheDurationSumm.WithLabelValues("GET").Observe(float64(time.Since(start).Milliseconds()))
+	fmt.Printf("GET key: %s, val: %s\n", key, val)
 
 	if err == redis.Nil {
 		return "", nil
@@ -116,6 +119,7 @@ func (c *redisCache) Put(ctx context.Context, key string, value string, shortLiv
 	}
 
 	start := time.Now()
+	fmt.Printf("PUT key: %s, value: %s, ttl: %s\n", key, value, ttl)
 	err := c.redisClient.SetEx(ctx, c.namespaced(key), value, ttl).Err()
 	redisCacheDurationSumm.WithLabelValues("SETEX").Observe(float64(time.Since(start).Milliseconds()))
 

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -114,7 +114,7 @@ func (c *redisCache) Put(ctx context.Context, key string, value string, shortLiv
 	ttl := c.defaultTTL
 
 	// disable PUT on short lived key if shortLivedTTL is not set
-	if shortLived && c.shortLivedTTL > 0 {
+	if shortLived && c.shortLivedTTL == 0 {
 		return nil
 	}
 

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -84,7 +84,7 @@ type redisCache struct {
 	shortLivedTTL   time.Duration
 }
 
-func newRedisCache(redisClient *redis.UniversalClient, redisReadClient *redis.UniversalClient, prefix string, defaultTTL time.Duration, shortLivedTTL time.Duration) *redisCache {
+func newRedisCache(redisClient redis.UniversalClient, redisReadClient redis.UniversalClient, prefix string, defaultTTL time.Duration, shortLivedTTL time.Duration) *redisCache {
 	return &redisCache{redisClient, redisReadClient, prefix, defaultTTL, shortLivedTTL}
 }
 

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -14,8 +14,11 @@ import (
 )
 
 type Cache interface {
+	// Get fetches a value from the cache
 	Get(ctx context.Context, key string) (string, error)
-	Put(ctx context.Context, key string, value string) error
+
+	// Put updates a value in the cache with a TTL
+	Put(ctx context.Context, key string, value string, shortLived bool) error
 }
 
 const (
@@ -39,7 +42,11 @@ func (c *cache) Get(ctx context.Context, key string) (string, error) {
 	return "", nil
 }
 
-func (c *cache) Put(ctx context.Context, key string, value string) error {
+func (c *cache) Put(ctx context.Context, key string, value string, shortLived bool) error {
+	// ignore value with short lived flag
+	if shortLived {
+		return nil
+	}
 	c.lru.Add(key, value)
 	return nil
 }
@@ -61,10 +68,10 @@ func (c *fallbackCache) Get(ctx context.Context, key string) (string, error) {
 	return val, nil
 }
 
-func (c *fallbackCache) Put(ctx context.Context, key string, value string) error {
-	err := c.primaryCache.Put(ctx, key, value)
+func (c *fallbackCache) Put(ctx context.Context, key string, value string, shortLived bool) error {
+	err := c.primaryCache.Put(ctx, key, value, shortLived)
 	if err != nil {
-		return c.secondaryCache.Put(ctx, key, value)
+		return c.secondaryCache.Put(ctx, key, value, shortLived)
 	}
 	return nil
 }
@@ -73,11 +80,12 @@ type redisCache struct {
 	redisClient     redis.UniversalClient
 	redisReadClient redis.UniversalClient
 	prefix          string
-	ttl             time.Duration
+	defaultTTL      time.Duration
+	shortLivedTTL   time.Duration
 }
 
-func newRedisCache(redisClient redis.UniversalClient, redisReadClient redis.UniversalClient, prefix string, ttl time.Duration) *redisCache {
-	return &redisCache{redisClient, redisReadClient, prefix, ttl}
+func newRedisCache(redisClient *redis.UniversalClient, redisReadClient *redis.UniversalClient, prefix string, defaultTTL time.Duration, shortLivedTTL time.Duration) *redisCache {
+	return &redisCache{redisClient, redisReadClient, prefix, defaultTTL, shortLivedTTL}
 }
 
 func (c *redisCache) namespaced(key string) string {
@@ -101,9 +109,9 @@ func (c *redisCache) Get(ctx context.Context, key string) (string, error) {
 	return val, nil
 }
 
-func (c *redisCache) Put(ctx context.Context, key string, value string) error {
+func (c *redisCache) Put(ctx context.Context, key string, value string, shortLived bool) error {
 	start := time.Now()
-	err := c.redisClient.SetEx(ctx, c.namespaced(key), value, c.ttl).Err()
+	err := c.redisClient.SetEx(ctx, c.namespaced(key), value, c.defaultTTL).Err()
 	redisCacheDurationSumm.WithLabelValues("SETEX").Observe(float64(time.Since(start).Milliseconds()))
 
 	if err != nil {
@@ -135,9 +143,9 @@ func (c *cacheWithCompression) Get(ctx context.Context, key string) (string, err
 	return string(val), nil
 }
 
-func (c *cacheWithCompression) Put(ctx context.Context, key string, value string) error {
+func (c *cacheWithCompression) Put(ctx context.Context, key string, value string, shortLived bool) error {
 	encodedVal := snappy.Encode(nil, []byte(value))
-	return c.cache.Put(ctx, key, string(encodedVal))
+	return c.cache.Put(ctx, key, string(encodedVal), shortLived)
 }
 
 type RPCCache interface {
@@ -152,6 +160,7 @@ type rpcCache struct {
 
 func newRPCCache(cache Cache) RPCCache {
 	staticHandler := &StaticMethodHandler{cache: cache}
+	shortLivedHandler := &StaticMethodHandler{cache: cache, shortLived: true}
 	debugGetRawReceiptsHandler := &StaticMethodHandler{cache: cache,
 		filterGet: func(req *RPCReq) bool {
 			// cache only if the request is for a block hash
@@ -176,14 +185,24 @@ func newRPCCache(cache Cache) RPCCache {
 		},
 	}
 	handlers := map[string]RPCMethodHandler{
-		"eth_chainId":                           staticHandler,
-		"net_version":                           staticHandler,
-		"eth_getBlockTransactionCountByHash":    staticHandler,
-		"eth_getUncleCountByBlockHash":          staticHandler,
-		"eth_getBlockByHash":                    staticHandler,
-		"eth_getTransactionByBlockHashAndIndex": staticHandler,
-		"eth_getUncleByBlockHashAndIndex":       staticHandler,
-		"debug_getRawReceipts":                  debugGetRawReceiptsHandler,
+		"eth_chainId":                             staticHandler,
+		"net_version":                             staticHandler,
+		"eth_getBlockTransactionCountByHash":      staticHandler,
+		"eth_getUncleCountByBlockHash":            staticHandler,
+		"eth_getBlockByHash":                      staticHandler,
+		"eth_getTransactionByBlockHashAndIndex":   staticHandler,
+		"eth_getUncleByBlockHashAndIndex":         staticHandler,
+		"debug_getRawReceipts":                    debugGetRawReceiptsHandler,
+		"eth_getBlockByNumber":                    shortLivedHandler,
+		"eth_blockNumber":                         shortLivedHandler,
+		"eth_getBalance":                          shortLivedHandler,
+		"eth_getStorageAt":                        shortLivedHandler,
+		"eth_getTransactionCount":                 shortLivedHandler,
+		"eth_getBlockTransactionCountByNumber":    shortLivedHandler,
+		"eth_getUncleCountByBlockNumber":          shortLivedHandler,
+		"eth_getCode":                             shortLivedHandler,
+		"eth_getTransactionByBlockNumberAndIndex": shortLivedHandler,
+		"eth_getUncleByBlockNumberAndIndex":       shortLivedHandler,
 	}
 	return &rpcCache{
 		cache:    cache,

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -112,8 +112,10 @@ func (c *redisCache) Get(ctx context.Context, key string) (string, error) {
 
 func (c *redisCache) Put(ctx context.Context, key string, value string, shortLived bool) error {
 	ttl := c.defaultTTL
-	if shortLived {
-		ttl = c.shortLivedTTL
+
+	// disable PUT on short lived key if shortLivedTTL is not set
+	if shortLived && c.shortLivedTTL > 0 {
+		return nil
 	}
 
 	start := time.Now()

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -3,7 +3,6 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
@@ -97,11 +96,9 @@ func (c *redisCache) namespaced(key string) string {
 }
 
 func (c *redisCache) Get(ctx context.Context, key string) (string, error) {
-
 	start := time.Now()
 	val, err := c.redisReadClient.Get(ctx, c.namespaced(key)).Result()
 	redisCacheDurationSumm.WithLabelValues("GET").Observe(float64(time.Since(start).Milliseconds()))
-	fmt.Println("val", val)
 
 	if err == redis.Nil {
 		return "", nil

--- a/proxyd/cache_test.go
+++ b/proxyd/cache_test.go
@@ -220,7 +220,7 @@ func (c *errorCache) Get(ctx context.Context, key string) (string, error) {
 	return "", errors.New("test error")
 }
 
-func (c *errorCache) Put(ctx context.Context, key string, value string) error {
+func (c *errorCache) Put(ctx context.Context, key string, value string, shortLived bool) error {
 	return errors.New("test error")
 }
 
@@ -241,7 +241,7 @@ func TestFallbackCache(t *testing.T) {
 
 	for i, cache := range success {
 		t.Run("success", func(t *testing.T) {
-			err := cache.Put(ctx, "foo", fmt.Sprintf("bar%d", i))
+			err := cache.Put(ctx, "foo", fmt.Sprintf("bar%d", i), false)
 			require.NoError(t, err)
 
 			val, err := cache.Get(ctx, "foo")
@@ -256,7 +256,7 @@ func TestFallbackCache(t *testing.T) {
 			require.Error(t, err)
 			require.Empty(t, val)
 
-			err = cache.Put(ctx, "foo", "baz")
+			err = cache.Put(ctx, "foo", "baz", false)
 			require.Error(t, err)
 		})
 	}

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -32,9 +32,9 @@ type ServerConfig struct {
 }
 
 type CacheConfig struct {
-	Enabled  bool         `toml:"enabled"`
-	TTL      TOMLDuration `toml:"ttl"`
-	BlockTTL TOMLDuration `toml:"block_ttl"`
+	Enabled       bool         `toml:"enabled"`
+	TTL           TOMLDuration `toml:"ttl"`
+	ShortLivedTTL TOMLDuration `toml:"short_lived_ttl"`
 }
 
 type RedisConfig struct {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -32,8 +32,9 @@ type ServerConfig struct {
 }
 
 type CacheConfig struct {
-	Enabled bool         `toml:"enabled"`
-	TTL     TOMLDuration `toml:"ttl"`
+	Enabled  bool         `toml:"enabled"`
+	TTL      TOMLDuration `toml:"ttl"`
+	BlockTTL TOMLDuration `toml:"block_ttl"`
 }
 
 type RedisConfig struct {

--- a/proxyd/integration_tests/testdata/caching.toml
+++ b/proxyd/integration_tests/testdata/caching.toml
@@ -10,6 +10,7 @@ namespace = "proxyd"
 
 [cache]
 enabled = true
+block_ttl = "1s"
 
 [backends]
 [backends.good]

--- a/proxyd/integration_tests/testdata/caching.toml
+++ b/proxyd/integration_tests/testdata/caching.toml
@@ -10,7 +10,7 @@ namespace = "proxyd"
 
 [cache]
 enabled = true
-block_ttl = "1s"
+short_lived_ttl = "1s"
 
 [backends]
 [backends.good]

--- a/proxyd/methods.go
+++ b/proxyd/methods.go
@@ -17,10 +17,11 @@ type RPCMethodHandler interface {
 }
 
 type StaticMethodHandler struct {
-	cache     Cache
-	m         sync.RWMutex
-	filterGet func(*RPCReq) bool
-	filterPut func(*RPCReq, *RPCRes) bool
+	cache      Cache
+	m          sync.RWMutex
+	shortLived bool
+	filterGet  func(*RPCReq) bool
+	filterPut  func(*RPCReq, *RPCRes) bool
 }
 
 func (e *StaticMethodHandler) key(req *RPCReq) string {
@@ -83,7 +84,7 @@ func (e *StaticMethodHandler) PutRPCMethod(ctx context.Context, req *RPCReq, res
 	key := e.key(req)
 	value := mustMarshalJSON(res.Result)
 
-	err := e.cache.Put(ctx, key, string(value))
+	err := e.cache.Put(ctx, key, string(value), e.shortLived)
 	if err != nil {
 		log.Error("error putting into cache", "key", key, "method", req.Method, "err", err)
 		return err

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -310,7 +310,12 @@ func Start(config *Config) (*Server, func(), error) {
 			if config.Cache.TTL != 0 {
 				ttl = time.Duration(config.Cache.TTL)
 			}
-			cache = newRedisCache(redisClient, redisReadClient, config.Redis.Namespace, ttl)
+
+			blockTtl := defaultBlockTtl
+			if config.Cache.BlockTTL != 0 {
+				blockTtl = time.Duration(config.Cache.BlockTTL)
+			}
+			cache = newRedisCache(redisClient, redisReadClient, config.Redis.Namespace, ttl, blockTtl)
 
 			if config.Redis.FallbackToMemory {
 				cache = newFallbackCache(cache, newMemoryCache())

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -311,11 +311,7 @@ func Start(config *Config) (*Server, func(), error) {
 				ttl = time.Duration(config.Cache.TTL)
 			}
 
-			blockTtl := defaultBlockTtl
-			if config.Cache.BlockTTL != 0 {
-				blockTtl = time.Duration(config.Cache.BlockTTL)
-			}
-			cache = newRedisCache(redisClient, redisReadClient, config.Redis.Namespace, ttl, blockTtl)
+			cache = newRedisCache(redisClient, redisReadClient, config.Redis.Namespace, ttl, time.Duration(config.Cache.ShortLivedTTL))
 
 			if config.Redis.FallbackToMemory {
 				cache = newFallbackCache(cache, newMemoryCache())

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -43,6 +43,7 @@ const (
 	defaultWSReadTimeout         = 2 * time.Minute
 	defaultWSWriteTimeout        = 10 * time.Second
 	defaultCacheTtl              = 1 * time.Hour
+	defaultBlockTtl              = 2 * time.Second
 	maxRequestBodyLogLen         = 2000
 	defaultMaxUpstreamBatchSize  = 10
 	defaultRateLimitHeader       = "X-Forwarded-For"


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

We currently send a ton of traffic to backend nodes on barely uncacheable endpoints (endpoints based on block number). This PR adds a cache with a very short TTL (`block_ttl` - defaults to `2 seconds`) for these endpoints.

> Since Redis 2.6 the expire error is from 0 to 1 milliseconds.

Short TTLs seem fine for Redis. Other caching backends will currently ignore short lived cache keys.

_Open question: should we implement this for in-memory cache?_

**Tests**

TODO

**Additional context**

Add any other context about the problem you're solving.
