### PR TITLE
Fix op-conductor-ops docker builds

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -452,7 +452,7 @@ workflows:
           docker_file: op-conductor-ops/Dockerfile
           docker_name: op-conductor-ops
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: op-conductor-ops
+          docker_context: .
   op-signer:
     when:
       or: [<< pipeline.parameters.run-build-op-signer >>, << pipeline.parameters.run-all >>]

--- a/op-conductor-ops/Dockerfile
+++ b/op-conductor-ops/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:$PATH"
 
 # Copy only the dependency files initially to leverage Docker caching
-COPY pyproject.toml poetry.lock* ./
+COPY /op-conductor-ops/pyproject.toml /op-conductor-ops/poetry.lock* ./
 
 # Configure Poetry to not use virtualenvs inside the container
 RUN poetry config virtualenvs.create false
@@ -24,7 +24,7 @@ RUN poetry config virtualenvs.create false
 RUN poetry install --no-interaction --no-ansi
 
 # Copy the rest of the application
-COPY . .
+COPY /op-conductor-ops/ .
 
 # Set permissions for the executable
 RUN chmod +x op-conductor-ops


### PR DESCRIPTION
Build context must be root dir for docker-release job