### PR TITLE
fix: unmarshall jsonrpc error data as byte[]

### DIFF
--- a/proxyd/rpc.go
+++ b/proxyd/rpc.go
@@ -55,10 +55,10 @@ func (r *RPCRes) MarshalJSON() ([]byte, error) {
 }
 
 type RPCErr struct {
-	Code          int    `json:"code"`
-	Message       string `json:"message"`
-	Data          string `json:"data,omitempty"`
-	HTTPErrorCode int    `json:"-"`
+	Code          int             `json:"code"`
+	Message       string          `json:"message"`
+	Data          json.RawMessage `json:"data,omitempty"`
+	HTTPErrorCode int             `json:"-"`
 }
 
 func (r *RPCErr) Error() string {

--- a/proxyd/rpc_test.go
+++ b/proxyd/rpc_test.go
@@ -63,7 +63,7 @@ func TestRPCResJSON(t *testing.T) {
 				Error: &RPCErr{
 					Code:    1234,
 					Message: "test err",
-					Data:    "revert",
+					Data:    []byte(`"revert"`),
 				},
 				ID: []byte("123"),
 			},


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

According to the [JSONRPC2.0 spec](https://www.jsonrpc.org/specification#error_object), the error object's data can be "A Primitive or Structured value that contains additional information about the error."

Currently, proxyd only unmarshalls the `error.data` as a string. This does not work for all node providers if they provide a struct instead.

For example, we sometimes get the response
`{"jsonrpc":"2.0","id":1,"error":{"code":-32521,"message":"execution reverted","data":{"revertData":"0x"}}}`

This response will cause an error in proxyd because it can't be unmarshalled since data is a struct. Instead proxyd returns a vague and inaccurate error `no backend is currently health to serve traffic`.

**Tests**

Updated the existing unit test. Additionally we've deployed proxyd ourselves and regression tested.

**Additional context**

n/a

**Metadata**

- Fixes #[Link to Issue]
