### PR TITLE
[NAT] Add a RunID

### DIFF
--- a/op-nat/gate.go
+++ b/op-nat/gate.go
@@ -20,7 +20,7 @@ type Gate struct {
 // Run runs all the tests in the gate.
 // Returns the overall result of the gate and an error if any of the tests failed.
 // Gate-specific params are passed in as `_` because we haven't implemented them yet.
-func (g Gate) Run(ctx context.Context, log log.Logger, cfg Config, _ interface{}) (ValidatorResult, error) {
+func (g Gate) Run(ctx context.Context, log log.Logger, runID string, cfg Config, _ interface{}) (ValidatorResult, error) {
 	log.Info("", "type", g.Type(), "id", g.Name())
 	var overallResult ResultType = ResultPassed
 	hasSkipped := false
@@ -34,7 +34,7 @@ func (g Gate) Run(ctx context.Context, log log.Logger, cfg Config, _ interface{}
 		// Get params
 		params := g.Params[validator.Name()]
 
-		res, err := validator.Run(ctx, log, cfg, params)
+		res, err := validator.Run(ctx, log, runID, cfg, params)
 		allErrors = errors.Join(allErrors, err)
 		if res.Result == ResultFailed {
 			overallResult = ResultFailed
@@ -48,7 +48,7 @@ func (g Gate) Run(ctx context.Context, log log.Logger, cfg Config, _ interface{}
 		overallResult = ResultSkipped
 	}
 	log.Info("", "type", g.Type(), "id", g.Name(), "result", overallResult, "error", allErrors)
-	metrics.RecordValidation("todo", g.Name(), g.Type(), overallResult.String(), allErrors)
+	metrics.RecordValidation("todo", runID, g.Name(), g.Type(), overallResult.String())
 	return ValidatorResult{
 		ID:         g.ID,
 		Type:       g.Type(),

--- a/op-nat/gate_test.go
+++ b/op-nat/gate_test.go
@@ -28,7 +28,7 @@ func TestGate(t *testing.T) {
 			},
 		}
 
-		result, err := gate.Run(context.Background(), log.New(), Config{}, nil)
+		result, err := gate.Run(context.Background(), log.New(), "run1", Config{}, nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, ResultPassed, result.Result)
@@ -52,7 +52,7 @@ func TestGate(t *testing.T) {
 			},
 		}
 
-		result, err := gate.Run(context.Background(), log.New(), Config{}, nil)
+		result, err := gate.Run(context.Background(), log.New(), "run1", Config{}, nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, ResultFailed, result.Result)
@@ -87,7 +87,7 @@ func TestGate(t *testing.T) {
 			},
 		}
 
-		result, err := gate.Run(context.Background(), log.New(), Config{}, nil)
+		result, err := gate.Run(context.Background(), log.New(), "run1", Config{}, nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, ResultFailed, result.Result)

--- a/op-nat/go.mod
+++ b/op-nat/go.mod
@@ -8,6 +8,7 @@ replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth 
 require (
 	github.com/ethereum-optimism/optimism v1.10.0
 	github.com/ethereum/go-ethereum v1.14.11
+	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.6.5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
@@ -53,7 +54,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/golang/snappy v0.0.5-0.20231225225746-43d5d4cd4e0e // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/go-bexpr v0.1.11 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect

--- a/op-nat/justfile
+++ b/op-nat/justfile
@@ -21,6 +21,8 @@ clean:
 
 # Run tests
 # test: (go_test "./...")
+test:
+    go build ./... && go test -v ./...
 
 # Run prometheus and grafana
 start-monitoring:

--- a/op-nat/metrics/metrics.go
+++ b/op-nat/metrics/metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -16,6 +17,7 @@ const (
 
 var (
 	Debug                bool = true
+	validResults              = []string{"pass", "fail", "skip"}
 	nonAlphanumericRegex      = regexp.MustCompile(`[^a-zA-Z ]+`)
 
 	errorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -32,6 +34,7 @@ var (
 		Help:      "Count of validations",
 	}, []string{
 		"network_name",
+		"run_id",
 		"name",
 		"type",
 		"result",
@@ -43,6 +46,7 @@ var (
 		Help:      "Count of acceptance tests",
 	}, []string{
 		"network_name",
+		"run_id",
 		"result",
 	})
 )
@@ -78,25 +82,42 @@ func RecordErrorDetails(label string, err error) {
 	RecordError(label)
 }
 
-func RecordValidation(network string, valName string, valType string, result string, valErr error) {
+func RecordValidation(network string, runID string, valName string, valType string, result string) {
+	if !isValidResult(result) {
+		log.Error("RecordValidation - invalid result", "result", result)
+		return
+	}
 	if Debug {
 		log.Debug("metric inc",
 			"m", "validations_total",
 			"network", network,
+			"run_id", runID,
 			"validator", valName,
 			"type", valType,
 			"result", result)
 	}
-	validationsTotal.WithLabelValues(network, valName, valType, result).Inc()
+	validationsTotal.WithLabelValues(network, runID, valName, valType, result).Inc()
 }
 
-func RecordAcceptance(network string, result string, err error) {
+func RecordAcceptance(network string, runID string, result string) {
+	if !isValidResult(result) {
+		log.Error("RecordAcceptance - invalid result", "result", result)
+		return
+	}
 	if Debug {
 		log.Debug("metric inc",
 			"m", "acceptances_total",
 			"network", network,
+			"run_id", runID,
 			"result", result,
-			"error", err)
+		)
 	}
-	acceptancesTotal.WithLabelValues(network, result).Inc()
+	acceptancesTotal.WithLabelValues(network, runID, result).Inc()
+}
+
+func isValidResult(result string) bool {
+	if slices.Contains(validResults, result) {
+		return true
+	}
+	return false
 }

--- a/op-nat/metrics/metrics.go
+++ b/op-nat/metrics/metrics.go
@@ -116,8 +116,5 @@ func RecordAcceptance(network string, runID string, result string) {
 }
 
 func isValidResult(result string) bool {
-	if slices.Contains(validResults, result) {
-		return true
-	}
-	return false
+	return slices.Contains(validResults, result)
 }

--- a/op-nat/metrics/metrics_test.go
+++ b/op-nat/metrics/metrics_test.go
@@ -65,12 +65,12 @@ func TestRecordErrorDetails(t *testing.T) {
 
 func TestRecordValidation(t *testing.T) {
 	// Test various validation scenarios
-	RecordValidation("test-network", "validator1", "test", "pass", nil)
-	RecordValidation("test-network", "validator2", "test", "fail", errors.New("validation error"))
+	RecordValidation("test-network", "run1", "validator1", "test", "pass")
+	RecordValidation("test-network", "run1", "validator2", "test", "fail")
 }
 
 func TestRecordAcceptance(t *testing.T) {
 	// Test acceptance scenarios
-	RecordAcceptance("test-network", "pass", nil)
-	RecordAcceptance("test-network", "fail", errors.New("acceptance error"))
+	RecordAcceptance("test-network", "run1", "pass")
+	RecordAcceptance("test-network", "run1", "fail")
 }

--- a/op-nat/suite.go
+++ b/op-nat/suite.go
@@ -20,7 +20,7 @@ type Suite struct {
 // Run runs all the tests in the suite.
 // Returns the overall result of the suite and an error if any of the tests failed.
 // Suite-specific params are passed in as `_` because we haven't implemented them yet.
-func (s Suite) Run(ctx context.Context, log log.Logger, cfg Config, _ interface{}) (ValidatorResult, error) {
+func (s Suite) Run(ctx context.Context, log log.Logger, runID string, cfg Config, _ interface{}) (ValidatorResult, error) {
 	log.Info("", "type", s.Type(), "id", s.Name())
 	var overallResult ResultType = ResultPassed
 	hasSkipped := false
@@ -30,7 +30,7 @@ func (s Suite) Run(ctx context.Context, log log.Logger, cfg Config, _ interface{
 		// Get test-specific params
 		params := s.TestsParams[test.ID]
 
-		res, err := test.Run(ctx, log, cfg, params)
+		res, err := test.Run(ctx, log, runID, cfg, params)
 		allErrors = errors.Join(allErrors, err)
 		if res.Result == ResultFailed {
 			overallResult = ResultFailed
@@ -44,7 +44,7 @@ func (s Suite) Run(ctx context.Context, log log.Logger, cfg Config, _ interface{
 		overallResult = ResultSkipped
 	}
 	log.Info("", "type", s.Type(), "id", s.Name(), "result", overallResult, "error", allErrors)
-	metrics.RecordValidation("todo", s.Name(), s.Type(), overallResult.String(), allErrors)
+	metrics.RecordValidation("todo", runID, s.Name(), s.Type(), overallResult.String())
 	return ValidatorResult{
 		ID:         s.ID,
 		Type:       s.Type(),

--- a/op-nat/suite_test.go
+++ b/op-nat/suite_test.go
@@ -33,7 +33,7 @@ func TestSuite(t *testing.T) {
 			},
 		}
 
-		result, err := suite.Run(context.Background(), log.New(), Config{}, nil)
+		result, err := suite.Run(context.Background(), log.New(), "run1", Config{}, nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, ResultPassed, result.Result)
@@ -58,7 +58,7 @@ func TestSuite(t *testing.T) {
 			},
 		}
 
-		result, err := suite.Run(context.Background(), log.New(), Config{}, nil)
+		result, err := suite.Run(context.Background(), log.New(), "run1", Config{}, nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, ResultFailed, result.Result)
@@ -83,7 +83,7 @@ func TestSuite(t *testing.T) {
 			},
 		}
 
-		result, err := suite.Run(context.Background(), log.New(), Config{}, nil)
+		result, err := suite.Run(context.Background(), log.New(), "run1", Config{}, nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, ResultFailed, result.Result)

--- a/op-nat/test.go
+++ b/op-nat/test.go
@@ -3,7 +3,6 @@ package nat
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/ethereum-optimism/infra/op-nat/metrics"
 	"github.com/ethereum/go-ethereum/log"
@@ -17,7 +16,7 @@ type Test struct {
 	Fn            func(ctx context.Context, log log.Logger, cfg Config, params interface{}) (bool, error)
 }
 
-func (t Test) Run(ctx context.Context, log log.Logger, cfg Config, params interface{}) (ValidatorResult, error) {
+func (t Test) Run(ctx context.Context, log log.Logger, runID string, cfg Config, params interface{}) (ValidatorResult, error) {
 	if t.Fn == nil {
 		return ValidatorResult{
 			Result: ResultFailed,
@@ -32,9 +31,10 @@ func (t Test) Run(ctx context.Context, log log.Logger, cfg Config, params interf
 
 	log.Info("", "type", t.Type(), "id", t.Name(), "params", testParams)
 	res, err := t.Fn(ctx, log, cfg, testParams)
-	log.Info("", "type", t.Type(), "id", t.Name(), "params", testParams, "result", strconv.FormatBool(res), "error", err)
+	result := ResultTypeFromBool(res)
+	log.Info("", "type", t.Type(), "id", t.Name(), "params", testParams, "result", result.String(), "error", err)
 
-	metrics.RecordValidation("todo", t.Name(), t.Type(), strconv.FormatBool(res), err)
+	metrics.RecordValidation("todo", runID, t.Name(), t.Type(), result.String())
 
 	return ValidatorResult{
 		ID:     t.ID,

--- a/op-nat/test_test.go
+++ b/op-nat/test_test.go
@@ -23,7 +23,7 @@ func TestTest(t *testing.T) {
 			},
 		}
 
-		result, err := test.Run(context.Background(), log.New(), Config{}, nil)
+		result, err := test.Run(context.Background(), log.New(), "run1", Config{}, nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, ResultPassed, result.Result)
@@ -42,7 +42,7 @@ func TestTest(t *testing.T) {
 			},
 		}
 
-		result, err := test.Run(context.Background(), log.New(), Config{}, customParams)
+		result, err := test.Run(context.Background(), log.New(), "run1", Config{}, customParams)
 
 		require.NoError(t, err)
 		assert.Equal(t, ResultPassed, result.Result)
@@ -89,7 +89,7 @@ func TestTest(t *testing.T) {
 					},
 				}
 
-				result, err := test.Run(context.Background(), log.New(), Config{}, nil)
+				result, err := test.Run(context.Background(), log.New(), "run1", Config{}, nil)
 
 				if tc.expectErr != nil {
 					assert.Equal(t, tc.expectErr, err)

--- a/op-nat/validator.go
+++ b/op-nat/validator.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Validator interface {
-	Run(ctx context.Context, log log.Logger, cfg Config, params interface{}) (ValidatorResult, error)
+	Run(ctx context.Context, log log.Logger, runID string, cfg Config, params interface{}) (ValidatorResult, error)
 	Name() string
 	Type() string
 }
@@ -32,11 +32,11 @@ func ResultTypeFromBool(b bool) ResultType {
 func (r ResultType) String() string {
 	switch r {
 	case ResultPassed:
-		return "passed"
+		return "pass"
 	case ResultFailed:
-		return "failed"
+		return "fail"
 	case ResultSkipped:
-		return "skipped"
+		return "skip"
 	default:
 		return "unknown"
 	}
@@ -47,5 +47,6 @@ type ValidatorResult struct {
 	Type       string
 	Result     ResultType
 	Error      error
+	RunID      string
 	SubResults []ValidatorResult
 }


### PR DESCRIPTION
**Description**

Adds the notion of a "RunID", which is a unique identifier for each run/invocation of NAT. We also emit these metrics to prometheus.

<img width="2514" alt="Screenshot 2025-01-28 at 15 20 30" src="https://github.com/user-attachments/assets/f199f57b-ec74-4d1b-b4a9-a5e5ce17867d" />
