### PR TITLE
feat(op-conductor-ops): Add voting column in sequencer status table

### DIFF
--- a/op-conductor-ops/op-conductor-ops.py
+++ b/op-conductor-ops/op-conductor-ops.py
@@ -65,6 +65,7 @@ def status(network: str):
         "Sequencer Healthy",
         "Conductor Leader",
         "Active Sequencer",
+        "Voting",
         "Unsafe Number",
         "Unsafe Hash",
     )
@@ -75,6 +76,7 @@ def status(network: str):
             print_boolean(sequencer.sequencer_healthy),
             print_boolean(sequencer.conductor_leader),
             print_boolean(sequencer.sequencer_active),
+            print_boolean(sequencer.voting),
             str(sequencer.unsafe_l2_number),
             str(sequencer.unsafe_l2_hash),
         )


### PR DESCRIPTION
**Description**

Add `Voting` column in the op-conductor-ops status table to indicate whether each sequencer is a voting member.

Example output:
```
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Sequencer ID           ┃ Conductor Active ┃ Sequencer Healthy ┃ Conductor Leader ┃ Active Sequencer ┃ Voting ┃ Unsafe Number ┃ Unsafe Hash                                             ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ sequencer-1            │ ✅               │ ✅                │ ✅               │ ✅               │ ✅     │ 13727158      │ 0x6a5c650f7590284d3d6435c6421c3afac981263ca6bf8c2854e9… │
│ sequencer-1            │ ✅               │ ✅                │ ❌               │ ❌               │ ❌     │ 13727158      │ 0x6a5c650f7590284d3d6435c6421c3afac981263ca6bf8c2854e9… │
│ sequencer-2            │ ✅               │ ✅                │ ❌               │ ❌               │ ✅     │ 13727158      │ 0x6a5c650f7590284d3d6435c6421c3afac981263ca6bf8c2854e9… │
│ sequencer-3            │ ✅               │ ✅                │ ❌               │ ❌               │ ✅     │ 13727158      │ 0x6a5c650f7590284d3d6435c6421c3afac981263ca6bf8c2854e9… │
│ sequencer-4            │ ✅               │ ✅                │ ❌               │ ❌               │ ❌     │ 13727158      │ 0x6a5c650f7590284d3d6435c6421c3afac981263ca6bf8c2854e9… │
└────────────────────────┴──────────────────┴───────────────────┴──────────────────┴──────────────────┴────────┴───────────────┴─────────────────────────────────────────────────────────┘
```
