### PR TITLE
Refactor struct and function names for consistency

### DIFF
--- a/op-nat/validators/tests/simple-transfer.go
+++ b/op-nat/validators/tests/simple-transfer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type SimpleTranferParams struct {
+type SimpleTransferParams struct {
 	// TransferAmount is the amount of eth transferred
 	TransferAmount big.Int
 	// MinBalance is how much eth is required to run the test
@@ -23,13 +23,13 @@ type SimpleTranferParams struct {
 // SimpleTransfer is a test that runs a transfer on a network
 var SimpleTransfer = nat.Test{
 	ID: "simple-transfer",
-	DefaultParams: SimpleTranferParams{
+	DefaultParams: SimpleTransferParams{
 		TransferAmount: *big.NewInt(1 * ethparams.GWei),
 		MinBalance:     *big.NewInt(10 * ethparams.GWei),
 	},
 	Fn: func(ctx context.Context, cfg nat.Config, params interface{}) (bool, error) {
 
-		p := params.(SimpleTranferParams)
+		p := params.(SimpleTransferParams)
 		for _, network := range cfg.GetNetworks() {
 			sender, receiver, err := SetupSimpleTransferTest(ctx, network, cfg, p)
 			if err != nil {
@@ -48,7 +48,7 @@ var SimpleTransfer = nat.Test{
 	},
 }
 
-func SetupSimpleTransferTest(ctx context.Context, network *network.Network, cfg nat.Config, p SimpleTranferParams) (*wallet.Wallet, *wallet.Wallet, error) {
+func SetupSimpleTransferTest(ctx context.Context, network *network.Network, cfg nat.Config, p SimpleTransferParams) (*wallet.Wallet, *wallet.Wallet, error) {
 
 	sender, err := cfg.GetWalletWithBalance(ctx, network, &p.MinBalance)
 	if err != nil {
@@ -67,7 +67,7 @@ func SetupSimpleTransferTest(ctx context.Context, network *network.Network, cfg 
 
 }
 
-func SimpleTransferTest(ctx context.Context, log log.Logger, network *network.Network, sender, receiver *wallet.Wallet, p SimpleTranferParams) (bool, error) {
+func SimpleTransferTest(ctx context.Context, log log.Logger, network *network.Network, sender, receiver *wallet.Wallet, p SimpleTransferParams) (bool, error) {
 	// Make sure the accounts are unstuck before sending any transactions
 	if network == nil || sender == nil || receiver == nil {
 		return false, errors.New("error empty arguments provided for SimpleTransferTest")

--- a/op-signer/service/service.go
+++ b/op-signer/service/service.go
@@ -18,7 +18,7 @@ import (
 
 type SignerService struct {
 	eth      *EthService
-	opsigner *OpsignerSerivce
+	opsigner *OpsignerService
 }
 
 type EthService struct {
@@ -27,7 +27,7 @@ type EthService struct {
 	provider provider.SignatureProvider
 }
 
-type OpsignerSerivce struct {
+type OpsignerService struct {
 	logger   log.Logger
 	config   SignerServiceConfig
 	provider provider.SignatureProvider
@@ -43,7 +43,7 @@ func NewSignerServiceWithProvider(
 	provider provider.SignatureProvider,
 ) *SignerService {
 	ethService := EthService{logger, config, provider}
-	opsignerService := OpsignerSerivce{logger, config, provider}
+	opsignerService := OpsignerService{logger, config, provider}
 	return &SignerService{&ethService, &opsignerService}
 }
 
@@ -166,7 +166,7 @@ func (s *EthService) SignTransaction(ctx context.Context, args signer.Transactio
 	return hexutil.Bytes(txraw), nil
 }
 
-func (s *OpsignerSerivce) SignBlockPayload(ctx context.Context, args signer.BlockPayloadArgs) (hexutil.Bytes, error) {
+func (s *OpsignerService) SignBlockPayload(ctx context.Context, args signer.BlockPayloadArgs) (hexutil.Bytes, error) {
 	clientInfo := ClientInfoFromContext(ctx)
 	authConfig, err := s.config.GetAuthConfigForClient(clientInfo.ClientName, args.SenderAddress)
 	if err != nil {


### PR DESCRIPTION
This PR updates struct and function names in `simple-transfer.go` and `service.go` to maintain naming consistency across the codebase. The changes improve readability and align with existing naming conventions.

### Changes:
- Renamed `SimpleTranferParams` to `SimpleTransferParams` in `simple-transfer.go`
- Renamed `OpsignerSerivce` to `OpsignerService` in `service.go`

### Tests
No functional changes were introduced, so existing tests should cover the modifications.
