### PR TITLE
[proxyd]: Add block range rate limiting, and max block range to non-consensus mode

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -735,6 +735,7 @@ type BackendGroup struct {
 	Nonconsensus           *NonconsensusPoller
 	FallbackBackends       map[string]bool
 	MaxBlockRange          uint64
+	RateLimitRange         bool
 	routingStrategy        RoutingStrategy
 	multicallRPCErrorCheck bool
 }

--- a/proxyd/block_range.go
+++ b/proxyd/block_range.go
@@ -1,0 +1,68 @@
+package proxyd
+
+import (
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+type BlockRange struct {
+	FromBlock uint64
+	ToBlock   uint64
+}
+
+type BlockNumberTracker interface {
+	GetLatestBlockNumber() (uint64, bool)
+	GetSafeBlockNumber() (uint64, bool)
+	GetFinalizedBlockNumber() (uint64, bool)
+}
+
+func ExtractBlockRange(req *RPCReq, tracker BlockNumberTracker) *BlockRange {
+	switch req.Method {
+	case "eth_getLogs", "eth_newFilter":
+		var p []map[string]interface{}
+		if err := json.Unmarshal(req.Params, &p); err != nil {
+			return nil
+		}
+		fromBlock, hasFrom := p[0]["fromBlock"].(string)
+		toBlock, hasTo := p[0]["toBlock"].(string)
+		if !hasFrom && !hasTo {
+			return nil
+		}
+		// if either fromBlock or toBlock is defined, default the other to "latest" if unset
+		if hasFrom && !hasTo {
+			toBlock = "latest"
+		} else if hasTo && !hasFrom {
+			fromBlock = "latest"
+		}
+		from, fromOk := stringToBlockNumber(fromBlock, tracker)
+		to, toOk := stringToBlockNumber(toBlock, tracker)
+		if !fromOk || !toOk {
+			return nil
+		}
+		return &BlockRange{
+			FromBlock: from,
+			ToBlock:   to,
+		}
+	default:
+		return nil
+	}
+}
+
+func stringToBlockNumber(tag string, tracker BlockNumberTracker) (uint64, bool) {
+	switch tag {
+	case "latest":
+		return tracker.GetLatestBlockNumber()
+	case "safe":
+		return tracker.GetSafeBlockNumber()
+	case "finalized":
+		return tracker.GetFinalizedBlockNumber()
+	case "earliest":
+		return 0, true
+	case "pending":
+		latest, ok := tracker.GetLatestBlockNumber()
+		return latest + 1, ok
+	}
+	d, err := hexutil.DecodeUint64(tag)
+	return d, err == nil
+}

--- a/proxyd/block_range_test.go
+++ b/proxyd/block_range_test.go
@@ -1,0 +1,174 @@
+package proxyd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type MockBlockNumberTracker struct {
+	Latest   uint64
+	Safe     uint64
+	Final    uint64
+	LatestOk bool
+	SafeOk   bool
+	FinalOk  bool
+}
+
+func (m *MockBlockNumberTracker) GetLatestBlockNumber() (uint64, bool) {
+	return m.Latest, m.LatestOk
+}
+
+func (m *MockBlockNumberTracker) GetSafeBlockNumber() (uint64, bool) {
+	return m.Safe, m.SafeOk
+}
+
+func (m *MockBlockNumberTracker) GetFinalizedBlockNumber() (uint64, bool) {
+	return m.Final, m.FinalOk
+}
+
+func TestExtractBlockRange(t *testing.T) {
+	testCases := []struct {
+		name     string
+		req      *RPCReq
+		tracker  *MockBlockNumberTracker
+		expected *BlockRange
+	}{
+		{
+			name: "latest blocks",
+			req: &RPCReq{
+				Method: "eth_getLogs",
+				Params: []byte(`[{"fromBlock": "latest", "toBlock": "latest"}]`),
+			},
+			tracker: &MockBlockNumberTracker{
+				Latest:   100,
+				LatestOk: true,
+			},
+			expected: &BlockRange{
+				FromBlock: 100,
+				ToBlock:   100,
+			},
+		},
+		{
+			name: "finalized blocks",
+			req: &RPCReq{
+				Method: "eth_getLogs",
+				Params: []byte(`[{"fromBlock": "finalized", "toBlock": "finalized"}]`),
+			},
+			tracker: &MockBlockNumberTracker{
+				Final:   80,
+				FinalOk: true,
+			},
+			expected: &BlockRange{
+				FromBlock: 80,
+				ToBlock:   80,
+			},
+		},
+		{
+			name: "safe blocks",
+			req: &RPCReq{
+				Method: "eth_getLogs",
+				Params: []byte(`[{"fromBlock": "safe", "toBlock": "safe"}]`),
+			},
+			tracker: &MockBlockNumberTracker{
+				Safe:   90,
+				SafeOk: true,
+			},
+			expected: &BlockRange{
+				FromBlock: 90,
+				ToBlock:   90,
+			},
+		},
+		{
+			name: "earliest blocks",
+			req: &RPCReq{
+				Method: "eth_getLogs",
+				Params: []byte(`[{"fromBlock": "earliest", "toBlock": "earliest"}]`),
+			},
+			tracker: &MockBlockNumberTracker{},
+			expected: &BlockRange{
+				FromBlock: 0,
+				ToBlock:   0,
+			},
+		},
+		{
+			name: "hex block numbers",
+			req: &RPCReq{
+				Method: "eth_getLogs",
+				Params: []byte(`[{"fromBlock": "0x1", "toBlock": "0xa"}]`),
+			},
+			tracker: &MockBlockNumberTracker{},
+			expected: &BlockRange{
+				FromBlock: 1,
+				ToBlock:   10,
+			},
+		},
+		{
+			name: "unset fromBlock defaults to latest",
+			req: &RPCReq{
+				Method: "eth_getLogs",
+				Params: []byte(`[{"toBlock": "0xa"}]`),
+			},
+			tracker: &MockBlockNumberTracker{
+				Latest:   100,
+				LatestOk: true,
+			},
+			expected: &BlockRange{
+				FromBlock: 100,
+				ToBlock:   10,
+			},
+		},
+		{
+			name: "unset toBlock defaults to latest",
+			req: &RPCReq{
+				Method: "eth_getLogs",
+				Params: []byte(`[{"fromBlock": "0x1"}]`),
+			},
+			tracker: &MockBlockNumberTracker{
+				Latest:   100,
+				LatestOk: true,
+			},
+			expected: &BlockRange{
+				FromBlock: 1,
+				ToBlock:   100,
+			},
+		},
+		{
+			name: "both blocks unset returns nil",
+			req: &RPCReq{
+				Method: "eth_getLogs",
+				Params: []byte(`[{}]`),
+			},
+			tracker:  &MockBlockNumberTracker{},
+			expected: nil,
+		},
+		{
+			name: "non-logs method returns nil",
+			req: &RPCReq{
+				Method: "eth_getBalance",
+				Params: []byte(`[{"fromBlock": "latest", "toBlock": "latest"}]`),
+			},
+			tracker:  &MockBlockNumberTracker{},
+			expected: nil,
+		},
+		{
+			name: "latest block not available returns nil",
+			req: &RPCReq{
+				Method: "eth_getLogs",
+				Params: []byte(`[{"fromBlock": "latest", "toBlock": "latest"}]`),
+			},
+			tracker: &MockBlockNumberTracker{
+				Latest:   100,
+				LatestOk: false,
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ExtractBlockRange(tc.req, tc.tracker)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -167,6 +167,9 @@ type BackendGroupConfig struct {
 	// MaxBlockRange for eth_getLogs that works in both consensus and nonconsensus mode
 	MaxBlockRange uint64 `toml:"max_block_range"`
 
+	// RateLimitRange controls if eth_getLogs is rate limited by the request block range
+	RateLimitRange bool `toml:"rate_limit_range"`
+
 	/*
 		Deprecated: Use routing_strategy config to create a consensus_aware proxyd instance
 	*/

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -164,6 +164,9 @@ type BackendGroupConfig struct {
 
 	MulticallRPCErrorCheck bool `toml:"multicall_rpc_error_check"`
 
+	// MaxBlockRange for eth_getLogs that works in both consensus and nonconsensus mode
+	MaxBlockRange uint64 `toml:"max_block_range"`
+
 	/*
 		Deprecated: Use routing_strategy config to create a consensus_aware proxyd instance
 	*/
@@ -181,6 +184,8 @@ type BackendGroupConfig struct {
 	ConsensusHAHeartbeatInterval TOMLDuration `toml:"consensus_ha_heartbeat_interval"`
 	ConsensusHALockPeriod        TOMLDuration `toml:"consensus_ha_lock_period"`
 	ConsensusHARedis             RedisConfig  `toml:"consensus_ha_redis"`
+
+	NonconsensusPollerInterval TOMLDuration `toml:"nonconsensus_poller_interval"`
 
 	Fallbacks []string `toml:"fallbacks"`
 }

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -94,6 +94,8 @@ backends = ["infura"]
 # max_block_range = 10000
 # Whether to make rate limits block-range aware (e.g. eth_getLogs request for 10k blocks = 10k tokens)
 # rate_limit_range = true
+# Polling interval for the nonconsensus poller (set to negative to disable polling, e.g "-1s")
+# nonconsensus_poller_interval = "1s"
 # Enable consensus awareness for backend group, making it act as a load balancer, default false
 # consensus_aware = true
 # Period in which the backend wont serve requests if banned, default 5m

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -90,6 +90,10 @@ consensus_receipts_target = "alchemy_getTransactionReceipts"
 [backend_groups]
 [backend_groups.main]
 backends = ["infura"]
+# Maximum block range (for eth_getLogs method), no default (works in non-consensus mode too)
+# max_block_range = 10000
+# Whether to make rate limits block-range aware (e.g. eth_getLogs request for 10k blocks = 10k tokens)
+# rate_limit_range = true
 # Enable consensus awareness for backend group, making it act as a load balancer, default false
 # consensus_aware = true
 # Period in which the backend wont serve requests if banned, default 5m

--- a/proxyd/frontend_rate_limiter.go
+++ b/proxyd/frontend_rate_limiter.go
@@ -151,9 +151,9 @@ func NewFallbackRateLimiter(primary FrontendRateLimiter, secondary FrontendRateL
 	}
 }
 
-func (r *FallbackRateLimiter) Take(ctx context.Context, key string) (bool, error) {
-	if ok, err := r.primary.Take(ctx, key); err != nil {
-		return r.secondary.Take(ctx, key)
+func (r *FallbackRateLimiter) Take(ctx context.Context, key string, amount int) (bool, error) {
+	if ok, err := r.primary.Take(ctx, key, amount); err != nil {
+		return r.secondary.Take(ctx, key, amount)
 	} else {
 		return ok, err
 	}

--- a/proxyd/frontend_rate_limiter.go
+++ b/proxyd/frontend_rate_limiter.go
@@ -39,9 +39,9 @@ func newLimitedKeys(t int64) *limitedKeys {
 func (l *limitedKeys) Take(key string, amount, max int) bool {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
-	val := l.keys[key]
-	l.keys[key] = val + amount
-	return val < max
+	val := l.keys[key] + amount
+	l.keys[key] = val
+	return val <= max
 }
 
 // MemoryFrontendRateLimiter is a rate limiter that stores
@@ -118,7 +118,7 @@ func (r *RedisFrontendRateLimiter) Take(ctx context.Context, key string, amount 
 		return false, err
 	}
 
-	return incr.Val()-1 < int64(r.max), nil
+	return incr.Val() <= int64(r.max), nil
 }
 
 type noopFrontendRateLimiter struct{}

--- a/proxyd/frontend_rate_limiter_test.go
+++ b/proxyd/frontend_rate_limiter_test.go
@@ -34,6 +34,7 @@ func TestFrontendRateLimiter(t *testing.T) {
 		frl := cfg.frl
 		ctx := context.Background()
 		t.Run(cfg.name, func(t *testing.T) {
+			// Test with increment of 1
 			for i := 0; i < 4; i++ {
 				ok, err := frl.Take(ctx, "foo", 1)
 				require.NoError(t, err)
@@ -49,6 +50,21 @@ func TestFrontendRateLimiter(t *testing.T) {
 				ok, _ = frl.Take(ctx, "bar", 1)
 				require.Equal(t, i < max, ok)
 			}
+
+			// Test with increment of 2
+			time.Sleep(2 * time.Second)
+			ok, err := frl.Take(ctx, "baz", 2)
+			require.NoError(t, err)
+			require.True(t, ok)
+			ok, err = frl.Take(ctx, "baz", 1)
+			require.NoError(t, err)
+			require.False(t, ok)
+
+			// Test with increment of 3
+			time.Sleep(2 * time.Second)
+			ok, err = frl.Take(ctx, "baz", 3)
+			require.NoError(t, err)
+			require.False(t, ok)
 		})
 	}
 }

--- a/proxyd/frontend_rate_limiter_test.go
+++ b/proxyd/frontend_rate_limiter_test.go
@@ -71,7 +71,7 @@ func TestFrontendRateLimiter(t *testing.T) {
 
 type errorFrontend struct{}
 
-func (e *errorFrontend) Take(ctx context.Context, key string) (bool, error) {
+func (e *errorFrontend) Take(ctx context.Context, key string, amount int) (bool, error) {
 	return false, fmt.Errorf("test error")
 }
 
@@ -90,12 +90,12 @@ func TestFallbackRateLimiter(t *testing.T) {
 
 	ctx := context.Background()
 	for _, frl := range shouldSucceed {
-		ok, err := frl.Take(ctx, "foo")
+		ok, err := frl.Take(ctx, "foo", 1)
 		require.NoError(t, err)
 		require.True(t, ok)
 	}
 	for _, frl := range shouldFail {
-		ok, err := frl.Take(ctx, "foo")
+		ok, err := frl.Take(ctx, "foo", 1)
 		require.Error(t, err)
 		require.False(t, ok)
 	}

--- a/proxyd/frontend_rate_limiter_test.go
+++ b/proxyd/frontend_rate_limiter_test.go
@@ -35,18 +35,18 @@ func TestFrontendRateLimiter(t *testing.T) {
 		ctx := context.Background()
 		t.Run(cfg.name, func(t *testing.T) {
 			for i := 0; i < 4; i++ {
-				ok, err := frl.Take(ctx, "foo")
+				ok, err := frl.Take(ctx, "foo", 1)
 				require.NoError(t, err)
 				require.Equal(t, i < max, ok)
-				ok, err = frl.Take(ctx, "bar")
+				ok, err = frl.Take(ctx, "bar", 1)
 				require.NoError(t, err)
 				require.Equal(t, i < max, ok)
 			}
 			time.Sleep(2 * time.Second)
 			for i := 0; i < 4; i++ {
-				ok, _ := frl.Take(ctx, "foo")
+				ok, _ := frl.Take(ctx, "foo", 1)
 				require.Equal(t, i < max, ok)
-				ok, _ = frl.Take(ctx, "bar")
+				ok, _ = frl.Take(ctx, "bar", 1)
 				require.Equal(t, i < max, ok)
 			}
 		})

--- a/proxyd/integration_tests/testdata/multicall.toml
+++ b/proxyd/integration_tests/testdata/multicall.toml
@@ -21,6 +21,7 @@ rpc_url = "$NODE3_URL"
 [backend_groups.node]
 backends = ["node1", "node2", "node3"]
 routing_strategy = "multicall"
+nonconsensus_poller_interval = "-1s"
 
 [rpc_method_mappings]
 eth_call = "node"

--- a/proxyd/integration_tests/testdata/retries.toml
+++ b/proxyd/integration_tests/testdata/retries.toml
@@ -13,6 +13,7 @@ ws_url = "$GOOD_BACKEND_RPC_URL"
 [backend_groups]
 [backend_groups.main]
 backends = ["good"]
+nonconsensus_poller_interval = "-1s"
 
 [rpc_method_mappings]
 eth_chainId = "main"

--- a/proxyd/nonconsensus_poller.go
+++ b/proxyd/nonconsensus_poller.go
@@ -1,0 +1,119 @@
+package proxyd
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func NewNonconsensusPoller(bg *BackendGroup, opts ...NonconsensusOpt) *NonconsensusPoller {
+	ctx, cancel := context.WithCancel(context.Background())
+	np := &NonconsensusPoller{
+		interval:       DefaultPollerInterval,
+		ctx:            ctx,
+		cancel:         cancel,
+		done:           make(chan struct{}, 1),
+		latestBlock:    math.MaxUint64,
+		safeBlock:      math.MaxUint64,
+		finalizedBlock: math.MaxUint64,
+	}
+	for _, opt := range opts {
+		opt(np)
+	}
+	for _, backend := range bg.Backends {
+		go np.poll(backend)
+	}
+	return np
+}
+
+type NonconsensusOpt func(p *NonconsensusPoller)
+
+func WithPollingInterval(interval time.Duration) NonconsensusOpt {
+	return func(p *NonconsensusPoller) {
+		p.interval = interval
+	}
+}
+
+type NonconsensusPoller struct {
+	interval       time.Duration
+	ctx            context.Context
+	cancel         context.CancelFunc
+	done           chan struct{}
+	lock           sync.RWMutex
+	latestBlock    uint64
+	safeBlock      uint64
+	finalizedBlock uint64
+}
+
+func (p *NonconsensusPoller) Shutdown() {
+	p.cancel()
+	<-p.done
+}
+
+func (p *NonconsensusPoller) GetLatestBlockNumber() (uint64, bool) {
+	return p.getMaxBlockNumber(&p.latestBlock)
+}
+
+func (p *NonconsensusPoller) GetSafeBlockNumber() (uint64, bool) {
+	return p.getMaxBlockNumber(&p.safeBlock)
+}
+
+func (p *NonconsensusPoller) GetFinalizedBlockNumber() (uint64, bool) {
+	return p.getMaxBlockNumber(&p.finalizedBlock)
+}
+
+func (p *NonconsensusPoller) getMaxBlockNumber(ptr *uint64) (uint64, bool) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return *ptr, *ptr != math.MaxUint64
+}
+
+func (p *NonconsensusPoller) poll(be *Backend) {
+	timer := time.NewTimer(p.interval)
+	for {
+		select {
+		case <-p.ctx.Done():
+			close(p.done)
+			return
+		case <-timer.C:
+			p.update(be, "latest", &p.latestBlock)
+			p.update(be, "safe", &p.safeBlock)
+			p.update(be, "finalized", &p.finalizedBlock)
+			timer.Reset(p.interval)
+		}
+	}
+}
+
+func (p *NonconsensusPoller) update(be *Backend, label string, ptr *uint64) {
+	value, err := p.fetchBlock(p.ctx, be, label)
+	if err != nil {
+		log.Error("failed to fetch block", "backend", be.Name, "label", label, "err", err)
+		return
+	}
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if *ptr < value || *ptr == math.MaxUint64 {
+		*ptr = value
+	}
+}
+
+func (p *NonconsensusPoller) fetchBlock(ctx context.Context, be *Backend, block string) (uint64, error) {
+	var rpcRes RPCRes
+	err := be.ForwardRPC(ctx, &rpcRes, "68", "eth_getBlockByNumber", block, false)
+	if err != nil {
+		return 0, err
+	}
+
+	jsonMap, ok := rpcRes.Result.(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("unexpected response to eth_getBlockByNumber on backend %s", be.Name)
+	}
+	return hexutil.MustDecodeUint64(jsonMap["number"].(string)), nil
+}

--- a/proxyd/nonconsensus_poller_test.go
+++ b/proxyd/nonconsensus_poller_test.go
@@ -1,0 +1,71 @@
+package proxyd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/semaphore"
+)
+
+func TestNonConsensusPoller(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req RPCReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		resp := RPCRes{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+		}
+
+		switch req.Method {
+		case "eth_getBlockByNumber":
+			resp.Result = map[string]string{"number": "0x64"} // Block 100
+		default:
+			http.Error(w, "unsupported method", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+	bg := &BackendGroup{
+		Backends: []*Backend{
+			NewBackend("name", srv.URL, srv.URL, semaphore.NewWeighted(100)),
+		},
+	}
+
+	poller := NewNonconsensusPoller(bg, WithPollingInterval(100*time.Millisecond))
+	defer poller.Shutdown()
+
+	_, ok := poller.GetLatestBlockNumber()
+	assert.False(t, ok)
+
+	_, ok = poller.GetSafeBlockNumber()
+	assert.False(t, ok)
+
+	_, ok = poller.GetFinalizedBlockNumber()
+	assert.False(t, ok)
+
+	// Give the poller time to poll
+	time.Sleep(500 * time.Millisecond)
+
+	latest, ok := poller.GetLatestBlockNumber()
+	assert.True(t, ok)
+	assert.Equal(t, uint64(100), latest)
+
+	safe, ok := poller.GetSafeBlockNumber()
+	assert.True(t, ok)
+	assert.Equal(t, uint64(100), safe)
+
+	finalized, ok := poller.GetFinalizedBlockNumber()
+	assert.True(t, ok)
+	assert.Equal(t, uint64(100), finalized)
+}

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -487,7 +487,7 @@ func Start(config *Config) (*Server, func(), error) {
 		} else {
 			opts := make([]NonconsensusOpt, 0)
 
-			if bgcfg.NonconsensusPollerInterval > 0 {
+			if bgcfg.NonconsensusPollerInterval != 0 {
 				opts = append(opts, WithPollingInterval(time.Duration(bgcfg.NonconsensusPollerInterval)))
 			}
 

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -262,6 +262,7 @@ func Start(config *Config) (*Server, func(), error) {
 			WeightedRouting:        bg.WeightedRouting,
 			FallbackBackends:       fallbackBackends,
 			MaxBlockRange:          bg.MaxBlockRange,
+			RateLimitRange:         bg.RateLimitRange,
 			routingStrategy:        bg.RoutingStrategy,
 			multicallRPCErrorCheck: bg.MulticallRPCErrorCheck,
 		}

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -261,6 +261,7 @@ func Start(config *Config) (*Server, func(), error) {
 			Backends:               backends,
 			WeightedRouting:        bg.WeightedRouting,
 			FallbackBackends:       fallbackBackends,
+			MaxBlockRange:          bg.MaxBlockRange,
 			routingStrategy:        bg.RoutingStrategy,
 			multicallRPCErrorCheck: bg.MulticallRPCErrorCheck,
 		}
@@ -482,6 +483,15 @@ func Start(config *Config) (*Server, func(), error) {
 			if bgcfg.ConsensusHA {
 				tracker.(*RedisConsensusTracker).Init()
 			}
+		} else {
+			opts := make([]NonconsensusOpt, 0)
+
+			if bgcfg.NonconsensusPollerInterval > 0 {
+				opts = append(opts, WithPollingInterval(time.Duration(bgcfg.NonconsensusPollerInterval)))
+			}
+
+			np := NewNonconsensusPoller(bg, opts...)
+			bg.Nonconsensus = np
 		}
 	}
 

--- a/proxyd/rpc.go
+++ b/proxyd/rpc.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"io"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type RPCReq struct {
@@ -181,6 +183,51 @@ type Range struct {
 }
 
 func ParseRange(req *RPCReq, tracker BlockNumberTracker) *Range {
-	// TODO
-	return nil
+	switch req.Method {
+	case "eth_getLogs", "eth_newFilter":
+		var p []map[string]interface{}
+		if err := json.Unmarshal(req.Params, &p); err != nil {
+			return nil
+		}
+		fromBlock, hasFrom := p[0]["fromBlock"].(string)
+		toBlock, hasTo := p[0]["toBlock"].(string)
+		if !hasFrom && !hasTo {
+			return nil
+		}
+		// if either fromBlock or toBlock is defined, default the other to "latest" if unset
+		if hasFrom && !hasTo {
+			toBlock = "latest"
+		} else if hasTo && !hasFrom {
+			fromBlock = "latest"
+		}
+		from, fromOk := stringToBlockNumber(fromBlock, tracker)
+		to, toOk := stringToBlockNumber(toBlock, tracker)
+		if !fromOk || !toOk {
+			return nil
+		}
+		return &Range{
+			FromBlock: from,
+			ToBlock:   to,
+		}
+	default:
+		return nil
+	}
+}
+
+func stringToBlockNumber(tag string, tracker BlockNumberTracker) (uint64, bool) {
+	switch tag {
+	case "latest":
+		return tracker.GetLatestBlockNumber()
+	case "safe":
+		return tracker.GetSafeBlockNumber()
+	case "finalized":
+		return tracker.GetFinalizedBlockNumber()
+	case "earliest":
+		return 0, true
+	case "pending":
+		latest, ok := tracker.GetLatestBlockNumber()
+		return latest + 1, ok
+	}
+	d, err := hexutil.DecodeUint64(tag)
+	return d, err == nil
 }

--- a/proxyd/rpc.go
+++ b/proxyd/rpc.go
@@ -168,3 +168,19 @@ func IsBatch(raw []byte) bool {
 	}
 	return false
 }
+
+type BlockNumberTracker interface {
+	GetLatestBlockNumber() (uint64, bool)
+	GetSafeBlockNumber() (uint64, bool)
+	GetFinalizedBlockNumber() (uint64, bool)
+}
+
+type Range struct {
+	FromBlock uint64
+	ToBlock   uint64
+}
+
+func ParseRange(req *RPCReq, tracker BlockNumberTracker) *Range {
+	// TODO
+	return nil
+}

--- a/proxyd/rpc.go
+++ b/proxyd/rpc.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"strings"
-
-	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type RPCReq struct {
@@ -169,65 +167,4 @@ func IsBatch(raw []byte) bool {
 		return c == '['
 	}
 	return false
-}
-
-type BlockNumberTracker interface {
-	GetLatestBlockNumber() (uint64, bool)
-	GetSafeBlockNumber() (uint64, bool)
-	GetFinalizedBlockNumber() (uint64, bool)
-}
-
-type Range struct {
-	FromBlock uint64
-	ToBlock   uint64
-}
-
-func ParseRange(req *RPCReq, tracker BlockNumberTracker) *Range {
-	switch req.Method {
-	case "eth_getLogs", "eth_newFilter":
-		var p []map[string]interface{}
-		if err := json.Unmarshal(req.Params, &p); err != nil {
-			return nil
-		}
-		fromBlock, hasFrom := p[0]["fromBlock"].(string)
-		toBlock, hasTo := p[0]["toBlock"].(string)
-		if !hasFrom && !hasTo {
-			return nil
-		}
-		// if either fromBlock or toBlock is defined, default the other to "latest" if unset
-		if hasFrom && !hasTo {
-			toBlock = "latest"
-		} else if hasTo && !hasFrom {
-			fromBlock = "latest"
-		}
-		from, fromOk := stringToBlockNumber(fromBlock, tracker)
-		to, toOk := stringToBlockNumber(toBlock, tracker)
-		if !fromOk || !toOk {
-			return nil
-		}
-		return &Range{
-			FromBlock: from,
-			ToBlock:   to,
-		}
-	default:
-		return nil
-	}
-}
-
-func stringToBlockNumber(tag string, tracker BlockNumberTracker) (uint64, bool) {
-	switch tag {
-	case "latest":
-		return tracker.GetLatestBlockNumber()
-	case "safe":
-		return tracker.GetSafeBlockNumber()
-	case "finalized":
-		return tracker.GetFinalizedBlockNumber()
-	case "earliest":
-		return 0, true
-	case "pending":
-		latest, ok := tracker.GetLatestBlockNumber()
-		return latest + 1, ok
-	}
-	d, err := hexutil.DecodeUint64(tag)
-	return d, err == nil
 }

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -451,13 +451,12 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 
 		limitAmount := 1
 		backendGroup := s.BackendGroups[group]
-		parsedRange := ParseRange(parsedReq, backendGroup)
-		if parsedRange != nil {
-			blockRange := int(parsedRange.ToBlock - parsedRange.FromBlock + 1)
+		if blockRange := ExtractBlockRange(parsedReq, backendGroup); blockRange != nil {
+			blockCount := int(blockRange.ToBlock) - int(blockRange.FromBlock) + 1
 			if backendGroup.RateLimitRange {
-				limitAmount = max(limitAmount, blockRange)
+				limitAmount = max(limitAmount, blockCount)
 			}
-			if backendGroup.MaxBlockRange > 0 && blockRange > int(backendGroup.MaxBlockRange) {
+			if backendGroup.MaxBlockRange > 0 && blockCount > int(backendGroup.MaxBlockRange) {
 				log.Debug(
 					"RPC request over max block range",
 					"source", "rpc",

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -453,8 +453,11 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 		backendGroup := s.BackendGroups[group]
 		parsedRange := ParseRange(parsedReq, backendGroup)
 		if parsedRange != nil {
-			limitAmount = max(limitAmount, int(parsedRange.ToBlock-parsedRange.FromBlock+1))
-			if backendGroup.MaxBlockRange > 0 && limitAmount > int(backendGroup.MaxBlockRange) {
+			blockRange := int(parsedRange.ToBlock - parsedRange.FromBlock + 1)
+			if backendGroup.RateLimitRange {
+				limitAmount = max(limitAmount, blockRange)
+			}
+			if backendGroup.MaxBlockRange > 0 && blockRange > int(backendGroup.MaxBlockRange) {
 				log.Debug(
 					"RPC request over max block range",
 					"source", "rpc",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR implements two things:
 - the ability to limit the max block range, even if not in consensus mode
 - (opt-in, off by default) the ability to rate limit block range requests by block count

**Tests**

Added new tests.

**Additional context**

https://github.com/ethereum-optimism/optimism/pull/6686 originally implemented the ability to limit block range requests. The initial implementation supported both consensus and non-consensus mode, however there was feedback on that PR that we already had latest block polling in consensus mode, and any block range limiting should be added to that.

We've since tried to use consensus mode, and even opened some PRs to help (e.g. https://github.com/ethereum-optimism/optimism/pull/7275), but unfortunately our setup is not conducive to consensus mode.