### PR TITLE
fix: don't count replacement underpriced errors

### DIFF
--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -209,6 +209,7 @@ var (
 		"transaction pool is full",
 		"insufficient funds",
 		"replacement underpriced",
+		"replacement transaction underpriced",
 		"already known",
 		"max initcode size exceeded",
 		"insufficient balance",


### PR DESCRIPTION
**Description**

Update the list of special errors to match op-geth for underpriced transactions. See [here](https://github.com/ethereum-optimism/op-geth/blob/928070c7fc097362ed2d40a4f72889ba91544931/core/txpool/errors.go#L35).
