### PR TITLE
chore: Migrate tag-service workflow to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,31 @@ setup: true
 orbs:
   path-filtering: circleci/path-filtering@1.0.0
 
+parameters: 
+  # An explicit boolean parameter that triggers the tag-service pipeline
+  run-tag-service:
+    type: boolean
+    description: "Run the tag-service job. tag-service--bump and tag-service--service parameters also need to be specified"
+    default: false
+  # Controls the version bump for the tag-service job
+  # 
+  # If left empty, the tag-service job will not run
+  tag-service--bump:
+    type: enum
+    enum: ["", "major", "minor", "patch", "prerelease", "finalize-prerelease", "missing"]
+    default: ""
+  # Controls the affected service for the tag-service job
+  # 
+  # If left empty, the tag-service job will not run
+  tag-service--service:
+    type: enum
+    enum: ["", "op-signer", "op-ufm", "op-txproxy", "proxyd", "peer-mgmt-service"]
+    default: ""
+  # Toggle between prerelase and release for the tag-service job
+  tag-service--prerelease:
+    type: boolean
+    default: false
+
 workflows:
   check-updated-files:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,14 @@ setup: true
 orbs:
   path-filtering: circleci/path-filtering@1.0.0
 
-parameters: 
+parameters:
+  # 
+  # 
+  # These parameters are passed down to the continuation pipeline
+  # Thet are defined here so that the UI form for triggering pipelines
+  # is prepopulated and only allows for valid values to be set
+  # 
+  # 
   # An explicit boolean parameter that triggers the tag-service pipeline
   run-tag-service:
     type: boolean
@@ -17,6 +24,7 @@ parameters:
   # If left empty, the tag-service job will not run
   tag-service--bump:
     type: enum
+    description: "If left empty, the tag-service job will not run"
     enum: ["", "major", "minor", "patch", "prerelease", "finalize-prerelease", "missing"]
     default: ""
   # Controls the affected service for the tag-service job
@@ -24,11 +32,13 @@ parameters:
   # If left empty, the tag-service job will not run
   tag-service--service:
     type: enum
+    description: "If left empty, the tag-service job will not run"
     enum: ["", "op-signer", "op-ufm", "op-txproxy", "proxyd", "peer-mgmt-service"]
     default: ""
   # Toggle between prerelase and release for the tag-service job
   tag-service--prerelease:
     type: boolean
+    description: "Toggle between prerelase and release for the tag-service job"
     default: false
 
 workflows:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -37,26 +37,22 @@ parameters:
   run-all:
     type: boolean
     default: false
-  # An explicit boolean parameter that triggers the tag-service pipeline
+  # 
+  # 
+  # The following tags are defined more strictly in the parent pipeline
+  # so that when the pipeline is triggered manually, the user is forced
+  # to enter valid values and the UI parameter form is prepopulated.
+  # 
+  # 
   run-tag-service:
     type: boolean
-    description: "Run the tag-service job. tag-service--bump and tag-service--service parameters also need to be specified"
     default: false
-  # Controls the version bump for the tag-service job
-  # 
-  # If left empty, the tag-service job will not run
   tag-service--bump:
-    type: enum
-    enum: ["", "major", "minor", "patch", "prerelease", "finalize-prerelease", "missing"]
+    type: string
     default: ""
-  # Controls the affected service for the tag-service job
-  # 
-  # If left empty, the tag-service job will not run
   tag-service--service:
-    type: enum
-    enum: ["", "op-signer", "op-ufm", "op-txproxy", "proxyd", "peer-mgmt-service"]
+    type: string
     default: ""
-  # Toggle between prerelase and release for the tag-service job
   tag-service--prerelease:
     type: boolean
     default: false

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -420,8 +420,8 @@ jobs:
             gcloud auth configure-docker us-docker.pkg.dev
       - run:
           name: Run goreleaser
-          command: goreleaser release --clean -f << parameters.filename >>
-          working_directory: << parameters.module >>
+          command: |
+            goreleaser release --clean -f ./<<parameters.module>>/<<parameters.filename>>
     
   tag-service:
     executor: default

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -683,6 +683,8 @@ workflows:
           module: <<matrix.module>>
           context:
             - oplabs-gcr-release
+  tag:
+    jobs:
       - tag-service:
           context:
             - circleci-repo-infra

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -74,7 +74,7 @@ commands:
           working_directory: << parameters.module >>
       - run:
           name: Install mise dependencies
-          command: mise install
+          command: mise install --verbose
           working_directory: << parameters.module >>
 
   gcp-oidc-authenticate:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -69,12 +69,12 @@ commands:
           command: curl https://mise.run | MISE_INSTALL_PATH=/home/circleci/bin/mise sh
           working_directory: << parameters.module >>
       - run:
-          name: Activate mise
-          command: echo 'eval "$(mise activate bash)"' >> $BASH_ENV
-          working_directory: << parameters.module >>
-      - run:
           name: Contents
           command: ls -al
+          working_directory: << parameters.module >>
+      - run:
+          name: Activate mise
+          command: echo 'eval "$(mise activate bash)"' >> $BASH_ENV
           working_directory: << parameters.module >>
       - run:
           name: Mise doctor

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -678,11 +678,10 @@ workflows:
             - oplabs-gcr-release
   tag:
     when:
-      condition:
-        and: 
-          - << pipeline.parameters.run-tag-service >>
-          - << pipeline.parameters.tag-service--bump >>
-          - << pipeline.parameters.tag-service--service >>
+      and: 
+        - << pipeline.parameters.run-tag-service >>
+        - << pipeline.parameters.tag-service--bump >>
+        - << pipeline.parameters.tag-service--service >>
     jobs:
       - tag-service:
           context:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -683,14 +683,6 @@ workflows:
           module: <<matrix.module>>
           context:
             - oplabs-gcr-release
-  tag:
-    jobs:
       - tag-service:
           context:
             - circleci-repo-infra
-          # We only run the release workflow manually so we disable any push triggers
-          filters:
-            tags:
-              ignore: /.*/
-            branches:
-              ignore: /.*/

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -73,6 +73,10 @@ commands:
           command: echo 'eval "$(mise activate bash)"' >> $BASH_ENV
           working_directory: << parameters.module >>
       - run:
+          name: Contents
+          command: ls -al
+          working_directory: << parameters.module >>
+      - run:
           name: Mise doctor
           command: mise doctor
           working_directory: << parameters.module >>

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -73,6 +73,14 @@ commands:
           command: echo 'eval "$(mise activate bash)"' >> $BASH_ENV
           working_directory: << parameters.module >>
       - run:
+          name: Mise doctor
+          command: mise doctor
+          working_directory: << parameters.module >>
+      - run:
+          name: Mise config
+          command: mise config
+          working_directory: << parameters.module >>
+      - run:
           name: Install mise dependencies
           command: mise install --verbose
           working_directory: << parameters.module >>

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -426,40 +426,36 @@ jobs:
     
   tag-service:
     executor: default
+    parameters:
+      bump:
+        type: string
+      service:
+        type: string
+      prerelease:
+        type: boolean
     steps:
-      # We only want to run this job if we have all the necessary parameters
-      - when:
-          condition:
-            and: 
-              - << pipeline.parameters.run-tag-service >>
-              - << pipeline.parameters.tag-service--bump >>
-              - << pipeline.parameters.tag-service--service >>
-          steps:
-            - checkout
-            - run:
-                name: Fetch tags
-                command: git fetch --tags origin --force
-            - install-dependencies:
-                module: ops/tag-service
-            - utils/get-github-access-token:
-                output-token-name: INPUT_GITHUB_TOKEN
-            # This conditional step runs the prerelease command
-            - when:
-                condition: << pipeline.parameters.tag-service--prerelease >>
-                steps:
-                  - run:
-                      name: Prerelase
-                      command: ops/tag-service/tag-service.py --bump="<< pipeline.parameters.tag-service--bump >>" --service="<< pipeline.parameters.tag-service--service >>" --pre-release
-            # This conditional step runs the release command
-            - unless:
-                condition: << pipeline.parameters.tag-service--prerelease >>
-                steps:
-                  - run:
-                      name: Release
-                      command: ops/tag-service/tag-service.py --bump="<< pipeline.parameters.tag-service--bump >>" --service="<< pipeline.parameters.tag-service--service >>"
+      - checkout
       - run:
-          name: Placeholder
-          command: echo "This is a placeholder job only to satisfy CircleCI yaml schema. See https://circleci.com/docs/configuration-reference/#logic-statement-examples"
+          name: Fetch tags
+          command: git fetch --tags origin --force
+      - install-dependencies:
+          module: ops/tag-service
+      - utils/get-github-access-token:
+          output-token-name: INPUT_GITHUB_TOKEN
+      # This conditional step runs the prerelease command
+      - when:
+          condition: << parameters.prerelease >>
+          steps:
+            - run:
+                name: Prerelease << parameters.bump >> bump of << parameters.service >>
+                command: ops/tag-service/tag-service.py --bump="<< parameters.bump >>" --service="<< parameters.service >>" --pre-release
+      # This conditional step runs the release command
+      - unless:
+          condition: << parameters.prerelease >>
+          steps:
+            - run:
+                name: Release << parameters.bump >> bump of << parameters.service >>
+                command: ops/tag-service/tag-service.py --bump="<< parameters.bump >>" --service="<< parameters.service >>"
 
 workflows:
   logging:
@@ -681,7 +677,16 @@ workflows:
           context:
             - oplabs-gcr-release
   tag:
+    when:
+      condition:
+        and: 
+          - << pipeline.parameters.run-tag-service >>
+          - << pipeline.parameters.tag-service--bump >>
+          - << pipeline.parameters.tag-service--service >>
     jobs:
       - tag-service:
           context:
             - circleci-repo-infra
+          bump: << pipeline.parameters.tag-service--bump >>
+          service: << pipeline.parameters.tag-service--service >>
+          prerelease: << pipeline.parameters.tag-service--prerelease >>

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2,6 +2,15 @@ version: 2.1
 
 orbs:
   gcp-cli: circleci/gcp-cli@2.4.1
+  utils: ethereum-optimism/circleci-utils@0.0.12
+
+executors:
+  default:
+    machine:
+      image: ubuntu-2204:2024.08.1
+  builder:
+    docker:
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
 
 parameters:
   run-build-op-conductor-mon:
@@ -28,11 +37,50 @@ parameters:
   run-all:
     type: boolean
     default: false
-  vm-image:
-    type: string
-    default: ubuntu-2204:current
+  # An explicit boolean parameter that triggers the tag-service pipeline
+  run-tag-service:
+    type: boolean
+    description: "Run the tag-service job. tag-service--bump and tag-service--service parameters also need to be specified"
+    default: false
+  # Controls the version bump for the tag-service job
+  # 
+  # If left empty, the tag-service job will not run
+  tag-service--bump:
+    type: enum
+    enum: ["", "major", "minor", "patch", "prerelease", "finalize-prerelease", "missing"]
+    default: ""
+  # Controls the affected service for the tag-service job
+  # 
+  # If left empty, the tag-service job will not run
+  tag-service--service:
+    type: enum
+    enum: ["", "op-signer", "op-ufm", "op-txproxy", "proxyd", "peer-mgmt-service"]
+    default: ""
+  # Toggle between prerelase and release for the tag-service job
+  tag-service--prerelease:
+    type: boolean
+    default: false
 
 commands:
+  install-dependencies:
+    parameters:
+      module:
+        type: string
+        default: .
+    steps:
+      - run:
+          name: Install mise
+          command: curl https://mise.run | MISE_INSTALL_PATH=/home/circleci/bin/mise sh
+          working_directory: << parameters.module >>
+      - run:
+          name: Activate mise
+          command: echo 'eval "$(mise activate bash)"' >> $BASH_ENV
+          working_directory: << parameters.module >>
+      - run:
+          name: Install mise dependencies
+          command: mise install
+          working_directory: << parameters.module >>
+
   gcp-oidc-authenticate:
     description: "Authenticate with GCP using a CircleCI OIDC token."
     parameters:
@@ -77,8 +125,7 @@ commands:
 
 jobs:
   log-config-results:
-    docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest # only used to enable codecov.
+    executor: builder
     environment:
       CURRENT_TAG: << pipeline.git.tag >>
     steps:
@@ -162,8 +209,7 @@ jobs:
         description: Docker repo
         type: string
         default: "oplabs-tools-artifacts/images"
-    machine:
-      image: <<pipeline.parameters.vm-image>>
+    executor: default
     steps:
       - checkout
       - run:
@@ -209,8 +255,7 @@ jobs:
         description: Docker repo
         type: string
         default: "oplabs-tools-artifacts/images"
-    machine:
-      image: <<pipeline.parameters.vm-image>>
+    executor: default
     steps:
       - attach_workspace:
           at: /tmp/docker_images
@@ -290,10 +335,11 @@ jobs:
       module:
         description: Go Module Name
         type: string
-    docker:
-      - image: cimg/go:1.23
+    executor: default
     steps:
       - checkout
+      - install-dependencies:
+          module: << parameters.module >>
       - run:
           name: run generate
           command: |
@@ -361,32 +407,62 @@ jobs:
         description: Goreleaser config file
         default: .goreleaser.yaml
         type: string
-    docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+    executor: default
     resource_class: large
     steps:
       - setup_remote_docker
+      - install-dependencies:
+          module: << parameters.module >>
       - gcp-cli/install
       - gcp-oidc-authenticate:
           gcp_cred_config_file_path: /root/gcp_cred_config.json
           oidc_token_file_path: /root/oidc_token.json
       - checkout
       - run:
-          name: Install goreleaser pro
-          command: |
-            mkdir -p /tmp/goreleaser
-            cd /tmp/goreleaser
-            curl -L -o goreleaser.tgz https://github.com/goreleaser/goreleaser-pro/releases/download/v2.4.3-pro/goreleaser-pro_Linux_x86_64.tar.gz
-            tar -xzvf goreleaser.tgz
-            mv goreleaser /usr/local/bin/goreleaser
-      - run:
           name: Configure Docker
           command: |
             gcloud auth configure-docker us-docker.pkg.dev
       - run:
           name: Run goreleaser
-          command: |
-            goreleaser release --clean -f ./<<parameters.module>>/<<parameters.filename>>
+          command: goreleaser release --clean -f << parameters.filename >>
+          working_directory: << parameters.module >>
+    
+  tag-service:
+    executor: default
+    steps:
+      # We only want to run this job if we have all the necessary parameters
+      - when:
+          condition:
+            and: 
+              - << pipeline.parameters.run-tag-service >>
+              - << pipeline.parameters.tag-service--bump >>
+              - << pipeline.parameters.tag-service--service >>
+          steps:
+            - checkout
+            - run:
+                name: Fetch tags
+                command: git fetch --tags origin --force
+            - install-dependencies:
+                module: ops/tag-service
+            - utils/get-github-access-token:
+                output-token-name: INPUT_GITHUB_TOKEN
+            # This conditional step runs the prerelease command
+            - when:
+                condition: << pipeline.parameters.tag-service--prerelease >>
+                steps:
+                  - run:
+                      name: Prerelase
+                      command: ops/tag-service/tag-service.py --bump="<< pipeline.parameters.tag-service--bump >>" --service="<< pipeline.parameters.tag-service--service >>" --pre-release
+            # This conditional step runs the release command
+            - unless:
+                condition: << pipeline.parameters.tag-service--prerelease >>
+                steps:
+                  - run:
+                      name: Release
+                      command: ops/tag-service/tag-service.py --bump="<< pipeline.parameters.tag-service--bump >>" --service="<< pipeline.parameters.tag-service--service >>"
+      - run:
+          name: Placeholder
+          command: echo "This is a placeholder job only to satisfy CircleCI yaml schema. See https://circleci.com/docs/configuration-reference/#logic-statement-examples"
 
 workflows:
   logging:
@@ -607,3 +683,14 @@ workflows:
           module: <<matrix.module>>
           context:
             - oplabs-gcr-release
+  tag:
+    jobs:
+      - tag-service:
+          context:
+            - circleci-repo-infra
+          # We only run the release workflow manually so we disable any push triggers
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -136,6 +136,7 @@ jobs:
             echo "run-build-pms: << pipeline.parameters.run-build-pms >>"
             echo "run-build-op-ufm: << pipeline.parameters.run-build-op-ufm >>"
             echo "run-build-proxyd: << pipeline.parameters.run-build-proxyd >>"
+            echo "run-tag-service: << pipeline.parameters.run-tag-service >>"
             echo "run-all: << pipeline.parameters.run-all >>"
             echo ""
             echo "Pipeline Trigger Information:"

--- a/README.md
+++ b/README.md
@@ -10,3 +10,25 @@ This repository is an extension of the [Optimism monorepo](https://github.com/et
 ## Release Process
 
 For the thoroughly defined process releasing services in this repository, please refer to [this document](./RELEASE.md).
+
+## Development
+
+### Dependencies
+
+#### Using `mise`
+
+We use [`mise`](https://mise.jdx.dev/) as a dependency manager for these tools.
+Once properly installed, `mise` will provide the correct versions for each tool. `mise` does not
+replace any other installations of these binaries and will only serve these binaries when you are
+working inside of the `optimism` directory.
+
+##### Install `mise`
+
+Install `mise` by following the instructions provided on the
+[Getting Started page](https://mise.jdx.dev/getting-started.html#_1-install-mise-cli).
+
+##### Install dependencies
+
+```sh
+mise install
+```

--- a/mise.toml
+++ b/mise.toml
@@ -10,4 +10,3 @@ go = "1.21"
 [settings]
 # Needs to be enabled for hooks to work
 experimental = true
-libgit2 = false

--- a/mise.toml
+++ b/mise.toml
@@ -10,3 +10,4 @@ go = "1.21"
 [settings]
 # Needs to be enabled for hooks to work
 experimental = true
+libgit2 = false

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,12 @@
+[tools]
+
+# Core dependencies
+go = "1.21"
+
+# Go dependencies
+"ubi:golangci/golangci-lint" = "v1.63.4"
+"ubi:goreleaser/goreleaser-pro" = "v2.4.3-pro"
+
+[settings]
+# Needs to be enabled for hooks to work
+experimental = true

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ go = "1.21"
 
 # Go dependencies
 "ubi:golangci/golangci-lint" = "v1.63.4"
-"ubi:goreleaser/goreleaser-pro" = "v2.4.3-pro"
+"ubi:goreleaser/goreleaser-pro[exe=goreleaser]" = "v2.4.3-pro"
 
 [settings]
 # Needs to be enabled for hooks to work

--- a/ops/tag-service/mise.toml
+++ b/ops/tag-service/mise.toml
@@ -1,0 +1,13 @@
+[tools]
+
+# Core dependencies
+python = "3.10"
+
+[hooks]
+postinstall = [
+    'pip install -r requirements.txt'
+]
+
+[settings]
+# Needs to be enabled for hooks to work
+experimental = true


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Migrating `tag-service` manual github actions workflow to CircleCI. The setup is made a bit more complex since this project is using CircleCI's dynamic setup.

- Added an extra set of pipeline parameters that control the new `tag-service` job. These will be empty if the pipeline is run because of a push, they need to be specified when manually triggering a pipeline from CircleCI's UI.
  - To make the UX a bit more sturdy and nicer, these parameters are defined both in `config.yml` (strict definition, this definition populates the UI form for triggering pipelines) and `continue_config.yml` (so that they can be used in the actual job)
- Replaced inlined `executor`s with `executors` definitions. This way the `vm-image` pipeline parameter that was used to DRY the config can be dropped

I also added `mise` as a dependency manager. `mise` is being used in the [optimism monorepo](https://github.com/ethereum-optimism/optimism/blob/develop/mise.toml) and provides a great way of managing tooling required for development.

It is an add-on, it does not break or affect any existing development flows, just provides a convenient way of setting up your development environment (as well as the CI environment).

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**
