### PR TITLE
feat(op-acceptor): handle test panics

### DIFF
--- a/op-acceptor/cmd/main_test.go
+++ b/op-acceptor/cmd/main_test.go
@@ -2,60 +2,37 @@ package main_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/ethereum-optimism/infra/op-acceptor/exitcodes"
 	"github.com/stretchr/testify/require"
 )
 
 // TestExitCodeBehavior verifies that op-acceptor returns the correct exit codes in run-once mode:
 // - Exit code 0 when all tests pass
 // - Exit code 1 when any tests fail
-// - Exit code 2 when there's a runtime error (panic)
+// - Exit code 2 when there's a runtime error
 func TestExitCodeBehavior(t *testing.T) {
 	// Setup paths
 	cwd, err := os.Getwd()
 	require.NoError(t, err, "Failed to get current working directory")
-
 	projectRoot := filepath.Dir(cwd)
 
 	// Binary path
 	opAcceptorBin := filepath.Join(projectRoot, "bin", "op-acceptor")
-
-	// Build the binary if it doesn't exist
-	if !fileExists(opAcceptorBin) {
-		t.Logf("Building op-acceptor binary...")
-
-		// Create bin directory if needed
-		err = os.MkdirAll(filepath.Dir(opAcceptorBin), 0755)
-		require.NoError(t, err, "Failed to create directory for binary")
-
-		// Build the binary
-		buildCmd := exec.Command("go", "build", "-o", opAcceptorBin, filepath.Join(projectRoot, "cmd"))
-		var buildOutput bytes.Buffer
-		buildCmd.Stdout = &buildOutput
-		buildCmd.Stderr = &buildOutput
-
-		err = buildCmd.Run()
-		if err != nil {
-			t.Logf("Build output:\n%s", buildOutput.String())
-			t.Fatalf("Failed to build op-acceptor binary: %v", err)
-		}
-
-		t.Logf("Successfully built binary at %s", opAcceptorBin)
-	}
-
-	// Verify binary exists
-	require.FileExists(t, opAcceptorBin, "op-acceptor binary not found")
+	ensureBinaryExists(t, projectRoot, opAcceptorBin)
 
 	// Define test cases
 	testCases := []struct {
 		name           string
-		setupFunc      func(t *testing.T, testDir string) (gateID string, validatorPath string, inputTestDir string) // Function to set up test environment, returns gate and validator config
-		expectedStatus int                                                                                           // Expected exit code
+		setupFunc      func(t *testing.T, testDir string) (gateID string, validatorPath string, inputTestDir string)
+		expectedStatus int
 	}{
 		{
 			name: "Passing tests should exit with code 0",
@@ -67,11 +44,11 @@ func TestExitCodeBehavior(t *testing.T) {
 				// Create a simple passing test
 				createMockGoMod(t, testDir)
 				createMockTest(t, testDir, packageName, "passing_test.go", true)
-				validatorPath := createMockValidatorConfig(t, testDir, packageName, testName, gateID)
+				validatorPath := createValidatorConfig(t, testDir, packageName, testName, gateID, false)
 
 				return gateID, validatorPath, testDir
 			},
-			expectedStatus: 0,
+			expectedStatus: exitcodes.Success,
 		},
 		{
 			name: "Failing tests should exit with code 1",
@@ -83,11 +60,11 @@ func TestExitCodeBehavior(t *testing.T) {
 				// Create a simple failing test
 				createMockGoMod(t, testDir)
 				createMockTest(t, testDir, packageName, "failing_test.go", false)
-				validatorPath := createMockValidatorConfig(t, testDir, packageName, testName, gateID)
+				validatorPath := createValidatorConfig(t, testDir, packageName, testName, gateID, false)
 
 				return gateID, validatorPath, testDir
 			},
-			expectedStatus: 1,
+			expectedStatus: exitcodes.TestFailure,
 		},
 		{
 			name: "Runtime error should exit with code 2",
@@ -97,11 +74,29 @@ func TestExitCodeBehavior(t *testing.T) {
 				testName := "TestDoesNotExist"
 
 				// Create validator config that points to a non-existent directory
-				validatorPath := createMockInvalidValidatorConfig(t, testDir, "dummy", testName, gateID)
+				validatorPath := createValidatorConfig(t, testDir, "dummy", testName, gateID, true)
 
 				return gateID, validatorPath, nonExistentDir
 			},
-			expectedStatus: 2,
+			expectedStatus: exitcodes.RuntimeErr,
+		},
+		{
+			name: "Test with panic should exit with code 1",
+			setupFunc: func(t *testing.T, testDir string) (string, string, string) {
+				packageName := "panicking"
+				testName := "TestExplicitPanic"
+				gateID := "test-gate-panic"
+
+				// Create a test that deliberately panics
+				createMockGoMod(t, testDir)
+				createMockPanicTest(t, testDir, packageName, "panic_test.go")
+				validatorPath := createValidatorConfig(t, testDir, packageName, testName, gateID, false)
+
+				return gateID, validatorPath, testDir
+			},
+			// Go's test framework catches panics and treats them as test failures (exit code 1)
+			// rather than propagating them as runtime errors (exit code 2)
+			expectedStatus: exitcodes.TestFailure,
 		},
 	}
 
@@ -123,63 +118,91 @@ func TestExitCodeBehavior(t *testing.T) {
 	}
 }
 
+// ensureBinaryExists builds the op-acceptor binary if it doesn't exist
+func ensureBinaryExists(t *testing.T, projectRoot, binaryPath string) {
+	// Build the binary if it doesn't exist
+	if !fileExists(binaryPath) {
+		t.Logf("Building op-acceptor binary...")
+
+		// Create bin directory if needed
+		err := os.MkdirAll(filepath.Dir(binaryPath), 0755)
+		require.NoError(t, err, "Failed to create directory for binary")
+
+		// Build the binary
+		buildCmd := exec.Command("go", "build", "-o", binaryPath, filepath.Join(projectRoot, "cmd"))
+		var buildOutput bytes.Buffer
+		buildCmd.Stdout = &buildOutput
+		buildCmd.Stderr = &buildOutput
+
+		err = buildCmd.Run()
+		if err != nil {
+			t.Logf("Build output:\n%s", buildOutput.String())
+			t.Fatalf("Failed to build op-acceptor binary: %v", err)
+		}
+
+		t.Logf("Successfully built binary at %s", binaryPath)
+	}
+
+	// Verify binary exists
+	require.FileExists(t, binaryPath, "op-acceptor binary not found")
+}
+
 func createMockGoMod(t *testing.T, testDir string) {
-
-	// Create go.mod file for the test module
-	goModPath := filepath.Join(testDir, "go.mod")
-	goModContent := `module github.com/test/test
-
-go 1.20
-`
-
-	require.NoError(t, os.WriteFile(goModPath, []byte(goModContent), 0644))
+	// Initialize the module with go mod init
+	cmd := exec.Command("go", "mod", "init", "test")
+	cmd.Dir = testDir
+	require.NoError(t, cmd.Run(), "Failed to initialize module")
 }
 
 // createMockTest creates a test file that either passes or fails
 func createMockTest(t *testing.T, testDir, packageName, filename string, passing bool) string {
-
 	// Create package directory
 	packageDir := filepath.Join(testDir, packageName)
 	require.NoError(t, os.MkdirAll(packageDir, 0755))
 
 	// Create test file
 	testPath := filepath.Join(packageDir, filename)
-	var testContent string
 
+	// Use a template approach for test content
+	testTemplate := `package %s
+
+import "testing"
+
+func %s(t *testing.T) {
+	%s
+}
+`
+
+	var testName, testBody string
 	if passing {
-		testContent = fmt.Sprintf(`package %s
-
-import (
-	"testing"
-)
-
-func TestAlwaysPasses(t *testing.T) {
-	// This test will always pass
-}
-`, packageName)
+		testName = "TestAlwaysPasses"
+		testBody = "// This test will always pass"
 	} else {
-		testContent = fmt.Sprintf(`package %s
-
-import (
-	"testing"
-)
-
-func TestAlwaysFails(t *testing.T) {
-	// This test will always fail
-	t.Error("This test intentionally fails")
-}
-`, packageName)
+		testName = "TestAlwaysFails"
+		testBody = `t.Fatal("This test intentionally fails")`
 	}
 
-	fmt.Println("Writing test file to", testPath)
-	require.NoError(t, os.WriteFile(testPath, []byte(testContent), 0644))
+	testContent := fmt.Sprintf(testTemplate, packageName, testName, testBody)
+
+	t.Logf("Writing test file to %s", testPath)
+	writeFile(t, testPath, testContent)
 
 	return packageDir
 }
 
-// createMockValidatorConfig creates a validator configuration file
-func createMockValidatorConfig(t *testing.T, testDir, packageName, testName, gateID string) string {
+// Helper function to write files with error checking
+func writeFile(t *testing.T, path, content string) {
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644),
+		fmt.Sprintf("Failed to write file: %s", path))
+}
+
+// createValidatorConfig creates a validator configuration file
+// useInvalidPath can be set to true to create a config with an invalid path
+func createValidatorConfig(t *testing.T, testDir, packageName, testName, gateID string, useInvalidPath bool) string {
 	packageDir := filepath.Join(testDir, packageName)
+	if useInvalidPath {
+		packageDir = packageName // Use the raw name to create an invalid path
+	}
 
 	validatorPath := filepath.Join(testDir, "test-validators.yaml")
 	validatorConfig := fmt.Sprintf(`# Test validator configuration file for exit code testing
@@ -195,28 +218,7 @@ gates:
             package: %s
 `, gateID, testName, packageDir)
 
-	require.NoError(t, os.WriteFile(validatorPath, []byte(validatorConfig), 0644))
-	return validatorPath
-}
-
-// createMockInvalidValidatorConfig creates a validator configuration file with a non-existent package path
-// to simulate a runtime error
-func createMockInvalidValidatorConfig(t *testing.T, testDir, nonExistentPath, testName, gateID string) string {
-	validatorPath := filepath.Join(testDir, "test-validators.yaml")
-	validatorConfig := fmt.Sprintf(`# Test validator configuration file for exit code testing
-
-gates:
-  - id: %s
-    description: "Test gate for exit code testing"
-    suites:
-      test-suite:
-        description: "Test suite for exit code testing"
-        tests:
-          - name: %s
-            package: %s
-`, gateID, testName, nonExistentPath)
-
-	require.NoError(t, os.WriteFile(validatorPath, []byte(validatorConfig), 0644))
+	writeFile(t, validatorPath, validatorConfig)
 	return validatorPath
 }
 
@@ -224,18 +226,53 @@ gates:
 func runOpAcceptor(t *testing.T, binary, testdir, validators, gate string) int {
 	t.Logf("Running op-acceptor with testdir=%s, gate=%s, validators=%s", testdir, gate, validators)
 
-	cmd := exec.Command(binary,
-		"--run-interval=0",
+	// Create a command with timeout context
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	execCmd := exec.CommandContext(ctx, binary,
+		"--run-interval=0", // This ensures the process runs once and exits
 		"--gate="+gate,
 		"--testdir="+testdir,
 		"--validators="+validators)
 
-	err := cmd.Run()
-	exitCode := getExitCode(err)
+	// Capture output for debugging
+	var stdout, stderr bytes.Buffer
+	execCmd.Stdout = &stdout
+	execCmd.Stderr = &stderr
 
-	t.Logf("Exit code: %d", exitCode)
+	err := execCmd.Run()
 
-	return exitCode
+	// Log output regardless of success/failure
+	if stdout.Len() > 0 {
+		t.Logf("stdout:\n%s", stdout.String())
+	}
+	if stderr.Len() > 0 {
+		t.Logf("stderr:\n%s", stderr.String())
+	}
+
+	// Check if the context deadline was exceeded
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Logf("Command timed out")
+		// Kill the process if it's still running
+		if execCmd.Process != nil {
+			killErr := execCmd.Process.Kill()
+			if killErr != nil {
+				t.Logf("Failed to kill process: %v", killErr)
+			}
+		}
+		return exitcodes.RuntimeErr // Return error code for timeout
+	}
+
+	if err == nil {
+		return exitcodes.Success
+	}
+
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode()
+	}
+
+	return exitcodes.RuntimeErr // Return error code for unexpected errors
 }
 
 // Helper function to check if a file exists
@@ -244,15 +281,30 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-// Helper function to get the exit code from an exec.ExitError
-func getExitCode(err error) int {
-	if err == nil {
-		return 0
-	}
+// createMockPanicTest creates a test file that deliberately panics
+func createMockPanicTest(t *testing.T, testDir, packageName, filename string) string {
+	// Create package directory
+	packageDir := filepath.Join(testDir, packageName)
+	require.NoError(t, os.MkdirAll(packageDir, 0755))
 
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		return exitErr.ExitCode()
-	}
+	// Create test file
+	testPath := filepath.Join(packageDir, filename)
 
-	return -1 // Unknown error
+	// Test content with explicit panic
+	testContent := fmt.Sprintf(`package %s
+
+import (
+	"testing"
+)
+
+func TestExplicitPanic(t *testing.T) {
+	// This test will deliberately panic
+	panic("This is a deliberate panic to test error handling")
+}
+`, packageName)
+
+	t.Logf("Writing panic test file to %s", testPath)
+	writeFile(t, testPath, testContent)
+
+	return packageDir
 }

--- a/op-acceptor/errors.go
+++ b/op-acceptor/errors.go
@@ -1,0 +1,52 @@
+package nat
+
+import (
+	"errors"
+	"fmt"
+)
+
+// RuntimeError represents an operational error that should lead to exit code 2
+// Examples include configuration errors, file not found, etc.
+type RuntimeError struct {
+	Err error
+}
+
+func (e *RuntimeError) Error() string {
+	return fmt.Sprintf("runtime error: %v", e.Err)
+}
+
+// Unwrap implements the errors.Unwrap interface
+func (e *RuntimeError) Unwrap() error {
+	return e.Err
+}
+
+// NewRuntimeError creates a new RuntimeError
+func NewRuntimeError(err error) *RuntimeError {
+	return &RuntimeError{Err: err}
+}
+
+// IsRuntimeError checks if the error is or wraps a RuntimeError
+func IsRuntimeError(err error) bool {
+	var runtimeErr *RuntimeError
+	return err != nil && errors.As(err, &runtimeErr)
+}
+
+// TestFailureError represents a failure from test assertions (exit code 1)
+type TestFailureError struct {
+	Message string
+}
+
+func (e *TestFailureError) Error() string {
+	return fmt.Sprintf("test failure: %s", e.Message)
+}
+
+// NewTestFailureError creates a new TestFailureError
+func NewTestFailureError(message string) *TestFailureError {
+	return &TestFailureError{Message: message}
+}
+
+// IsTestFailureError checks if the error is or wraps a TestFailureError
+func IsTestFailureError(err error) bool {
+	var testErr *TestFailureError
+	return err != nil && errors.As(err, &testErr)
+}

--- a/op-acceptor/exitcodes/exitcodes.go
+++ b/op-acceptor/exitcodes/exitcodes.go
@@ -1,0 +1,15 @@
+// Package exitcodes defines the standard exit codes used by op-acceptor.
+package exitcodes
+
+// Exit code constants used by op-acceptor
+// These constants define the exit codes that the application uses to indicate
+// various states when it exits:
+//
+// * Success (0): Used when all tests pass successfully
+// * TestFailure (1): Used when one or more tests fail
+// * RuntimeErr (2): Used for runtime errors such as panics, timeouts or other failures
+const (
+	Success     = 0 // All tests pass
+	TestFailure = 1 // Test failures
+	RuntimeErr  = 2 // Runtime errors or timeouts
+)

--- a/op-acceptor/gandalf.go
+++ b/op-acceptor/gandalf.go
@@ -1,9 +1,16 @@
 package nat
 
-import "fmt"
+import (
+	"fmt"
+	"testing"
+)
 
 // printGandalf gatekeeps naughty network deployments
 func printGandalf() {
+	if testing.Testing() {
+		// skip when running tests
+		return
+	}
 	ysnp := `▗▖  ▗▖▗▄▖ ▗▖ ▗▖     ▗▄▄▖▗▖ ▗▖ ▗▄▖ ▗▖   ▗▖       ▗▖  ▗▖ ▗▄▖▗▄▄▄▖    ▗▄▄▖  ▗▄▖  ▗▄▄▖ ▗▄▄▖
  ▝▚▞▘▐▌ ▐▌▐▌ ▐▌    ▐▌   ▐▌ ▐▌▐▌ ▐▌▐▌   ▐▌       ▐▛▚▖▐▌▐▌ ▐▌ █      ▐▌ ▐▌▐▌ ▐▌▐▌   ▐▌   
   ▐▌ ▐▌ ▐▌▐▌ ▐▌     ▝▀▚▖▐▛▀▜▌▐▛▀▜▌▐▌   ▐▌       ▐▌ ▝▜▌▐▌ ▐▌ █      ▐▛▀▘ ▐▛▀▜▌ ▝▀▚▖ ▝▀▚▖


### PR DESCRIPTION
**Description**

* Handle potential test panics to safeguard the remainder of the tests
* Defines the CLIs exit codes and reuses them throughout main and tests
* Simplifies some of the testing code in which we create go packages & code

**Metadata**

- Implements https://github.com/ethereum-optimism/infra/issues/241