### PR TITLE
feat(op-acceptor): Introduce run-once mode for CI use-cases, enable by default

### DIFF
--- a/op-acceptor/README.md
+++ b/op-acceptor/README.md
@@ -91,6 +91,17 @@ go run cmd/main.go \
   --validators validators.yaml \    # Path to the validator definitions
 ```
 
+By default, op-acceptor will run tests once and then exit, which is ideal for CI/CD pipelines and one-off testing.
+
+If you want to run tests periodically (for continuous monitoring), specify a run interval:
+```bash
+go run cmd/main.go \
+  --gate betanet \
+  --testdir ../../optimism/ \
+  --validators validators.yaml \
+  --run-interval=1h                 # Run tests every hour
+```
+
 Want to monitor your validation runs? Start our local monitoring stack:
 ```bash
 just start-monitoring  # Launches Prometheus and Grafana alongside op-acceptor

--- a/op-acceptor/cmd/main.go
+++ b/op-acceptor/cmd/main.go
@@ -64,7 +64,7 @@ func run(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, 
 
 	cfg.Log.Debug("Config", "config", cfg)
 
-	natService, err := nat.New(ctx.Context, cfg, Version)
+	natService, err := nat.New(ctx.Context, cfg, Version, closeApp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create nat: %w", err)
 	}

--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	TargetGate      string
 	GoBinary        string
 	RunInterval     time.Duration // Interval between test runs
+	RunOnce         bool          // Indicates if the service should exit after one test run
 
 	Log log.Logger
 }
@@ -48,12 +49,16 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 		return nil, fmt.Errorf("failed to get absolute path for validator config: %w", err)
 	}
 
+	runInterval := ctx.Duration(flags.RunInterval.Name)
+	runOnce := runInterval == 0
+
 	return &Config{
 		TestDir:         absTestDir,
 		ValidatorConfig: absValidatorConfig,
 		TargetGate:      gate,
 		GoBinary:        ctx.String(flags.GoBinary.Name),
-		RunInterval:     ctx.Duration(flags.RunInterval.Name),
+		RunInterval:     runInterval,
+		RunOnce:         runOnce,
 		Log:             log,
 	}, nil
 }

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -2,7 +2,6 @@ package flags
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/urfave/cli/v2"
 
@@ -44,9 +43,9 @@ var (
 	}
 	RunInterval = &cli.DurationFlag{
 		Name:    "run-interval",
-		Value:   time.Hour,
+		Value:   0,
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RUN_INTERVAL"),
-		Usage:   "Interval between test runs when running continuously (e.g. '1h', '30m')",
+		Usage:   "Interval between test runs (e.g. '1h', '30m'). Set to 0 or omit for run-once mode.",
 	}
 )
 


### PR DESCRIPTION
## Summary
This PR changes the default behavior of op-acceptor to run tests once and exit (run-once mode), rather than running continuously. The existing continuous mode is preserved by explicitly setting `--run-interval`.

## Motivation
In a CI or manual testing environment users want to run tests once, get results, and exit. The current default requires manual termination, which is inconvenient for those use-cases.

## Changes
- Changed default `--run-interval` from `1h` to `0` (run-once mode)
- Added `RunOnce` config field to track execution mode
- Modified `Start()` to handle run-once mode and trigger application shutdown
- Updated documentation and added test case

## Backward Compatibility
Users who need continuous execution can specify `--run-interval=1h` to maintain the same behavior.

## Testing
Implementation verified with unit tests, build validation, and linting.
