### PR TITLE
fix(op-acceptor): Log metrics indicating test runtime errors

### DIFF
--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -338,13 +338,16 @@ func (r *runner) RunTest(metadata types.ValidatorMetadata) (*types.TestResult, e
 		result, err = r.runSingleTest(metadata)
 	}
 
+	var status types.TestStatus
 	if result != nil {
 		result.Duration = time.Since(start)
-
-		// TODO: handle network
-		// https://github.com/ethereum-optimism/infra/issues/193
-		metrics.RecordValidation("todo", r.runID, metadata.ID, metadata.Type.String(), result.Status)
+		status = result.Status
+	} else {
+		status = types.TestStatusError
 	}
+	// TODO: handle network
+	// https://github.com/ethereum-optimism/infra/issues/193
+	metrics.RecordValidation("todo", r.runID, metadata.ID, metadata.Type.String(), status)
 
 	return result, err
 }

--- a/op-acceptor/types/test.go
+++ b/op-acceptor/types/test.go
@@ -9,9 +9,10 @@ import (
 type TestStatus string
 
 const (
-	TestStatusPass TestStatus = "pass"
-	TestStatusFail TestStatus = "fail"
-	TestStatusSkip TestStatus = "skip"
+	TestStatusPass  TestStatus = "pass"
+	TestStatusFail  TestStatus = "fail"
+	TestStatusSkip  TestStatus = "skip"
+	TestStatusError TestStatus = "error"
 )
 
 // TestResult captures the outcome of a single test run


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Originally this PR fixed the following failure so that it can be debugged:

https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/84706/workflows/32915bdd-8fd5-4a3b-892d-5dc3e058a7da/jobs/3365063/parallel-runs/0/steps/0-109

Now just ensures metrics are updated to reflect test failure.