### PR TITLE
Use signBlockPayload metric properly

### DIFF
--- a/op-signer/app.go
+++ b/op-signer/app.go
@@ -93,6 +93,7 @@ func (s *SignerApp) initPprof(cfg *Config) error {
 func (s *SignerApp) initMetrics(cfg *Config) error {
 	registry := opmetrics.NewRegistry()
 	registry.MustRegister(service.MetricSignTransactionTotal)
+	registry.MustRegister(service.MetricSignBlockPayloadTotal)
 	s.registry = registry // some things require metrics registry
 
 	if !cfg.MetricsConfig.Enabled {

--- a/op-signer/service/metrics.go
+++ b/op-signer/service/metrics.go
@@ -9,4 +9,11 @@ var (
 			Help: ""},
 		[]string{"client", "status", "error"},
 	)
+
+	MetricSignBlockPayloadTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signer_signblockpayload_total",
+			Help: ""},
+		[]string{"client", "status", "error"},
+	)
 )

--- a/op-signer/service/service.go
+++ b/op-signer/service/service.go
@@ -189,7 +189,7 @@ func (s *OpsignerSerivce) signBlockPayload(
 
 	labels := prometheus.Labels{"client": clientInfo.ClientName, "status": "error", "error": ""}
 	defer func() {
-		MetricSignTransactionTotal.With(labels).Inc()
+		MetricSignBlockPayloadTotal.With(labels).Inc()
 	}()
 
 	msg, err := getMsg()


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
op-signer was incorrectly using `signer_signtransaction_total` when signing block payload. Create a new prometheus metric `signer_signBlockPayload_total` and use that when signing block payload. 