### PR TITLE
feat(op-acceptor): handle package tests better.

### DIFF
--- a/op-acceptor/runner/runner_test.go
+++ b/op-acceptor/runner/runner_test.go
@@ -543,3 +543,175 @@ func TestSuiteStatusDetermination(t *testing.T) {
 		})
 	}
 }
+
+func TestRunPackageTests(t *testing.T) {
+	// Setup test with multiple tests in a package
+	testContent := []byte(`
+package feature_test
+
+import "testing"
+
+func TestPackageOne(t *testing.T) {
+	t.Log("Test package one running")
+}
+
+func TestPackageTwo(t *testing.T) {
+	t.Log("Test package two running")
+}
+
+func TestPackageThree(t *testing.T) {
+	t.Log("Test package three running")
+}
+
+func TestPackageFour(t *testing.T) {
+	t.Log("Test package four running")
+}
+`)
+
+	configContent := []byte(`
+gates:
+  - id: package-gate
+    description: "Package gate"
+    suites:
+      package-suite:
+        description: "Package suite"
+        tests:
+          - package: "./feature"
+            run_all: true
+`)
+	r := setupTestRunner(t, testContent, configContent)
+
+	// Run all tests
+	result, err := r.RunAllTests()
+	require.NoError(t, err)
+	assert.Equal(t, types.TestStatusPass, result.Status)
+
+	// Verify structure
+	require.Contains(t, result.Gates, "package-gate", "should have package-gate")
+	gate := result.Gates["package-gate"]
+	assert.Equal(t, types.TestStatusPass, gate.Status)
+
+	// Verify suite structure
+	require.Contains(t, gate.Suites, "package-suite", "should have package-suite")
+	suite := gate.Suites["package-suite"]
+	assert.Equal(t, types.TestStatusPass, suite.Status)
+
+	// Verify tests in the suite
+	assert.Len(t, suite.Tests, 1, "should have one test (the package)")
+
+	// Get the package test
+	var packageTest *types.TestResult
+	for _, test := range suite.Tests {
+		packageTest = test
+		break
+	}
+	require.NotNil(t, packageTest, "package test should exist")
+
+	// Verify the package test has subtests
+	assert.NotEmpty(t, packageTest.SubTests, "package test should have subtests")
+	assert.Len(t, packageTest.SubTests, 4, "should have found all 4 tests in the package")
+
+	// Verify each subtest exists and passed
+	subTestNames := []string{"TestPackageOne", "TestPackageTwo", "TestPackageThree", "TestPackageFour"}
+	for _, name := range subTestNames {
+		assert.Contains(t, packageTest.SubTests, name, "should have subtest "+name)
+		assert.Equal(t, types.TestStatusPass, packageTest.SubTests[name].Status, name+" should be passing")
+	}
+
+	// Verify stats include all subtests
+	assert.Equal(t, 5, result.Stats.Total, "stats should include all tests (1 package + 4 subtests)")
+	assert.Equal(t, 5, result.Stats.Passed, "all tests should be passing")
+	assert.Equal(t, 0, result.Stats.Failed, "no tests should be failing")
+	assert.Equal(t, 0, result.Stats.Skipped, "no tests should be skipped")
+
+	// Verify gate stats
+	assert.Equal(t, 5, gate.Stats.Total, "gate stats should include all tests")
+	assert.Equal(t, 5, gate.Stats.Passed, "all gate tests should be passing")
+
+	// Verify suite stats
+	assert.Equal(t, 5, suite.Stats.Total, "suite stats should include all tests")
+	assert.Equal(t, 5, suite.Stats.Passed, "all suite tests should be passing")
+}
+
+func TestRunPackageWithFailingTests(t *testing.T) {
+	// Setup test with a failing test in a package
+	testContent := []byte(`
+package feature_test
+
+import "testing"
+
+func TestFailing(t *testing.T) {
+	t.Error("This test fails")
+}
+`)
+
+	configContent := []byte(`
+gates:
+  - id: failing-gate
+    description: "Gate with a failing test"
+    suites:
+      failing-suite:
+        description: "Suite with a failing test"
+        tests:
+          - package: "./feature"
+            run_all: true
+`)
+	r := setupTestRunner(t, testContent, configContent)
+
+	// Run all tests
+	result, err := r.RunAllTests()
+	require.NoError(t, err)
+	assert.Equal(t, types.TestStatusFail, result.Status, "overall result should be failure when any test fails")
+
+	// Verify structure
+	require.Contains(t, result.Gates, "failing-gate", "should have failing-gate")
+	gate := result.Gates["failing-gate"]
+	assert.Equal(t, types.TestStatusFail, gate.Status, "gate status should be failure")
+
+	// Verify suite structure
+	require.Contains(t, gate.Suites, "failing-suite", "should have failing-suite")
+	suite := gate.Suites["failing-suite"]
+	assert.Equal(t, types.TestStatusFail, suite.Status, "suite status should be failure")
+
+	// Verify tests in the suite
+	assert.Len(t, suite.Tests, 1, "should have one test (the package)")
+
+	// Get the package test
+	var packageTest *types.TestResult
+	for _, test := range suite.Tests {
+		packageTest = test
+		break
+	}
+	require.NotNil(t, packageTest, "package test should exist")
+
+	// Verify the package test failed
+	assert.Equal(t, types.TestStatusFail, packageTest.Status, "package test should be marked as failing")
+	assert.NotNil(t, packageTest.Error, "package test should have an error")
+
+	// Verify the package test has subtests
+	assert.NotEmpty(t, packageTest.SubTests, "package test should have subtests")
+	assert.Len(t, packageTest.SubTests, 1, "should have found the failing test")
+
+	// Verify the subtest has the correct status
+	subTest := packageTest.SubTests["TestFailing"]
+	require.NotNil(t, subTest, "should have the TestFailing subtest")
+	assert.Equal(t, types.TestStatusFail, subTest.Status, "subtest should be failing")
+
+	// Verify stats are accurate
+	assert.Equal(t, 2, result.Stats.Total, "stats should include all tests (1 package + 1 subtest)")
+	assert.Equal(t, 0, result.Stats.Passed, "no tests should pass")
+	assert.Equal(t, 2, result.Stats.Failed, "1 subtest and parent package should fail")
+	assert.Equal(t, 0, result.Stats.Skipped, "no tests should be skipped")
+
+	// Verify gate stats
+	assert.Equal(t, 2, gate.Stats.Total, "gate stats should include all tests")
+	assert.Equal(t, 0, gate.Stats.Passed, "no tests should pass")
+	assert.Equal(t, 2, gate.Stats.Failed, "all tests should fail")
+	assert.Equal(t, 0, gate.Stats.Skipped, "no tests should be skipped")
+
+	// Verify suite stats
+	assert.Equal(t, 2, suite.Stats.Total, "suite stats should include all tests")
+	assert.Equal(t, 0, suite.Stats.Passed, "no tests should pass")
+	assert.Equal(t, 2, suite.Stats.Failed, "all tests should fail")
+	assert.Equal(t, 0, suite.Stats.Skipped, "no tests should be skipped")
+}

--- a/op-acceptor/types/test.go
+++ b/op-acceptor/types/test.go
@@ -1,6 +1,9 @@
 package types
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // TestStatus represents the possible states of a test execution
 type TestStatus string
@@ -15,8 +18,9 @@ const (
 type TestResult struct {
 	Metadata ValidatorMetadata
 	Status   TestStatus
-	Error    error         // Changed from string to error
-	Duration time.Duration // Track test execution time
+	Error    error                  // Changed from string to error
+	Duration time.Duration          // Track test execution time
+	SubTests map[string]*TestResult // Store individual test results when running a package
 }
 
 // TestConfig represents a test configuration
@@ -24,4 +28,20 @@ type TestConfig struct {
 	Name    string `yaml:"name,omitempty"`
 	Package string `yaml:"package"`
 	RunAll  bool   `yaml:"run_all,omitempty"`
+}
+
+// GetTestDisplayName returns a formatted display name for a test based on its name and metadata
+// If the test name is empty but a package is specified, it will return the package name in a readable format
+func GetTestDisplayName(testName string, metadata ValidatorMetadata) string {
+	displayName := testName
+	if displayName == "" && metadata.Package != "" {
+		// For package names, use a shortened version to avoid wrapping
+		pkgParts := strings.Split(metadata.Package, "/")
+		if len(pkgParts) > 0 {
+			displayName = pkgParts[len(pkgParts)-1] + " (package)"
+		} else {
+			displayName = metadata.Package
+		}
+	}
+	return displayName
 }

--- a/op-acceptor/types/validator.go
+++ b/op-acceptor/types/validator.go
@@ -36,3 +36,14 @@ type ValidatorMetadata struct {
 	Timeout  string
 	RunAll   bool
 }
+
+// GetName returns a name for the validator based on available fields
+func (v ValidatorMetadata) GetName() string {
+	if v.FuncName != "" {
+		return v.FuncName
+	}
+	if v.Package != "" {
+		return v.Package
+	}
+	return v.ID
+}


### PR DESCRIPTION
**Description**

Show the result of each sub-test within a package in the output. Also show the package name.

**Test**
Added some unit tests. Also made a custom validators.yaml with just a single package which has 4 subtests. The output was as expected (pictured).

<img width="1217" alt="Screenshot 2025-03-12 at 13 57 56" src="https://github.com/user-attachments/assets/d1ee1338-f73f-4727-a030-778a371af7c1" />


**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/14803
- Unblocks https://github.com/ethereum-optimism/optimism/pull/14802
