### PR TITLE
[NAT] Prometheus integration

### DIFF
--- a/op-nat/.gitignore
+++ b/op-nat/.gitignore
@@ -1,1 +1,3 @@
 bin
+**/testdata/grafana-data
+**/testdata/prometheus-data

--- a/op-nat/cmd/main.go
+++ b/op-nat/cmd/main.go
@@ -10,6 +10,7 @@ import (
 
 	nat "github.com/ethereum-optimism/infra/op-nat"
 	"github.com/ethereum-optimism/infra/op-nat/flags"
+	"github.com/ethereum-optimism/infra/op-nat/service"
 	"github.com/ethereum-optimism/infra/op-nat/validators/gates"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
@@ -23,8 +24,6 @@ var (
 )
 
 func main() {
-	oplog.SetupDefaults()
-
 	app := cli.NewApp()
 	app.Flags = cliapp.ProtectFlags(flags.Flags)
 	app.Version = fmt.Sprintf("%s-%s-%s", Version, GitCommit, GitDate)
@@ -33,6 +32,12 @@ func main() {
 	app.Description = "op-nat tests networks"
 	app.Action = cliapp.LifecycleCmd(run)
 
+	// Start server
+	svc := service.New()
+	svc.Start(context.Background())
+	defer svc.Shutdown()
+
+	// Start CLI
 	ctx := ctxinterrupt.WithSignalWaiterMain(context.Background())
 	err := app.RunContext(ctx, os.Args)
 	if err != nil {

--- a/op-nat/docker-compose.yml
+++ b/op-nat/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./metrics/testdata/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./metrics/testdata/prometheus-data:/prometheus
+    networks:
+      - monitoring
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana-enterprise
+    ports:
+      - "3000:3000"
+    container_name: grafana
+    depends_on:
+      - prometheus
+    networks:
+      - monitoring
+    volumes:
+      - ./metrics/testdata/grafana-data:/var/lib/grafana
+
+networks:
+  monitoring:
+    driver: bridge
+
+volumes:
+  grafana-data:
+    driver: local 

--- a/op-nat/gate_test.go
+++ b/op-nat/gate_test.go
@@ -31,7 +31,7 @@ func TestGate(t *testing.T) {
 		result, err := gate.Run(context.Background(), log.New(), Config{}, nil)
 
 		require.NoError(t, err)
-		assert.True(t, result.Passed)
+		assert.Equal(t, ResultPassed, result.Result)
 	})
 
 	t.Run("fails if any validator fails", func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestGate(t *testing.T) {
 		result, err := gate.Run(context.Background(), log.New(), Config{}, nil)
 
 		require.NoError(t, err)
-		assert.False(t, result.Passed)
+		assert.Equal(t, ResultFailed, result.Result)
 	})
 
 	t.Run("doesnt stop on validator failure", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestGate(t *testing.T) {
 		result, err := gate.Run(context.Background(), log.New(), Config{}, nil)
 
 		require.NoError(t, err)
-		assert.False(t, result.Passed)
+		assert.Equal(t, ResultFailed, result.Result)
 		assert.Equal(t, []string{"test1", "test2", "test3"}, executionOrder, "shouldnt stop on validator failure")
 	})
 }

--- a/op-nat/go.mod
+++ b/op-nat/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/ethereum/go-ethereum v1.14.11
 	github.com/jedib0t/go-pretty/v6 v6.6.5
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.20.5
+	github.com/rs/cors v1.11.0
 	github.com/scharissis/tx-fuzz v0.0.0-20250116214814-b8b8094fac69
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.5
@@ -71,13 +73,11 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	github.com/rs/cors v1.11.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/supranational/blst v0.3.13 // indirect

--- a/op-nat/justfile
+++ b/op-nat/justfile
@@ -1,22 +1,31 @@
 # TODO: just is not working as we depend on go.just
-
-import '../justfiles/go.just'
-
+#
+#
+# import '../justfiles/go.just'
+#
 # Build ldflags string
-_LDFLAGSSTRING := "'" + trim(
-    "-X main.GitCommit=" + GITCOMMIT + " " + \
-    "-X main.GitDate=" + GITDATE + " " + \
-    "-X main.Version=" + VERSION + " " + \
-    "") + "'"
+# _LDFLAGSSTRING := "'" + trim(
+#     "-X main.GitCommit=" + GITCOMMIT + " " + \
+#     "-X main.GitDate=" + GITDATE + " " + \
+#     "-X main.Version=" + VERSION + " " + \
+#     "") + "'"
 
 BINARY := "./bin/op-nat"
 
 # Build op-nat binary
-op-nat: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+# op-nat: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:
     rm -f {{BINARY}}
 
 # Run tests
-test: (go_test "./...")
+# test: (go_test "./...")
+
+# Run prometheus and grafana
+start-monitoring:
+    docker compose -f 'docker-compose.yml' up -d --build
+
+# Stop prometheus and grafana
+stop-monitoring:
+    docker compose -f 'docker-compose.yml' down

--- a/op-nat/metrics/metrics.go
+++ b/op-nat/metrics/metrics.go
@@ -1,0 +1,102 @@
+package metrics
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	MetricsNamespace = "nat"
+)
+
+var (
+	Debug                bool = true
+	nonAlphanumericRegex      = regexp.MustCompile(`[^a-zA-Z ]+`)
+
+	errorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "errors_total",
+		Help:      "Count of errors",
+	}, []string{
+		"error",
+	})
+
+	validationsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "validations_total",
+		Help:      "Count of validations",
+	}, []string{
+		"network_name",
+		"name",
+		"type",
+		"result",
+	})
+
+	acceptancesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "acceptances_total",
+		Help:      "Count of acceptance tests",
+	}, []string{
+		"network_name",
+		"result",
+	})
+)
+
+// errToLabel tries to make the error string a more valid Prometheus label
+func errToLabel(err error) string {
+	if err == nil {
+		return "nil"
+	}
+	errClean := nonAlphanumericRegex.ReplaceAllString(err.Error(), "")
+	errClean = strings.ReplaceAll(errClean, " ", "_")
+	errClean = strings.ReplaceAll(errClean, "__", "_")
+	return errClean
+}
+
+func RecordError(error string) {
+	if Debug {
+		log.Debug("metric inc",
+			"m", "errors_total",
+			"error", error,
+		)
+	}
+	errorsTotal.WithLabelValues(error).Inc()
+}
+
+// RecordErrorDetails concats the error message to the label
+// and also tries to clean the label to be a valid Prometheus label
+func RecordErrorDetails(label string, err error) {
+	if err == nil {
+		return
+	}
+	label = fmt.Sprintf("%s.%s", label, errToLabel(err))
+	RecordError(label)
+}
+
+func RecordValidation(network string, valName string, valType string, result string, valErr error) {
+	if Debug {
+		log.Debug("metric inc",
+			"m", "validations_total",
+			"network", network,
+			"validator", valName,
+			"type", valType,
+			"result", result)
+	}
+	validationsTotal.WithLabelValues(network, valName, valType, result).Inc()
+}
+
+func RecordAcceptance(network string, result string, err error) {
+	if Debug {
+		log.Debug("metric inc",
+			"m", "acceptances_total",
+			"network", network,
+			"result", result,
+			"error", err)
+	}
+	acceptancesTotal.WithLabelValues(network, result).Inc()
+}

--- a/op-nat/metrics/metrics_test.go
+++ b/op-nat/metrics/metrics_test.go
@@ -1,0 +1,76 @@
+package metrics
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+)
+
+func TestErrToLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+		},
+		{
+			name: "simple error",
+			err:  errors.New("test error"),
+		},
+		{
+			name: "error with special chars",
+			err:  errors.New("test@error#123"),
+		},
+		{
+			name: "error with multiple spaces",
+			err:  errors.New("test   error"),
+		},
+		{
+			name: "error with multiple underscores",
+			err:  errors.New("test__error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := errToLabel(tt.err)
+			validLabelRegex := regexp.MustCompile(`[a-zA-Z_][a-zA-Z0-9_]*`)
+			if !validLabelRegex.MatchString(result) {
+				t.Errorf("errLabel() = %v, is not a valid Prometheus label", result)
+			}
+		})
+	}
+}
+
+func TestRecordError(t *testing.T) {
+	// just test that it doesn't panic
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("RecordError panic'd")
+		}
+	}()
+
+	RecordError("test_error")
+}
+
+func TestRecordErrorDetails(t *testing.T) {
+	// Test with nil error
+	RecordErrorDetails("test", nil)
+
+	// Test with actual error
+	RecordErrorDetails("test", errors.New("sample error"))
+}
+
+func TestRecordValidation(t *testing.T) {
+	// Test various validation scenarios
+	RecordValidation("test-network", "validator1", "test", "pass", nil)
+	RecordValidation("test-network", "validator2", "test", "fail", errors.New("validation error"))
+}
+
+func TestRecordAcceptance(t *testing.T) {
+	// Test acceptance scenarios
+	RecordAcceptance("test-network", "pass", nil)
+	RecordAcceptance("test-network", "fail", errors.New("acceptance error"))
+}

--- a/op-nat/metrics/testdata/prometheus.yml
+++ b/op-nat/metrics/testdata/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+- job_name: nat
+  scrape_interval: 2s
+  static_configs:
+  - targets:
+    - host.docker.internal:7300

--- a/op-nat/nat.go
+++ b/op-nat/nat.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/jedib0t/go-pretty/v6/table"
 
+	"github.com/ethereum-optimism/infra/op-nat/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 )
 
@@ -48,6 +49,8 @@ func (n *nat) Start(ctx context.Context) error {
 	n.log.Info("Starting OpNAT")
 	n.ctx = ctx
 	n.running.Store(true)
+
+	n.results = []ValidatorResult{}
 	for _, validator := range n.config.Validators {
 		n.log.Info("Running acceptance tests...")
 
@@ -55,18 +58,19 @@ func (n *nat) Start(ctx context.Context) error {
 		params := n.params[validator.Name()]
 
 		result, err := validator.Run(ctx, n.log, *n.config, params)
-		n.log.Info("Completed validator", "validator", validator.Name(), "type", validator.Type(), "passed", result.Passed, "error", err)
+		n.log.Info("Completed validator", "validator", validator.Name(), "type", validator.Type(), "result", result.Result.String(), "error", err)
 		if err != nil {
 			n.log.Error("Error running validator", "validator", validator.Name(), "error", err)
 		}
 		n.results = append(n.results, result)
 	}
+	n.printResultsTable()
+
 	n.log.Info("OpNAT finished")
 	return nil
 }
 
 func (n *nat) Stop(ctx context.Context) error {
-	n.printResultsTable()
 	n.running.Store(false)
 	n.log.Info("OpNAT stopped")
 	return nil
@@ -86,33 +90,40 @@ func (n *nat) printResultsTable() {
 	colConfigAutoMerge := table.ColumnConfig{AutoMerge: true}
 	t.SetColumnConfigs([]table.ColumnConfig{colConfigAutoMerge})
 
-	overallPass := true
-	for _, result := range n.results {
-		appendResultRows(t, result)
-		if !result.Passed {
-			overallPass = false
+	var overallResult ResultType = ResultPassed
+	var hasSkipped = false
+	var overallErr error
+	for _, res := range n.results {
+		appendResultRows(t, res)
+		overallErr = errors.Join(overallErr)
+		if res.Result == ResultFailed {
+			overallResult = ResultFailed
+		}
+		if res.Result == ResultSkipped {
+			hasSkipped = true
 		}
 		t.AppendSeparator()
 	}
-	t.AppendFooter([]interface{}{"SUMMARY", "", boolToPassFail(overallPass), ""})
-	if !overallPass {
+	if overallResult == ResultPassed && hasSkipped {
+		overallResult = ResultSkipped
+	}
+	t.AppendFooter([]interface{}{"SUMMARY", "", overallResult.String(), ""})
+	if overallResult == ResultFailed {
 		t.SetStyle(table.StyleColoredBlackOnRedWhite)
 	}
 	t.Render()
+
+	// Emit metrics
+	// TODO: This shouldn't be here; needs a refactor
+	// TODO: don't hardcode the network name
+	metrics.RecordAcceptance("op-kurtosis-1", overallResult.String(), overallErr)
 }
 
 func appendResultRows(t table.Writer, result ValidatorResult) {
 	resultRows := []table.Row{}
-	resultRows = append(resultRows, table.Row{result.Type, result.ID, boolToPassFail(result.Passed), result.Error})
+	resultRows = append(resultRows, table.Row{result.Type, result.ID, result.Result.String(), result.Error})
 	t.AppendRows(resultRows)
 	for _, subResult := range result.SubResults {
 		appendResultRows(t, subResult)
 	}
-}
-
-func boolToPassFail(passed bool) string {
-	if passed {
-		return "PASS"
-	}
-	return "FAIL"
 }

--- a/op-nat/nat_test.go
+++ b/op-nat/nat_test.go
@@ -112,6 +112,6 @@ func TestNATParameterization(t *testing.T) {
 		require.Len(t, nat.results, 1)
 		assert.Equal(t, "test-with-params", nat.results[0].ID)
 		assert.Equal(t, "Test", nat.results[0].Type)
-		assert.True(t, nat.results[0].Passed)
+		assert.Equal(t, ResultPassed, nat.results[0].Result)
 	})
 }

--- a/op-nat/service/healthz_server.go
+++ b/op-nat/service/healthz_server.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/rs/cors"
+)
+
+type HealthzServer struct {
+	ctx    context.Context
+	server *http.Server
+}
+
+func (h *HealthzServer) Start(ctx context.Context, addr string) error {
+	hdlr := http.NewServeMux()
+	hdlr.HandleFunc("/healthz", h.Handle)
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"*"},
+	})
+	server := &http.Server{
+		Handler: c.Handler(hdlr),
+		Addr:    addr,
+	}
+	h.server = server
+	h.ctx = ctx
+	return h.server.ListenAndServe()
+}
+
+func (h *HealthzServer) Shutdown() error {
+	return h.server.Shutdown(h.ctx)
+}
+
+func (h *HealthzServer) Handle(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Received health check request at %s", r.URL.Path)
+	w.Write([]byte("OK")) //nolint:errcheck
+}

--- a/op-nat/service/metrics_server.go
+++ b/op-nat/service/metrics_server.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type MetricsServer struct {
+	ctx    context.Context
+	server *http.Server
+}
+
+func (m *MetricsServer) Start(ctx context.Context, addr string) error {
+	server := &http.Server{
+		Handler: promhttp.Handler(),
+		Addr:    addr,
+	}
+	m.server = server
+	m.ctx = ctx
+	return m.server.ListenAndServe()
+}
+
+func (m *MetricsServer) Shutdown() error {
+	return m.server.Shutdown(m.ctx)
+}

--- a/op-nat/service/service.go
+++ b/op-nat/service/service.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+
+	"github.com/ethereum-optimism/infra/op-nat/metrics"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	HealthzHost = "0.0.0.0"
+	HealthzPort = "8080"
+
+	MetricsHost = "0.0.0.0"
+	MetricsPort = "7300"
+)
+
+type Service struct {
+	Healthz *HealthzServer
+	Metrics *MetricsServer
+}
+
+func New() *Service {
+	s := &Service{
+		Healthz: &HealthzServer{},
+		Metrics: &MetricsServer{},
+	}
+	return s
+}
+
+func (s *Service) Start(ctx context.Context) {
+	log.Info("service starting")
+
+	go func() {
+		addr := net.JoinHostPort(HealthzHost, HealthzPort)
+		log.Info("starting healthz server", "addr", addr)
+		if err := s.Healthz.Start(ctx, addr); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error("error starting healthz server", "err", err)
+			metrics.RecordErrorDetails("error starting healthz server", err)
+		}
+	}()
+
+	go func() {
+		addr := net.JoinHostPort(MetricsHost, MetricsPort)
+		log.Info("starting metrics server", "addr", addr)
+		if err := s.Metrics.Start(ctx, addr); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error("error starting metrics server", "err", err)
+			metrics.RecordErrorDetails("error starting healthz server", err)
+		}
+	}()
+
+	log.Info("service started")
+}
+
+func (s *Service) Shutdown() {
+	log.Info("service shutting down")
+
+	_ = s.Healthz.Shutdown()
+	log.Info("healthz stopped")
+
+	_ = s.Metrics.Shutdown()
+	log.Info("metrics stopped")
+
+	log.Info("service stopped")
+}

--- a/op-nat/suite_test.go
+++ b/op-nat/suite_test.go
@@ -36,7 +36,7 @@ func TestSuite(t *testing.T) {
 		result, err := suite.Run(context.Background(), log.New(), Config{}, nil)
 
 		require.NoError(t, err)
-		assert.True(t, result.Passed)
+		assert.Equal(t, ResultPassed, result.Result)
 		assert.Equal(t, []string{"test1", "test2"}, executionOrder)
 	})
 
@@ -61,7 +61,7 @@ func TestSuite(t *testing.T) {
 		result, err := suite.Run(context.Background(), log.New(), Config{}, nil)
 
 		require.NoError(t, err)
-		assert.False(t, result.Passed)
+		assert.Equal(t, ResultFailed, result.Result)
 		assert.NoError(t, result.Error)
 	})
 
@@ -86,7 +86,7 @@ func TestSuite(t *testing.T) {
 		result, err := suite.Run(context.Background(), log.New(), Config{}, nil)
 
 		require.NoError(t, err)
-		assert.False(t, result.Passed)
+		assert.Equal(t, ResultFailed, result.Result)
 		assert.Error(t, result.Error)
 	})
 }

--- a/op-nat/test.go
+++ b/op-nat/test.go
@@ -3,7 +3,9 @@ package nat
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/ethereum-optimism/infra/op-nat/metrics"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -18,7 +20,7 @@ type Test struct {
 func (t Test) Run(ctx context.Context, log log.Logger, cfg Config, params interface{}) (ValidatorResult, error) {
 	if t.Fn == nil {
 		return ValidatorResult{
-			Passed: false,
+			Result: ResultFailed,
 		}, fmt.Errorf("test function is nil")
 	}
 
@@ -29,13 +31,16 @@ func (t Test) Run(ctx context.Context, log log.Logger, cfg Config, params interf
 	}
 
 	log.Info("", "type", t.Type(), "id", t.Name(), "params", testParams)
-	passed, err := t.Fn(ctx, log, cfg, testParams)
-	log.Info("", "type", t.Type(), "id", t.Name(), "params", testParams, "passed", passed, "error", err)
+	res, err := t.Fn(ctx, log, cfg, testParams)
+	log.Info("", "type", t.Type(), "id", t.Name(), "params", testParams, "result", strconv.FormatBool(res), "error", err)
+
+	metrics.RecordValidation("todo", t.Name(), t.Type(), strconv.FormatBool(res), err)
+
 	return ValidatorResult{
 		ID:     t.ID,
 		Type:   t.Type(),
 		Error:  err,
-		Passed: passed,
+		Result: ResultTypeFromBool(res),
 	}, err
 }
 

--- a/op-nat/test_test.go
+++ b/op-nat/test_test.go
@@ -26,7 +26,7 @@ func TestTest(t *testing.T) {
 		result, err := test.Run(context.Background(), log.New(), Config{}, nil)
 
 		require.NoError(t, err)
-		assert.True(t, result.Passed)
+		assert.Equal(t, ResultPassed, result.Result)
 		assert.Equal(t, defaultParams, receivedParams)
 	})
 
@@ -45,7 +45,7 @@ func TestTest(t *testing.T) {
 		result, err := test.Run(context.Background(), log.New(), Config{}, customParams)
 
 		require.NoError(t, err)
-		assert.True(t, result.Passed)
+		assert.Equal(t, ResultPassed, result.Result)
 		assert.Equal(t, customParams, receivedParams)
 	})
 
@@ -54,28 +54,28 @@ func TestTest(t *testing.T) {
 			name         string
 			fnReturn     bool
 			fnErr        error
-			expectPassed bool
+			expectResult ResultType
 			expectErr    error
 		}{
 			{
 				name:         "returns true when Fn returns true",
 				fnReturn:     true,
 				fnErr:        nil,
-				expectPassed: true,
+				expectResult: ResultPassed,
 				expectErr:    nil,
 			},
 			{
 				name:         "returns false when Fn returns false",
 				fnReturn:     false,
 				fnErr:        nil,
-				expectPassed: false,
+				expectResult: ResultFailed,
 				expectErr:    nil,
 			},
 			{
 				name:         "propagates error from Fn",
 				fnReturn:     false,
 				fnErr:        assert.AnError,
-				expectPassed: false,
+				expectResult: ResultFailed,
 				expectErr:    assert.AnError,
 			},
 		}
@@ -95,7 +95,7 @@ func TestTest(t *testing.T) {
 					assert.Equal(t, tc.expectErr, err)
 				} else {
 					require.NoError(t, err)
-					assert.Equal(t, tc.expectPassed, result.Passed)
+					assert.Equal(t, tc.expectResult, result.Result)
 				}
 			})
 		}

--- a/op-nat/validator.go
+++ b/op-nat/validator.go
@@ -12,10 +12,40 @@ type Validator interface {
 	Type() string
 }
 
+type ResultType int
+
+const (
+	ResultFailed ResultType = iota
+	ResultPassed
+	ResultSkipped
+)
+
+// TODO: Temporary until test.Fn's return ValidatorResult
+func ResultTypeFromBool(b bool) ResultType {
+	if b {
+		return ResultPassed
+	}
+	return ResultFailed
+}
+
+// String provides a string representation of ResultType
+func (r ResultType) String() string {
+	switch r {
+	case ResultPassed:
+		return "passed"
+	case ResultFailed:
+		return "failed"
+	case ResultSkipped:
+		return "skipped"
+	default:
+		return "unknown"
+	}
+}
+
 type ValidatorResult struct {
 	ID         string
 	Type       string
-	Passed     bool
+	Result     ResultType
 	Error      error
 	SubResults []ValidatorResult
 }


### PR DESCRIPTION
**Description**

This change allows NAT to expose prometheus metrics. The result of a validator has been changed from bool to a string enum as part of this to allow for the "skipped" possibility in the future. Also included is the ability to start a local prometheus & grafana stack to easily test metric-related changes.

**Tests**

Some unit tests are included. This was also tested end-to-end with prometheus & grafana.