### PR TITLE
Add timeout configuration support

### DIFF
--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	RunInterval     time.Duration // Interval between test runs
 	RunOnce         bool          // Indicates if the service should exit after one test run
 	AllowSkips      bool          // Allow tests to be skipped instead of failing when preconditions are not met
+	DefaultTimeout  time.Duration // Default timeout for individual tests, can be overridden by test config
 
 	Log log.Logger
 }
@@ -53,6 +54,8 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 	runInterval := ctx.Duration(flags.RunInterval.Name)
 	runOnce := runInterval == 0
 
+	defaultTimeout := ctx.Duration(flags.DefaultTimeout.Name)
+
 	return &Config{
 		TestDir:         absTestDir,
 		ValidatorConfig: absValidatorConfig,
@@ -62,5 +65,6 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 		RunOnce:         runOnce,
 		AllowSkips:      ctx.Bool(flags.AllowSkips.Name),
 		Log:             log,
+		DefaultTimeout:  defaultTimeout,
 	}, nil
 }

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/urfave/cli/v2"
 
@@ -53,6 +54,12 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "ALLOW_SKIPS"),
 		Usage:   "Allow tests to be skipped instead of failing when preconditions are not met.",
 	}
+	DefaultTimeout = &cli.DurationFlag{
+		Name:    "default-timeout",
+		Value:   5 * time.Minute,
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "DEFAULT_TIMEOUT"),
+		Usage:   "Default timeout of an individual test (e.g. '30s', '5m', etc.). This setting is superseded by test or suite level timeout configuration. Set to '0' to disable any default timeout. Defaults to '5m'.",
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -65,6 +72,7 @@ var optionalFlags = []cli.Flag{
 	GoBinary,
 	RunInterval,
 	AllowSkips,
+	DefaultTimeout,
 }
 var Flags []cli.Flag
 

--- a/op-acceptor/justfile
+++ b/op-acceptor/justfile
@@ -38,3 +38,6 @@ start-monitoring:
 # Stop prometheus and grafana
 stop-monitoring:
     docker compose -f 'docker-compose.yml' down
+
+lint:
+    golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -48,6 +48,7 @@ func New(ctx context.Context, config *Config, version string, shutdownCallback f
 	reg, err := registry.NewRegistry(registry.Config{
 		Log:                 config.Log,
 		ValidatorConfigFile: config.ValidatorConfig,
+		DefaultTimeout:      config.DefaultTimeout,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create registry: %w", err)

--- a/op-acceptor/registry/registry.go
+++ b/op-acceptor/registry/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/ethereum-optimism/infra/op-acceptor/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -21,6 +22,7 @@ type Registry struct {
 type Config struct {
 	Log                 log.Logger
 	ValidatorConfigFile string
+	DefaultTimeout      time.Duration
 }
 
 // NewRegistry creates a new registry instance
@@ -200,6 +202,14 @@ func (r *Registry) discoverTestsInConfig(configs []types.TestConfig, gateID stri
 	var tests []types.ValidatorMetadata
 
 	for _, cfg := range configs {
+
+		var timeout time.Duration
+		if cfg.Timeout != nil {
+			timeout = *cfg.Timeout
+		} else {
+			timeout = r.config.DefaultTimeout
+		}
+
 		// If only package is specified (no name), treat it as "run all"
 		if cfg.Name == "" {
 			tests = append(tests, types.ValidatorMetadata{
@@ -209,6 +219,7 @@ func (r *Registry) discoverTestsInConfig(configs []types.TestConfig, gateID stri
 				Package: cfg.Package,
 				RunAll:  true,
 				Type:    types.ValidatorTypeTest,
+				Timeout: timeout,
 			})
 			continue
 		}
@@ -221,6 +232,7 @@ func (r *Registry) discoverTestsInConfig(configs []types.TestConfig, gateID stri
 			FuncName: cfg.Name,
 			Package:  cfg.Package,
 			Type:     types.ValidatorTypeTest,
+			Timeout:  timeout,
 		})
 	}
 

--- a/op-acceptor/types/test.go
+++ b/op-acceptor/types/test.go
@@ -27,9 +27,10 @@ type TestResult struct {
 
 // TestConfig represents a test configuration
 type TestConfig struct {
-	Name    string `yaml:"name,omitempty"`
-	Package string `yaml:"package"`
-	RunAll  bool   `yaml:"run_all,omitempty"`
+	Name    string         `yaml:"name,omitempty"`
+	Package string         `yaml:"package"`
+	RunAll  bool           `yaml:"run_all,omitempty"`
+	Timeout *time.Duration `yaml:"timeout,omitempty"`
 }
 
 // GetTestDisplayName returns a formatted display name for a test based on its name and metadata

--- a/op-acceptor/types/validator.go
+++ b/op-acceptor/types/validator.go
@@ -33,7 +33,7 @@ type ValidatorMetadata struct {
 	Suite    string
 	FuncName string
 	Package  string
-	Timeout  string
+	Timeout  time.Duration
 	RunAll   bool
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds the ability to configure the timeout of an individual test or test package, and also adds the ability to update the default test timeout for an op-acceptor startup invocation via CLI.

**Tests**

I've tested the command building.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #261 
