### PR TITLE
feat(op-acceptor): better test error logging

### DIFF
--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -12,16 +12,16 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// Config holds the configuration for the Network Acceptance Tester.
 type Config struct {
+	Log             log.Logger
 	TestDir         string
 	ValidatorConfig string
-	TargetGate      string
+	RunInterval     time.Duration
+	RunOnce         bool
 	GoBinary        string
-	RunInterval     time.Duration // Interval between test runs
-	RunOnce         bool          // Indicates if the service should exit after one test run
-	AllowSkips      bool          // Allow tests to be skipped instead of failing when preconditions are not met
-
-	Log log.Logger
+	TargetGate      string
+	AllowSkips      bool
 }
 
 // NewConfig creates a new Config instance

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -49,9 +49,9 @@ var (
 	}
 	AllowSkips = &cli.BoolFlag{
 		Name:    "allow-skips",
+		Usage:   "Allow tests to be skipped when preconditions aren't met",
 		Value:   false,
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "ALLOW_SKIPS"),
-		Usage:   "Allow tests to be skipped instead of failing when preconditions are not met.",
 	}
 )
 


### PR DESCRIPTION
**Description**

Runner makes a best-effort attempt to extract the pertinent error message for failing tests.
This is a temporary solution; will replace it with something better.

Sample output:
```
Gate: holocene (8.5s)
├── Status: fail
├── Tests: 1 passed, 3 failed, 0 skipped
├── Test: TestFindRPCEndpoints (2.2s) [status=pass]
├── Test: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/fjord (6.3s) [status=fail]
│       └── Error: Failed tests:
Test TestCheckFjordScript failed: exit status 1
    systest.go:185: precondition not met: no available wallet with balance of at least of 1000000
Test TestFees failed: exit status 1
    systest.go:185: precondition not met: no available wallet with balance of at least of 1000000000000000000
│       │       ├── Test: TestCheckFjordScript (0.0s) [status=fail]
│       │       └── Error: exit status 1
    systest.go:185: precondition not met: no available wallet with balance of at least of 1000000
│       │       └── Test: TestFees (0.0s) [status=fail]
│       │       └── Error: exit status 1
    systest.go:185: precondition not met: no available wallet with balance of at least of 1000000000000000000
```
