### PR TITLE
feat(proxyd): add external authentication support and refactor auth handling

### DIFF
--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -117,6 +117,8 @@ backends = ["alchemy"]
 # is provided. Note that you will need to quote the environment variable
 # in order for it to be value TOML, e.g. "$FOO_AUTH_KEY" = "foo_alias".
 secret = "test"
+# URL for external authentication service (optional)
+auth_url = "https://api.developer.coinbase.com/rpc/v1/base"
 
 # Mapping of methods to backend groups.
 [rpc_method_mappings]

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -21,7 +21,7 @@ ws_port = 8085
 max_body_size_bytes = 10485760
 max_concurrent_rpcs = 1000
 # Server log level
-log_level = "info"
+log_level = "debug"
 
 [redis]
 # URL to a Redis instance.

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -21,7 +21,7 @@ ws_port = 8085
 max_body_size_bytes = 10485760
 max_concurrent_rpcs = 1000
 # Server log level
-log_level = "debug"
+log_level = "info"
 
 [redis]
 # URL to a Redis instance.

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -117,8 +117,6 @@ backends = ["alchemy"]
 # is provided. Note that you will need to quote the environment variable
 # in order for it to be value TOML, e.g. "$FOO_AUTH_KEY" = "foo_alias".
 secret = "test"
-# URL for external authentication service (optional)
-auth_url = "https://api.developer.coinbase.com/rpc/v1/base"
 
 # Mapping of methods to backend groups.
 [rpc_method_mappings]

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -288,7 +288,7 @@ func Start(config *Config) (*Server, func(), error) {
 
 	var resolvedAuth map[string]string
 	if config.Authentication != nil {
-		log.Info("Authentication config contents",
+		log.Info("Startfunction Authentication config contents",
 			"raw_config", config.Authentication,
 			"auth_url_value", config.Authentication["auth_url"],
 			"secret_value", config.Authentication["secret"])
@@ -297,13 +297,13 @@ func Start(config *Config) (*Server, func(), error) {
 
 		// First, check and process the auth_url if present
 		if authURL, ok := config.Authentication["auth_url"]; ok {
-			log.Info("Found auth_url in config", "auth_url", authURL)
+			log.Info("Startfunction Found auth_url in config", "auth_url", authURL)
 			resolvedURL, err := ReadFromEnvOrConfig(authURL)
 			if err != nil {
 				return nil, nil, err
 			}
 			resolvedAuth["auth_url"] = resolvedURL
-			log.Info("Configured external auth service",
+			log.Info("Startfunction Configured external auth service",
 				"original_url", authURL,
 				"resolved_url", resolvedURL)
 		}
@@ -311,6 +311,7 @@ func Start(config *Config) (*Server, func(), error) {
 		for key, alias := range config.Authentication {
 			// Skip auth_url as we've already processed it
 			if key == "auth_url" {
+				log.Info("Startfunction Skipping auth_url", "key", key)
 				continue
 			}
 
@@ -319,7 +320,7 @@ func Start(config *Config) (*Server, func(), error) {
 				return nil, nil, err
 			}
 			resolvedAuth[resolvedKey] = alias
-			log.Info("Configured traditional auth", "key", resolvedKey, "alias", alias)
+			log.Info("Startfunction Configured traditional auth", "key", resolvedKey, "alias", alias)
 		}
 	}
 

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -278,14 +278,13 @@ func Start(config *Config) (*Server, func(), error) {
 		}
 	}
 
-	var resolvedAuth map[string]string
+	var resolvedAuth map[string]string = make(map[string]string) // Initialize map first
+
 	if config.Authentication != nil {
 		log.Info("Startfunction Authentication config contents",
 			"raw_config", config.Authentication,
 			"auth_url_value", config.Authentication["auth_url"],
 			"secret_value", config.Authentication["secret"])
-
-		resolvedAuth = make(map[string]string)
 
 		// First, check and process the auth_url if present
 		if authURL, ok := config.Authentication["auth_url"]; ok {
@@ -349,9 +348,9 @@ func Start(config *Config) (*Server, func(), error) {
 		return NewMemoryFrontendRateLimit(dur, max)
 	}
 
-	log.Info("Creating server",
-		"resolvedAuth", resolvedAuth,
-		"has_auth_url", resolvedAuth["auth_url"] != "")
+	log.Info("StartFunction Creating server with auth paths",
+		"resolvedAuth_nil", resolvedAuth == nil,
+		"config_auth_nil", config.Authentication == nil)
 
 	srv, err := NewServer(
 		backendGroups,

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -289,15 +289,9 @@ func Start(config *Config) (*Server, func(), error) {
 
 		// First, check and process the auth_url if present
 		if authURL, ok := config.Authentication["auth_url"]; ok {
-			log.Info("Startfunction Found auth_url in config", "auth_url", authURL)
-			resolvedURL, err := ReadFromEnvOrConfig(authURL)
-			if err != nil {
-				return nil, nil, err
-			}
-			resolvedAuth["auth_url"] = resolvedURL
+			resolvedAuth["auth_url"] = authURL
 			log.Info("Startfunction Configured external auth service",
-				"original_url", authURL,
-				"resolved_url", resolvedURL)
+				"auth_url", authURL)
 		}
 		// Then process any remaining keys as traditional auth keys
 		for key, alias := range config.Authentication {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -33,14 +33,6 @@ func Start(config *Config) (*Server, func(), error) {
 		return nil, nil, errors.New("must define at least one RPC method mapping")
 	}
 
-	if config.Authentication != nil {
-		if secret, ok := config.Authentication["secret"]; ok {
-			if secret == "none" {
-				return nil, nil, errors.New("cannot use none as an auth key")
-			}
-		}
-	}
-
 	// redis primary client
 	var redisClient redis.UniversalClient
 	if config.Redis.URL != "" {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -288,19 +288,24 @@ func Start(config *Config) (*Server, func(), error) {
 
 	var resolvedAuth map[string]string
 	if config.Authentication != nil {
-		log.Info("Startfunction Processing authentication config")
+		log.Info("Authentication config contents",
+			"raw_config", config.Authentication,
+			"auth_url_value", config.Authentication["auth_url"],
+			"secret_value", config.Authentication["secret"])
+
 		resolvedAuth = make(map[string]string)
 
 		// First, check and process the auth_url if present
 		if authURL, ok := config.Authentication["auth_url"]; ok {
-			log.Info("Startfunction Found auth_url config", "url", authURL)
+			log.Info("Found auth_url in config", "auth_url", authURL)
 			resolvedURL, err := ReadFromEnvOrConfig(authURL)
 			if err != nil {
 				return nil, nil, err
 			}
-			// Store the auth_url with a special key that we'll check for later
 			resolvedAuth["auth_url"] = resolvedURL
-			log.Info("Startfunction Configured external auth service", "url", resolvedURL)
+			log.Info("Configured external auth service",
+				"original_url", authURL,
+				"resolved_url", resolvedURL)
 		}
 		// Then process any remaining keys as traditional auth keys
 		for key, alias := range config.Authentication {
@@ -314,7 +319,7 @@ func Start(config *Config) (*Server, func(), error) {
 				return nil, nil, err
 			}
 			resolvedAuth[resolvedKey] = alias
-			log.Info("Startfunction Configured traditional auth", "key", resolvedKey, "alias", alias)
+			log.Info("Configured traditional auth", "key", resolvedKey, "alias", alias)
 		}
 	}
 
@@ -356,6 +361,10 @@ func Start(config *Config) (*Server, func(), error) {
 
 		return NewMemoryFrontendRateLimit(dur, max)
 	}
+
+	log.Info("Creating server",
+		"resolvedAuth", resolvedAuth,
+		"has_auth_url", resolvedAuth["auth_url"] != "")
 
 	srv, err := NewServer(
 		backendGroups,

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -278,25 +278,14 @@ func Start(config *Config) (*Server, func(), error) {
 		}
 	}
 
-	var resolvedAuth map[string]string = make(map[string]string) // Initialize map first
+	var resolvedAuth map[string]string = make(map[string]string)
 
 	if config.Authentication != nil {
-		log.Info("Startfunction Authentication config contents",
-			"raw_config", config.Authentication,
-			"auth_url_value", config.Authentication["auth_url"],
-			"secret_value", config.Authentication["secret"])
-
-		// First, check and process the auth_url if present
 		if authURL, ok := config.Authentication["auth_url"]; ok {
 			resolvedAuth["auth_url"] = authURL
-			log.Info("Startfunction Configured external auth service",
-				"auth_url", authURL)
 		}
-		// Then process any remaining keys as traditional auth keys
 		for key, alias := range config.Authentication {
-			// Skip auth_url as we've already processed it
 			if key == "auth_url" {
-				log.Info("Startfunction Skipping auth_url", "key", key)
 				continue
 			}
 
@@ -305,7 +294,6 @@ func Start(config *Config) (*Server, func(), error) {
 				return nil, nil, err
 			}
 			resolvedAuth[resolvedKey] = alias
-			log.Info("Startfunction Configured traditional auth", "key", resolvedKey, "alias", alias)
 		}
 	}
 
@@ -347,10 +335,6 @@ func Start(config *Config) (*Server, func(), error) {
 
 		return NewMemoryFrontendRateLimit(dur, max)
 	}
-
-	log.Info("StartFunction Creating server with auth paths",
-		"resolvedAuth_nil", resolvedAuth == nil,
-		"config_auth_nil", config.Authentication == nil)
 
 	srv, err := NewServer(
 		backendGroups,

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -668,7 +668,7 @@ func (s *Server) performAuthCallback(r *http.Request, authURL string) (string, e
 
 	// Make the request
 	client := &http.Client{Timeout: 5 * time.Second}
-	log.Info("performAuthCallback making request", "authURL", authURL, "req", req)
+	log.Info("performAuthCallback making request", "authURL", authURL, "req URL Path", req.URL.Path)
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Error("performAuthCallback request failed", "err", err)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -51,11 +51,6 @@ const (
 
 var emptyArrayResponse = json.RawMessage("[]")
 
-var (
-	// Shared HTTP client for auth callbacks with 5 second timeout
-	authHTTPClient = &http.Client{Timeout: 5 * time.Second}
-)
-
 type AuthCallbackRequest struct {
 	Headers    map[string][]string `json:"headers"`
 	Path       string              `json:"path"`

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -672,19 +672,6 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 		log.Info("populateContext using traditional auth",
 			"auth_key", authorization,
 			"valid_keys", len(s.authenticatedPaths))
-
-		// Fallback to traditional auth
-		if authorization == "" || s.authenticatedPaths[authorization] == "" {
-			log.Info("populateContext blocked unauthorized request",
-				"auth_key", authorization,
-				"valid_keys_count", len(s.authenticatedPaths))
-			httpResponseCodesTotal.WithLabelValues("401").Inc()
-			w.WriteHeader(401)
-			return nil
-		}
-		log.Info("populateContext traditional auth succeeded",
-			"auth_key", authorization,
-			"alias", s.authenticatedPaths[authorization])
 		ctx = context.WithValue(ctx, ContextKeyAuth, s.authenticatedPaths[authorization]) // nolint:staticcheck
 	}
 	return context.WithValue(ctx, ContextKeyReqID, randStr(10)) // nolint:staticcheck

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -622,9 +622,12 @@ func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context.Context {
-	log.Info("populateContext authenticatedPaths",
-		"paths", s.authenticatedPaths,
-		"has_auth_url", s.authenticatedPaths["auth_url"] != "")
+	log.Info("populateContext detailed inspection",
+		"s ", s,
+		"auth_paths_nil", s.authenticatedPaths == nil,
+		"auth_paths_len", len(s.authenticatedPaths),
+		"all_keys", getMapKeys(s.authenticatedPaths),
+		"auth_url_exists", s.authenticatedPaths != nil && s.authenticatedPaths["auth_url"] != "")
 
 	vars := mux.Vars(r)
 	authorization := vars["authorization"]
@@ -959,4 +962,16 @@ func createBatchRequest(elems []batchElem) []*RPCReq {
 		batch[i] = elems[i].Req
 	}
 	return batch
+}
+
+// Helper function to get map keys
+func getMapKeys(m map[string]string) []string {
+	if m == nil {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -107,6 +107,10 @@ func NewServer(
 	maxBatchSize int,
 	limiterFactory limiterFactoryFunc,
 ) (*Server, error) {
+	log.Info("NewServer called",
+		"authenticatedPaths", authenticatedPaths,
+		"has_auth_url", authenticatedPaths["auth_url"] != "")
+
 	if cache == nil {
 		cache = &NoopRPCCache{}
 	}
@@ -618,6 +622,10 @@ func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context.Context {
+	log.Info("populateContext authenticatedPaths",
+		"paths", s.authenticatedPaths,
+		"has_auth_url", s.authenticatedPaths["auth_url"] != "")
+
 	vars := mux.Vars(r)
 	authorization := vars["authorization"]
 	xff := r.Header.Get(s.rateLimitHeader)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -658,7 +658,7 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 
 		ctx = context.WithValue(ctx, ContextKeyAuth, s.authenticatedPaths[authorization]) // nolint:staticcheck
 	}
-	return context.WithValue(ctx, ContextKeyReqID, randStr(10))
+	return context.WithValue(ctx, ContextKeyReqID, randStr(10)) // nolint:staticcheck
 }
 
 func (s *Server) performAuthCallback(r *http.Request, apiKey string) (string, error) {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -662,6 +662,23 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 }
 
 func (s *Server) performAuthCallback(r *http.Request, apiKey string) (string, error) {
+	// Stub authentication for testing
+	validKeys := []string{
+		"aayushi-key",
+		"v1KtFv89SKPFJhKcTlMWybsPAsfIVX3j",
+	}
+
+	// Check if apiKey matches any valid key
+	for _, validKey := range validKeys {
+		if apiKey == validKey {
+			return apiKey, nil
+		}
+	}
+
+	// Return unauthorized for any other key
+	return "", fmt.Errorf("unauthorized")
+
+	/* Original HTTP request logic commented out for now
 	if s.authURL == "" {
 		return "", fmt.Errorf("no auth URL configured")
 	}
@@ -688,6 +705,7 @@ func (s *Server) performAuthCallback(r *http.Request, apiKey string) (string, er
 	}
 
 	return apiKey, nil
+	*/
 }
 
 func randStr(l int) string {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -668,6 +668,7 @@ func (s *Server) performAuthCallback(r *http.Request, authURL string) (string, e
 
 	// Make the request
 	client := &http.Client{Timeout: 5 * time.Second}
+	log.Info("performAuthCallback making request", "authURL", authURL, "req", req)
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Error("performAuthCallback request failed", "err", err)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -625,7 +625,7 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 	authorization := vars["authorization"]
 	xff := r.Header.Get(s.rateLimitHeader)
 
-	log.Info("received request",
+	log.Info("populateContext received request",
 		"path", r.URL.Path,
 		"auth_key", authorization,
 		"auth_url_configured", s.authURL != "",
@@ -686,7 +686,7 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 }
 
 func (s *Server) performAuthCallback(r *http.Request, apiKey string) (string, error) {
-	log.Info("performing auth callback",
+	log.Info("performAuthCallback performing auth callback",
 		"api_key", apiKey)
 
 	if apiKey == "aayushi-key" {
@@ -886,11 +886,16 @@ func instrumentedHdlr(h http.Handler) http.HandlerFunc {
 }
 
 func GetAuthCtx(ctx context.Context) string {
-	authUser, ok := ctx.Value(ContextKeyAuth).(string)
-	if !ok {
+	if ctx == nil {
+		log.Info("GetAuthCtx called with nil context")
 		return "none"
 	}
-
+	authUser, ok := ctx.Value(ContextKeyAuth).(string)
+	if !ok {
+		log.Info("GetAuthCtx No auth value found in context")
+		return "none"
+	}
+	log.Info("GetAuthCtx Auth value found in context", "auth", authUser)
 	return authUser
 }
 

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -864,16 +864,10 @@ func instrumentedHdlr(h http.Handler) http.HandlerFunc {
 }
 
 func GetAuthCtx(ctx context.Context) string {
-	if ctx == nil {
-		log.Info("GetAuthCtx called with nil context")
-		return "none"
-	}
 	authUser, ok := ctx.Value(ContextKeyAuth).(string)
 	if !ok {
-		log.Info("GetAuthCtx No auth value found in context")
 		return "none"
 	}
-	log.Info("GetAuthCtx Auth value found in context", "auth", authUser)
 	return authUser
 }
 

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -644,11 +644,9 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 		// Use external authentication service
 		alias, err := s.performAuthCallback(r, authURL)
 		if err != nil || alias == "" { // Check both error and empty alias
-			log.Error("populateContext Auth callback failed", "err", err)
 			w.WriteHeader(http.StatusUnauthorized)
 			return nil
 		}
-		log.Info("populateContext Auth callback successful", "alias", alias)
 		ctx = context.WithValue(ctx, ContextKeyAuth, alias) // nolint:staticcheck
 	} else {
 		ctx = context.WithValue(ctx, ContextKeyAuth, s.authenticatedPaths[authorization]) // nolint:staticcheck
@@ -692,9 +690,6 @@ func (s *Server) performAuthCallback(r *http.Request, authURL string) (string, e
 
 	// Make the request
 	client := &http.Client{Timeout: 5 * time.Second}
-	log.Info("performAuthCallback making request",
-		"authURL", authURLWithToken,
-		"token", authorization)
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Error("performAuthCallback request failed", "err", err)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -939,15 +939,3 @@ func createBatchRequest(elems []batchElem) []*RPCReq {
 	}
 	return batch
 }
-
-// Helper function to get map keys
-func getMapKeys(m map[string]string) []string {
-	if m == nil {
-		return nil
-	}
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
-}

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -648,7 +648,7 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 		// Use external authentication service
 		alias, err := s.performAuthCallback(r, authURL)
 		if err != nil || alias == "" { // Check both error and empty alias
-			w.WriteHeader(http.StatusUnauthorized)
+			writeRPCError(ctx, w, nil, &RPCErr{Code: -32001, Message: "unauthorized"})
 			return nil
 		}
 		ctx = context.WithValue(ctx, ContextKeyAuth, alias) // nolint:staticcheck


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Implement authentication for RPC endpoints through authentication callback in proxyd. Proxyd will make an outgoing call to an auxiliary service for authentication instead of relying on hardcoded/environment values provided in the configuration file. 

- Adds performAuthCallback function
- Adds AuthCallbackRequest struct
- Modifies populateContext to use performAuthCallback when flagged
- Updates authentication configuration in Start function in proxyd.go to check if if auth_url is specified in the authentication map. If it is, use it to set authURL and pass it into the NewServer object.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
