### PR TITLE
[op-acceptor] add Go binary to docker image.

### DIFF
--- a/op-acceptor/.goreleaser.yaml
+++ b/op-acceptor/.goreleaser.yaml
@@ -7,7 +7,6 @@ project_name: op-acceptor
 
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
 
 builds:

--- a/op-acceptor/Dockerfile
+++ b/op-acceptor/Dockerfile
@@ -11,10 +11,22 @@ RUN just build
 
 FROM alpine:3.21
 
+# Install Go binary
+# (we copy Go directly from the builder stage for simplicity and consistency)
+COPY --from=builder /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH="/go"
+ENV PATH="${GOPATH}/bin:${PATH}"
+
 WORKDIR /app
 RUN addgroup -S app && adduser -S app -G app && \
     mkdir -p /devnets && \
     chown -R app:app /devnets
+
+# Modify ownership of /go to app user (as we need write permissions)
+RUN mkdir -p /go && \
+mkdir -p /go/pkg /go/bin /go/src && \
+chown -R app:app /go
 
 COPY --from=builder /app/bin/op-acceptor /app/
 COPY op-acceptor/example-validators.yaml /app/


### PR DESCRIPTION
**Description**

Adds the `go` binary to our docker images, as it's needed by op-acceptor to run the go tests.

(In the future we may use the go api directly but, for now, this has been proving very tricky)