### PR TITLE
feat(proxyd): add config to skip is syncing check

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -151,6 +151,7 @@ type Backend struct {
 	stripTrailingXFF     bool
 	proxydIP             string
 
+	skipIsSyncingCheck bool
 	skipPeerCountCheck bool
 	forcedCandidate    bool
 
@@ -234,6 +235,12 @@ func WithStrippedTrailingXFF() BackendOpt {
 func WithProxydIP(ip string) BackendOpt {
 	return func(b *Backend) {
 		b.proxydIP = ip
+	}
+}
+
+func WithSkipIsSyncingCheck(skipIsSyncingCheck bool) BackendOpt {
+	return func(b *Backend) {
+		b.skipIsSyncingCheck = skipIsSyncingCheck
 	}
 }
 

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -110,6 +110,8 @@ type BackendConfig struct {
 
 	Weight int `toml:"weight"`
 
+	SkipIsSyncingCheck bool `toml:"skip_is_syncing_check"`
+
 	ConsensusSkipPeerCountCheck bool   `toml:"consensus_skip_peer_count"`
 	ConsensusForcedCandidate    bool   `toml:"consensus_forced_candidate"`
 	ConsensusReceiptsTarget     string `toml:"consensus_receipts_target"`

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -762,7 +762,7 @@ func (cp *ConsensusPoller) FilterCandidates(backends []*Backend) map[*Backend]*b
 			)
 			continue
 		}
-		if !bs.inSync {
+		if !be.skipIsSyncingCheck && !bs.inSync {
 			continue
 		}
 		if bs.lastUpdate.Add(cp.maxUpdateThreshold).Before(time.Now()) {

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -77,6 +77,8 @@ client_key_file = ""
 # Specified the target method to get receipts, default "debug_getRawReceipts"
 # See https://github.com/ethereum-optimism/optimism/blob/186e46a47647a51a658e699e9ff047d39444c2de/op-node/sources/receipts.go#L186-L253
 consensus_receipts_target = "eth_getBlockReceipts"
+# Allow backends to skip eth_syncing checks, default false
+# skip_is_syncing_check = false
 
 [backends.alchemy]
 rpc_url = ""

--- a/proxyd/integration_tests/consensus_custom_config_test.go
+++ b/proxyd/integration_tests/consensus_custom_config_test.go
@@ -1,0 +1,131 @@
+package integration_tests
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/ethereum-optimism/infra/proxyd"
+	ms "github.com/ethereum-optimism/infra/proxyd/tools/mockserver/handler"
+	"github.com/stretchr/testify/require"
+)
+
+func setupCustomConfig(t *testing.T, configName string) (map[string]nodeContext, *proxyd.BackendGroup, *ProxydHTTPClient, func()) {
+	// setup mock servers
+	node1 := NewMockBackend(nil)
+	node2 := NewMockBackend(nil)
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	responses := path.Join(dir, "testdata/consensus_responses.yml")
+
+	h1 := ms.MockedHandler{
+		Overrides:    []*ms.MethodTemplate{},
+		Autoload:     true,
+		AutoloadFile: responses,
+	}
+	h2 := ms.MockedHandler{
+		Overrides:    []*ms.MethodTemplate{},
+		Autoload:     true,
+		AutoloadFile: responses,
+	}
+
+	require.NoError(t, os.Setenv("NODE1_URL", node1.URL()))
+	require.NoError(t, os.Setenv("NODE2_URL", node2.URL()))
+
+	node1.SetHandler(http.HandlerFunc(h1.Handler))
+	node2.SetHandler(http.HandlerFunc(h2.Handler))
+
+	// setup proxyd
+	config := ReadConfig(configName)
+	svr, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+
+	// expose the proxyd client
+	client := NewProxydClient("http://127.0.0.1:8545")
+
+	// expose the backend group
+	bg := svr.BackendGroups["node"]
+	require.NotNil(t, bg)
+	require.NotNil(t, bg.Consensus)
+	require.Equal(t, 2, len(bg.Backends)) // should match config
+
+	// convenient mapping to access the nodes by name
+	nodes := map[string]nodeContext{
+		"node1": {
+			mockBackend: node1,
+			backend:     bg.Backends[0],
+			handler:     &h1,
+		},
+		"node2": {
+			mockBackend: node2,
+			backend:     bg.Backends[1],
+			handler:     &h2,
+		},
+	}
+
+	return nodes, bg, client, shutdown
+}
+
+func TestConsensusSkipSyncTest(t *testing.T) {
+	nodes, bg, _, shutdown := setupCustomConfig(t, "consensus_skip_sync_check")
+	defer nodes["node1"].mockBackend.Close()
+	defer nodes["node2"].mockBackend.Close()
+	defer shutdown()
+
+	ctx := context.Background()
+
+	// poll for updated consensus
+	update := func() {
+		for _, be := range bg.Backends {
+			bg.Consensus.UpdateBackend(ctx, be)
+		}
+		bg.Consensus.UpdateBackendGroupConsensus(ctx)
+	}
+
+	// convenient methods to manipulate state and mock responses
+	reset := func() {
+		for _, node := range nodes {
+			node.handler.ResetOverrides()
+			node.mockBackend.Reset()
+			node.backend.ClearSlidingWindows()
+		}
+		bg.Consensus.ClearListeners()
+		bg.Consensus.Reset()
+
+	}
+
+	override := func(node string, method string, block string, response string) {
+		if _, ok := nodes[node]; !ok {
+			t.Fatalf("node %s does not exist in the nodes map", node)
+		}
+		nodes[node].handler.AddOverride(&ms.MethodTemplate{
+			Method:   method,
+			Block:    block,
+			Response: response,
+		})
+	}
+
+	overrideNotInSync := func(node string) {
+		override(node, "eth_syncing", "", buildResponse(map[string]string{
+			"startingblock": "0x0",
+			"currentblock":  "0x0",
+			"highestblock":  "0x100",
+		}))
+	}
+
+	t.Run("skip in sync check", func(t *testing.T) {
+		reset()
+		// make node1 not in sync
+		overrideNotInSync("node1")
+		update()
+
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.Contains(t, consensusGroup, nodes["node1"].backend)
+		require.False(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		require.Equal(t, 2, len(consensusGroup))
+	})
+}

--- a/proxyd/integration_tests/testdata/consensus_skip_sync_check.toml
+++ b/proxyd/integration_tests/testdata/consensus_skip_sync_check.toml
@@ -24,6 +24,7 @@ consensus_max_update_threshold = "2m"
 consensus_max_block_lag = 8
 consensus_min_peer_count = 4
 
+
 [rpc_method_mappings]
 eth_call = "node"
 eth_chainId = "node"

--- a/proxyd/integration_tests/testdata/consensus_skip_sync_check.toml
+++ b/proxyd/integration_tests/testdata/consensus_skip_sync_check.toml
@@ -1,0 +1,32 @@
+[server]
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 1
+max_degraded_latency_threshold = "30ms"
+
+[backends]
+[backends.node1]
+rpc_url = "$NODE1_URL"
+skip_is_syncing_check = true
+
+[backends.node2]
+rpc_url = "$NODE2_URL"
+skip_is_syncing_check = true
+
+[backend_groups]
+[backend_groups.node]
+backends = ["node1", "node2"]
+routing_strategy = "consensus_aware"
+consensus_handler = "noop" # allow more control over the consensus poller for tests
+consensus_ban_period = "1m"
+consensus_max_update_threshold = "2m"
+consensus_max_block_lag = 8
+consensus_min_peer_count = 4
+
+[rpc_method_mappings]
+eth_call = "node"
+eth_chainId = "node"
+eth_blockNumber = "node"
+eth_getBlockByNumber = "node"
+consensus_getReceipts = "node"

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -193,6 +193,7 @@ func Start(config *Config) (*Server, func(), error) {
 			opts = append(opts, WithStrippedTrailingXFF())
 		}
 		opts = append(opts, WithProxydIP(os.Getenv("PROXYD_IP")))
+		opts = append(opts, WithSkipIsSyncingCheck(cfg.SkipIsSyncingCheck))
 		opts = append(opts, WithConsensusSkipPeerCountCheck(cfg.ConsensusSkipPeerCountCheck))
 		opts = append(opts, WithConsensusForcedCandidate(cfg.ConsensusForcedCandidate))
 		opts = append(opts, WithWeight(cfg.Weight))


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

I'm using proxyd as a generalize purpose consensus aware LB for nodes. In some configuration, checking for the `eth_syncing` state of the node is not ideal. For instance, for Orbit's nitro nodes, it is more important to have an active sequencer feed for the nodes than to check for the sync state between the node and the parent chain. For this use-case, I would like to configure proxyd to disable this check. Ideally I should add specific handling for nitro nodes, but that's probably outside the scope of proxyd. 

**Tests**

I ran proxyd without this config and confirmed syncing state is still checked. I ran proxyd with the config and confirmed syncing state is not checked.
