### PR TITLE
feat: adjust metric to include multicall in rpc_requests_total metric

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -780,14 +780,14 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 		rpcReqs, overriddenResponses = bg.OverwriteConsensusResponses(rpcReqs, overriddenResponses, rewrittenReqs)
 	}
 
+	rpcRequestsTotal.Inc()
+
 	// When routing_strategy is set to 'multicall' the request will be forward to all backends
 	// and return the first successful response
 	if bg.GetRoutingStrategy() == MulticallRoutingStrategy && isValidMulticallTx(rpcReqs) && !isBatch {
 		backendResp := bg.ExecuteMulticall(ctx, rpcReqs)
 		return backendResp.RPCRes, backendResp.ServedBy, backendResp.error
 	}
-
-	rpcRequestsTotal.Inc()
 
 	ch := make(chan BackendGroupRPCResponse)
 	go func() {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
* Previously multicall would not increment rpcRequestsTotal which resulted in odd metric behavior, adjusting this to be incremented prior to calling ExecuteMulticall
**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
