### PR TITLE
fix(op-signer): fix disabling TLS

### DIFF
--- a/op-signer/app.go
+++ b/op-signer/app.go
@@ -141,6 +141,8 @@ func (s *SignerApp) initRPC(cfg *Config) error {
 		}
 
 		httpOptions = append(httpOptions, httputil.WithServerTLS(serverTlsConfig))
+	} else {
+		s.log.Warn("TLS disabled. This is insecure and only supported for local development. Please enable TLS in production environments!")
 	}
 
 	rpcCfg := cfg.RPCConfig

--- a/op-signer/app.go
+++ b/op-signer/app.go
@@ -67,7 +67,7 @@ func (s *SignerApp) init(cfg *Config) error {
 		return fmt.Errorf("metrics error: %w", err)
 	}
 	if err := s.initRPC(cfg); err != nil {
-		return fmt.Errorf("metrics error: %w", err)
+		return fmt.Errorf("rpc error: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
**Description**

`op-signer` supports enabling and disabling TLS via command line or env vars

```shell
$ go run cmd/main.go -h
    # ...
    --tls.enabled                       (default: true)                    ($OP_SIGNER_TLS_ENABLED)
          Enable or disable TLS client authentication for the signer
``` 

But disabling TLS would log an error and incorrectly refer to metrics

```shell
$ go run cmd/main.go 
t=2025-03-24T15:06:19+0800 lvl=crit msg="Application failed" message="failed to setup: metrics error: failed to read tls ca cert: "
exit status 1
```

This PR fixes support for disabling TLS and corrects the log message. I have also added a warning to inform users that disabling TLS is insecure and should only be done to support local dev. 

**Tests**

`op-signer` now runs with TLS disabled

```shell
$ go run cmd/main.go 
WARN [03-24|15:07:44.730] TLS disabled. This is insecure and only supported for local development. Please enable TLS in production environments!
DEBUG[03-24|15:07:44.730] Creating RPC handler
DEBUG[03-24|15:07:44.730] loading key from path                    keyPath=tls/ec_private.pem
DEBUG[03-24|15:07:44.730] parsing private key                      keyPath=tls/ec_private.pem
DEBUG[03-24|15:07:44.730] decoded PEM block                        keyPath=tls/ec_private.pem type="EC PRIVATE KEY"
DEBUG[03-24|15:07:44.730] failed to parse as SEC1 key, attempting ASN.1 parsing keyPath=tls/ec_private.pem error="x509: unknown elliptic curve"
DEBUG[03-24|15:07:44.730] successfully parsed private key          keyPath=tls/ec_private.pem curve=
INFO [03-24|15:07:44.730] loaded private key                       keyPath=tls/ec_private.pem address=0x057381c05B888060F26d1eeC1EfB5d3601252f4d
INFO [03-24|15:07:44.730] registered API                           route= namespace=eth
INFO [03-24|15:07:44.730] registered API                           route= namespace=opsigner
INFO [03-24|15:07:44.740] Started RPC server                       endpoint=http://[::]:8080
INFO [03-24|15:07:44.740] Started op-signer RPC server             addr=[::]:8080
```

