### PR TITLE
feat(op-acceptor): file-based test logging.

### DIFF
--- a/op-acceptor/.gitignore
+++ b/op-acceptor/.gitignore
@@ -1,3 +1,4 @@
 bin
+logs
 **/testdata/grafana-data
 **/testdata/prometheus-data

--- a/op-acceptor/README.md
+++ b/op-acceptor/README.md
@@ -116,6 +116,33 @@ Want to monitor your validation runs? Start our local monitoring stack:
 just start-monitoring  # Launches Prometheus and Grafana alongside op-acceptor
 ```
 
+### Log Management
+
+By default, test output from all tests is saved to log files, while only test results summaries are shown in the terminal. This makes the output much more manageable, especially when running many tests.
+
+Test logs are saved in a timestamped directory under the log directory path. The default log directory is `logs`, but you can specify a custom location:
+
+```bash
+go run cmd/main.go \
+  --gate interop \
+  --testdir ../../optimism/ \
+  --validators validators.yaml \
+  --logdir /path/to/logs          # Custom log directory
+```
+
+Each test run creates a directory with the following structure:
+```
+testrun-<run-id>/
+├── tests/               # All test logs, including passing tests
+├── failed/              # Just the logs for failed tests (hard links)
+└── summary.log          # Overall test run summary
+```
+
+In CI environments, you can easily access all failed test logs with:
+```bash
+cat /path/to/logs/testrun-*/failed/*
+```
+
 ### Create a release
 Releases are created by pushing tags which triggers a CircleCI pipeline.
 One simply needs to create an annotated tag (with a semantic version) and push it.

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -60,6 +60,12 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "DEFAULT_TIMEOUT"),
 		Usage:   "Default timeout of an individual test (e.g. '30s', '5m', etc.). This setting is superseded by test or suite level timeout configuration. Set to '0' to disable any default timeout. Defaults to '5m'.",
 	}
+	LogDir = &cli.StringFlag{
+		Name:    "logdir",
+		Value:   "logs",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "LOGDIR"),
+		Usage:   "Directory to store test logs. Defaults to 'logs' if not specified.",
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -73,6 +79,7 @@ var optionalFlags = []cli.Flag{
 	RunInterval,
 	AllowSkips,
 	DefaultTimeout,
+	LogDir,
 }
 var Flags []cli.Flag
 

--- a/op-acceptor/logging/filelogger.go
+++ b/op-acceptor/logging/filelogger.go
@@ -1,0 +1,683 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum-optimism/infra/op-acceptor/types"
+)
+
+// ResultSink is an interface for different ways of consuming test results
+type ResultSink interface {
+	// Consume processes a single test result
+	Consume(result *types.TestResult, runID string) error
+	// Complete is called when all results have been consumed
+	Complete(runID string) error
+}
+
+// FileLogger handles writing test output to files
+type FileLogger struct {
+	baseDir      string                // Base directory for logs
+	logDir       string                // Root log directory
+	failedDir    string                // Directory for failed tests
+	summaryFile  string                // Path to the summary file
+	allLogsFile  string                // Path to the combined log file
+	mu           sync.Mutex            // Protects concurrent file operations
+	sinks        []ResultSink          // Collection of result consumers
+	resultBuffer []*types.TestResult   // Buffer for storing results
+	asyncWriters map[string]*AsyncFile // Map of async file writers
+}
+
+// AsyncFile provides non-blocking file writing capabilities
+type AsyncFile struct {
+	file    *os.File
+	queue   chan []byte
+	wg      sync.WaitGroup
+	mu      sync.Mutex
+	stopped bool
+}
+
+// NewAsyncFile creates a new AsyncFile for non-blocking writes
+func NewAsyncFile(filepath string) (*AsyncFile, error) {
+	file, err := os.Create(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file %s: %w", filepath, err)
+	}
+
+	af := &AsyncFile{
+		file:  file,
+		queue: make(chan []byte, 100), // Buffer channel to reduce blocking
+	}
+
+	// Start the background writer
+	af.wg.Add(1)
+	go af.processQueue()
+
+	return af, nil
+}
+
+// Write queues data to be written asynchronously
+func (af *AsyncFile) Write(data []byte) error {
+	af.mu.Lock()
+	defer af.mu.Unlock()
+
+	if af.stopped {
+		return fmt.Errorf("async file is closed")
+	}
+
+	// Make a copy of the data to avoid race conditions
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+
+	// Send data to the queue
+	af.queue <- dataCopy
+	return nil
+}
+
+// processQueue processes the write queue in the background
+func (af *AsyncFile) processQueue() {
+	defer af.wg.Done()
+
+	for data := range af.queue {
+		_, err := af.file.Write(data)
+		if err != nil {
+			// Log the error but continue processing
+			fmt.Fprintf(os.Stderr, "Error writing to file: %v\n", err)
+		}
+	}
+}
+
+// Close stops the async writer and closes the file
+func (af *AsyncFile) Close() error {
+	af.mu.Lock()
+	if !af.stopped {
+		af.stopped = true
+		close(af.queue)
+	}
+	af.mu.Unlock()
+
+	// Wait for all writes to complete
+	af.wg.Wait()
+	return af.file.Close()
+}
+
+// NewFileLogger creates a new file logger with the specified base directory and runID
+// The runID must be provided, otherwise an error is returned
+func NewFileLogger(baseDir string, runID string) (*FileLogger, error) {
+	if runID == "" {
+		return nil, fmt.Errorf("runID is required")
+	}
+
+	dirName := fmt.Sprintf("testrun-%s", runID)
+	runDir := filepath.Join(baseDir, dirName)
+	failDir := filepath.Join(runDir, "failed")
+
+	// Create directories
+	dirs := []string{
+		runDir,
+		filepath.Join(runDir, "tests"),
+		failDir,
+	}
+
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	logger := &FileLogger{
+		baseDir:      runDir,
+		logDir:       baseDir,
+		failedDir:    failDir,
+		summaryFile:  filepath.Join(runDir, "summary.log"),
+		allLogsFile:  filepath.Join(runDir, "all.log"),
+		asyncWriters: make(map[string]*AsyncFile),
+		resultBuffer: make([]*types.TestResult, 0),
+	}
+
+	// Add default sinks
+	logger.sinks = append(logger.sinks, &IndividualTestFileSink{logger: logger})
+	logger.sinks = append(logger.sinks, &AllLogsFileSink{logger: logger})
+	logger.sinks = append(logger.sinks, &ConciseSummarySink{logger: logger})
+
+	return logger, nil
+}
+
+// getAsyncWriter gets or creates an AsyncFile for the given path
+func (l *FileLogger) getAsyncWriter(path string) (*AsyncFile, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Check if we already have a writer for this path
+	if writer, ok := l.asyncWriters[path]; ok {
+		return writer, nil
+	}
+
+	// Create a new writer
+	writer, err := NewAsyncFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store it for future use
+	l.asyncWriters[path] = writer
+	return writer, nil
+}
+
+// closeAllWriters closes all async writers
+func (l *FileLogger) closeAllWriters() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for _, writer := range l.asyncWriters {
+		_ = writer.Close() // Ignore errors on close
+	}
+	l.asyncWriters = make(map[string]*AsyncFile)
+}
+
+// GetDirectoryForRunID returns the path for a specific runID
+// The runID must be provided, otherwise an error is returned
+func (l *FileLogger) GetDirectoryForRunID(runID string) (string, error) {
+	if runID == "" {
+		return "", fmt.Errorf("runID is required")
+	}
+	return filepath.Join(l.logDir, fmt.Sprintf("testrun-%s", runID)), nil
+}
+
+// LogTestResult processes a test result through all registered sinks
+// If runID is provided, it will log to that specific run directory
+func (l *FileLogger) LogTestResult(result *types.TestResult, runID string) error {
+	if runID == "" {
+		return fmt.Errorf("runID is required")
+	}
+
+	// Store the result in the buffer
+	l.mu.Lock()
+	l.resultBuffer = append(l.resultBuffer, result)
+	l.mu.Unlock()
+
+	// Process the result through all sinks
+	for _, sink := range l.sinks {
+		if err := sink.Consume(result, runID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// LogSummary writes a summary of the test run to a file
+// The runID must be provided, otherwise an error is returned
+func (l *FileLogger) LogSummary(summary string, runID string) error {
+	if runID == "" {
+		return fmt.Errorf("runID is required")
+	}
+
+	// Use the specified runID directory
+	baseDir, err := l.GetDirectoryForRunID(runID)
+	if err != nil {
+		return err
+	}
+
+	// Create the directory if it doesn't exist
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", baseDir, err)
+	}
+
+	// Get the async writer for the summary file
+	summaryFile := filepath.Join(baseDir, "summary.log")
+	writer, err := l.getAsyncWriter(summaryFile)
+	if err != nil {
+		return err
+	}
+
+	// Write the summary
+	return writer.Write([]byte(summary))
+}
+
+// Complete finalizes all sinks and closes all file writers
+func (l *FileLogger) Complete(runID string) error {
+	if runID == "" {
+		return fmt.Errorf("runID is required")
+	}
+
+	// Notify all sinks that we're done
+	for _, sink := range l.sinks {
+		if err := sink.Complete(runID); err != nil {
+			return err
+		}
+	}
+
+	// Close all async writers
+	l.closeAllWriters()
+	return nil
+}
+
+// GetBaseDir returns the base directory for this test run
+func (l *FileLogger) GetBaseDir() string {
+	return l.baseDir
+}
+
+// GetFailedDir returns the directory containing logs for failed tests
+func (l *FileLogger) GetFailedDir() string {
+	return l.failedDir
+}
+
+// GetSummaryFile returns the path to the summary file
+func (l *FileLogger) GetSummaryFile() string {
+	return l.summaryFile
+}
+
+// GetAllLogsFile returns the path to the all logs file
+func (l *FileLogger) GetAllLogsFile() string {
+	return l.allLogsFile
+}
+
+// GetFailedDirForRunID returns the failed directory for a specific runID
+// The runID must be provided, otherwise an error is returned
+func (l *FileLogger) GetFailedDirForRunID(runID string) (string, error) {
+	if runID == "" {
+		return "", fmt.Errorf("runID is required")
+	}
+	baseDir, err := l.GetDirectoryForRunID(runID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(baseDir, "failed"), nil
+}
+
+// GetSummaryFileForRunID returns the summary file for a specific runID
+// The runID must be provided, otherwise an error is returned
+func (l *FileLogger) GetSummaryFileForRunID(runID string) (string, error) {
+	if runID == "" {
+		return "", fmt.Errorf("runID is required")
+	}
+	baseDir, err := l.GetDirectoryForRunID(runID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(baseDir, "summary.log"), nil
+}
+
+// GetAllLogsFileForRunID returns the all logs file for a specific runID
+// The runID must be provided, otherwise an error is returned
+func (l *FileLogger) GetAllLogsFileForRunID(runID string) (string, error) {
+	if runID == "" {
+		return "", fmt.Errorf("runID is required")
+	}
+	baseDir, err := l.GetDirectoryForRunID(runID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(baseDir, "all.log"), nil
+}
+
+// Helper functions
+
+// safeFilename converts a string to a safe filename by replacing problematic characters
+func safeFilename(s string) string {
+	// Replace characters that might be problematic in filenames
+	s = strings.ReplaceAll(s, "/", "_")
+	s = strings.ReplaceAll(s, "\\", "_")
+	s = strings.ReplaceAll(s, ":", "_")
+	s = strings.ReplaceAll(s, "*", "_")
+	s = strings.ReplaceAll(s, "?", "_")
+	s = strings.ReplaceAll(s, "\"", "_")
+	s = strings.ReplaceAll(s, "<", "_")
+	s = strings.ReplaceAll(s, ">", "_")
+	s = strings.ReplaceAll(s, "|", "_")
+	s = strings.ReplaceAll(s, " ", "_")
+	s = strings.ReplaceAll(s, "...", "")
+	return s
+}
+
+// getReadableTestFilename generates a more user-friendly filename for a test
+// It formats package names to be more concise and keeps test names readable
+func getReadableTestFilename(metadata types.ValidatorMetadata) string {
+	var fileName string
+
+	// Use the function name as the base
+	if metadata.FuncName != "" {
+		fileName = metadata.FuncName
+	} else if metadata.RunAll {
+		// For package tests that run all tests
+		fileName = "AllTests"
+	} else {
+		fileName = metadata.ID // Fallback to ID if no function name
+	}
+
+	// Extract package basename for cleaner filenames
+	pkgName := ""
+	if metadata.Package != "" {
+		// Handle GitHub-style package paths
+		if strings.Contains(metadata.Package, "github.com") {
+			// For github.com/org/repo/pkg/subpkg -> extract the last part
+			parts := strings.Split(metadata.Package, "/")
+			if len(parts) > 0 {
+				// Use the last path component but avoid empty strings
+				for i := len(parts) - 1; i >= 0; i-- {
+					if parts[i] != "" {
+						pkgName = parts[i]
+						break
+					}
+				}
+			}
+		} else {
+			// For other package paths, use the same approach
+			pkgParts := strings.Split(metadata.Package, "/")
+			if len(pkgParts) > 0 {
+				// Use the last path component but avoid empty strings
+				for i := len(pkgParts) - 1; i >= 0; i-- {
+					if pkgParts[i] != "" {
+						pkgName = pkgParts[i]
+						break
+					}
+				}
+			} else {
+				pkgName = metadata.Package
+			}
+		}
+	}
+
+	// Add gate and/or suite for context when present
+	prefix := ""
+	if metadata.Gate != "" && metadata.Suite != "" {
+		prefix = fmt.Sprintf("%s-%s", metadata.Gate, metadata.Suite)
+	} else if metadata.Gate != "" {
+		prefix = metadata.Gate
+	} else if metadata.Suite != "" {
+		prefix = metadata.Suite
+	}
+
+	// Build the final filename with appropriate components
+	var nameBuilder strings.Builder
+
+	if prefix != "" {
+		nameBuilder.WriteString(prefix)
+		nameBuilder.WriteString("_")
+	}
+
+	if pkgName != "" {
+		nameBuilder.WriteString(pkgName)
+		nameBuilder.WriteString("_")
+	}
+
+	nameBuilder.WriteString(fileName)
+
+	// Finally ensure the name is safe for a filename
+	return safeFilename(nameBuilder.String())
+}
+
+// Sink implementations
+
+// IndividualTestFileSink writes each test result to its own file
+type IndividualTestFileSink struct {
+	logger *FileLogger
+}
+
+// Consume writes a test result to a dedicated file
+func (s *IndividualTestFileSink) Consume(result *types.TestResult, runID string) error {
+	// Use the specified runID directory
+	baseDir, err := s.logger.GetDirectoryForRunID(runID)
+	if err != nil {
+		return err
+	}
+	failedDir := filepath.Join(baseDir, "failed")
+
+	// Create directories if they don't exist
+	dirs := []string{
+		baseDir,
+		filepath.Join(baseDir, "tests"),
+		failedDir,
+	}
+
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	// Generate a safe filename based on the test metadata
+	filename := getReadableTestFilename(result.Metadata)
+
+	// Full path to the test log file
+	testFilePath := filepath.Join(baseDir, "tests", filename+".log")
+
+	// Get or create the async writer
+	writer, err := s.logger.getAsyncWriter(testFilePath)
+	if err != nil {
+		return err
+	}
+
+	// Prepare the log content
+	var content strings.Builder
+	fmt.Fprintf(&content, "Test: %s\n", result.Metadata.FuncName)
+	fmt.Fprintf(&content, "Package: %s\n", result.Metadata.Package)
+	fmt.Fprintf(&content, "Status: %s\n", result.Status)
+	fmt.Fprintf(&content, "Duration: %s\n", result.Duration)
+	fmt.Fprintf(&content, "Gate: %s\n", result.Metadata.Gate)
+	fmt.Fprintf(&content, "Suite: %s\n", result.Metadata.Suite)
+	fmt.Fprintf(&content, "---------------------------------------------------\n\n")
+
+	// Write error if any
+	if result.Error != nil {
+		fmt.Fprintf(&content, "ERROR: %s\n\n", result.Error.Error())
+	}
+
+	// Write stdout/stderr output
+	if result.Stdout != "" {
+		fmt.Fprintf(&content, "STDOUT:\n%s\n", result.Stdout)
+	}
+
+	// Write the content to the file
+	if err := writer.Write([]byte(content.String())); err != nil {
+		return err
+	}
+
+	// If test failed, create a link in the failed directory
+	if result.Status == types.TestStatusFail {
+		failedFilePath := filepath.Join(failedDir, filename+".log")
+
+		// For failed tests, we'll create the file directly for simplicity
+		// instead of using a hard link which might not work across different filesystems
+		if err := os.WriteFile(failedFilePath, []byte(content.String()), 0644); err != nil {
+			return fmt.Errorf("failed to write failed test log: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Complete is a no-op for IndividualTestFileSink
+func (s *IndividualTestFileSink) Complete(runID string) error {
+	return nil
+}
+
+// AllLogsFileSink writes all test results to a single "all.log" file
+type AllLogsFileSink struct {
+	logger *FileLogger
+}
+
+// Consume writes a test result to the all.log file
+func (s *AllLogsFileSink) Consume(result *types.TestResult, runID string) error {
+	// Get the all.log file path for this runID
+	allLogsFile, err := s.logger.GetAllLogsFileForRunID(runID)
+	if err != nil {
+		return err
+	}
+
+	// Get or create the async writer
+	writer, err := s.logger.getAsyncWriter(allLogsFile)
+	if err != nil {
+		return err
+	}
+
+	// Use a cleaner, more structured format that's easier to read for large outputs
+	var content strings.Builder
+
+	// Create a clear header with visual distinction
+	fmt.Fprintf(&content, "\n")
+	fmt.Fprintf(&content, "┌─────────────────────────────────────────────────────────────────────┐\n")
+	fmt.Fprintf(&content, "│ TEST: %-64s │\n", truncateString(result.Metadata.FuncName, 64))
+	fmt.Fprintf(&content, "├─────────────────────────────────────────────────────────────────────┤\n")
+
+	// Add test metadata in a structured format
+	fmt.Fprintf(&content, "│ Status:   %-62s │\n", result.Status)
+	fmt.Fprintf(&content, "│ Package:  %-62s │\n", truncateString(result.Metadata.Package, 62))
+	fmt.Fprintf(&content, "│ Gate:     %-62s │\n", truncateString(result.Metadata.Gate, 62))
+	fmt.Fprintf(&content, "│ Suite:    %-62s │\n", truncateString(result.Metadata.Suite, 62))
+	fmt.Fprintf(&content, "│ Duration: %-62s │\n", result.Duration)
+	fmt.Fprintf(&content, "│ Time:     %-62s │\n", time.Now().Format(time.RFC3339))
+	fmt.Fprintf(&content, "└─────────────────────────────────────────────────────────────────────┘\n\n")
+
+	// Add error and stdout in clearly marked sections
+	if result.Error != nil {
+		fmt.Fprintf(&content, "ERROR:\n")
+		fmt.Fprintf(&content, "~~~~~~\n")
+		fmt.Fprintf(&content, "%s\n\n", result.Error.Error())
+	}
+
+	if result.Stdout != "" {
+		fmt.Fprintf(&content, "STDOUT:\n")
+		fmt.Fprintf(&content, "~~~~~~~\n")
+		// Indent the stdout for better readability
+		indentedOutput := indentText(result.Stdout, "  ")
+		fmt.Fprintf(&content, "%s\n", indentedOutput)
+	}
+
+	// Add a clear separator at the end
+	fmt.Fprintf(&content, "\n")
+
+	// Write the content to the file
+	return writer.Write([]byte(content.String()))
+}
+
+// indentText adds indentation to each line of text for better readability
+func indentText(text, indent string) string {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = indent + line
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// truncateString truncates a string to the specified max length
+// and adds an ellipsis if needed
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// Complete is a no-op for AllLogsFileSink
+func (s *AllLogsFileSink) Complete(runID string) error {
+	return nil
+}
+
+// ConciseSummarySink creates a concise summary in summary.log
+type ConciseSummarySink struct {
+	logger      *FileLogger
+	passed      int
+	failed      int
+	skipped     int
+	errored     int
+	startTime   time.Time
+	failedTests []string
+}
+
+// Consume updates the summary statistics
+func (s *ConciseSummarySink) Consume(result *types.TestResult, runID string) error {
+	// Initialize start time if this is the first result
+	if s.startTime.IsZero() {
+		s.startTime = time.Now()
+	}
+
+	// Update statistics based on test status
+	switch result.Status {
+	case types.TestStatusPass:
+		s.passed++
+	case types.TestStatusFail:
+		s.failed++
+		// Keep track of failed tests for the summary
+		testName := result.Metadata.FuncName
+		if result.Metadata.Package != "" {
+			testName = fmt.Sprintf("%s.%s", result.Metadata.Package, testName)
+		}
+		s.failedTests = append(s.failedTests, testName)
+	case types.TestStatusSkip:
+		s.skipped++
+	case types.TestStatusError:
+		s.errored++
+		// Keep track of errored tests too
+		testName := result.Metadata.FuncName
+		if result.Metadata.Package != "" {
+			testName = fmt.Sprintf("%s.%s", result.Metadata.Package, testName)
+		}
+		s.failedTests = append(s.failedTests, testName+" (ERROR)")
+	}
+
+	return nil
+}
+
+// Complete generates and writes the final summary
+func (s *ConciseSummarySink) Complete(runID string) error {
+	// Get the summary file path for this runID
+	summaryFile, err := s.logger.GetSummaryFileForRunID(runID)
+	if err != nil {
+		return err
+	}
+
+	// Get or create the async writer
+	writer, err := s.logger.getAsyncWriter(summaryFile)
+	if err != nil {
+		return err
+	}
+
+	// Calculate totals and duration
+	total := s.passed + s.failed + s.skipped + s.errored
+	duration := time.Since(s.startTime)
+
+	// Build the concise summary
+	var summary strings.Builder
+	fmt.Fprintf(&summary, "TEST SUMMARY\n")
+	fmt.Fprintf(&summary, "============\n")
+	fmt.Fprintf(&summary, "Run ID: %s\n", runID)
+	fmt.Fprintf(&summary, "Time: %s\n", time.Now().Format(time.RFC3339))
+	fmt.Fprintf(&summary, "Duration: %s\n\n", duration)
+
+	fmt.Fprintf(&summary, "Results:\n")
+	fmt.Fprintf(&summary, "  Total:   %d\n", total)
+	fmt.Fprintf(&summary, "  Passed:  %d\n", s.passed)
+	fmt.Fprintf(&summary, "  Failed:  %d\n", s.failed)
+	fmt.Fprintf(&summary, "  Skipped: %d\n", s.skipped)
+	fmt.Fprintf(&summary, "  Errors:  %d\n\n", s.errored)
+
+	// Add pass rate percentage
+	passRate := 0.0
+	if total > 0 {
+		passRate = float64(s.passed) / float64(total) * 100
+	}
+	fmt.Fprintf(&summary, "Pass Rate: %.1f%%\n\n", passRate)
+
+	// Include a list of failed tests if there are any
+	if len(s.failedTests) > 0 {
+		fmt.Fprintf(&summary, "Failed tests:\n")
+		for _, test := range s.failedTests {
+			fmt.Fprintf(&summary, "  - %s\n", test)
+		}
+		fmt.Fprintf(&summary, "\n")
+	}
+
+	// Add location of the detailed logs
+	fmt.Fprintf(&summary, "Full details: see %s\n", s.logger.GetAllLogsFile())
+
+	// Write the summary
+	return writer.Write([]byte(summary.String()))
+}

--- a/op-acceptor/logging/filelogger_test.go
+++ b/op-acceptor/logging/filelogger_test.go
@@ -1,0 +1,361 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/infra/op-acceptor/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileLogger(t *testing.T) {
+	// Create a temporary directory for test logs
+	tmpDir, err := os.MkdirTemp("", "filelogger_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a new FileLogger with a valid runID
+	runID := "test-run-123"
+	logger, err := NewFileLogger(tmpDir, runID)
+	require.NoError(t, err)
+
+	// Verify the directory structure
+	baseDir := logger.GetBaseDir()
+	assert.DirExists(t, baseDir)
+	assert.DirExists(t, filepath.Join(baseDir, "tests"))
+	assert.DirExists(t, filepath.Join(baseDir, "failed"))
+
+	// Create multiple test results
+	passResult := &types.TestResult{
+		Metadata: types.ValidatorMetadata{
+			ID:       "pass-test-id",
+			Gate:     "test-gate",
+			Suite:    "test-suite",
+			FuncName: "TestPassingFunction",
+			Package:  "github.com/example/package",
+		},
+		Status:   types.TestStatusPass,
+		Duration: time.Second * 2,
+		Stdout:   "Passing test stdout content",
+	}
+
+	failResult := &types.TestResult{
+		Metadata: types.ValidatorMetadata{
+			ID:       "fail-test-id",
+			Gate:     "test-gate",
+			Suite:    "test-suite",
+			FuncName: "TestFailingFunction",
+			Package:  "github.com/example/package",
+		},
+		Status:   types.TestStatusFail,
+		Error:    assert.AnError,
+		Duration: time.Second * 1,
+		Stdout:   "Failing test stdout content",
+	}
+
+	skipResult := &types.TestResult{
+		Metadata: types.ValidatorMetadata{
+			ID:       "skip-test-id",
+			Gate:     "test-gate",
+			Suite:    "test-suite",
+			FuncName: "TestSkippedFunction",
+			Package:  "github.com/example/package",
+		},
+		Status:   types.TestStatusSkip,
+		Duration: time.Millisecond * 500,
+		Stdout:   "Skipped test stdout content",
+	}
+
+	// Log the test results
+	err = logger.LogTestResult(passResult, runID)
+	require.NoError(t, err)
+
+	err = logger.LogTestResult(failResult, runID)
+	require.NoError(t, err)
+
+	err = logger.LogTestResult(skipResult, runID)
+	require.NoError(t, err)
+
+	// Complete the logging process
+	err = logger.Complete(runID)
+	require.NoError(t, err)
+
+	// Wait a short time to ensure async writes complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify individual test log files exist
+	expectedPassFilename := filepath.Join(baseDir, "tests", "test-gate-test-suite_package_TestPassingFunction.log")
+	assert.FileExists(t, expectedPassFilename)
+
+	expectedFailFilename := filepath.Join(baseDir, "tests", "test-gate-test-suite_package_TestFailingFunction.log")
+	assert.FileExists(t, expectedFailFilename)
+
+	expectedSkipFilename := filepath.Join(baseDir, "tests", "test-gate-test-suite_package_TestSkippedFunction.log")
+	assert.FileExists(t, expectedSkipFilename)
+
+	// Check that a copy of the failing test exists in the failed directory
+	expectedFailedCopyFilename := filepath.Join(baseDir, "failed", "test-gate-test-suite_package_TestFailingFunction.log")
+	assert.FileExists(t, expectedFailedCopyFilename)
+
+	// Verify all.log file exists
+	allLogsFile := logger.GetAllLogsFile()
+	assert.FileExists(t, allLogsFile)
+
+	// Verify summary file exists
+	summaryFile := logger.GetSummaryFile()
+	assert.FileExists(t, summaryFile)
+
+	// Read the content of all.log to verify it contains entries for all tests
+	allLogsContent, err := os.ReadFile(allLogsFile)
+	require.NoError(t, err)
+	allLogsContentStr := string(allLogsContent)
+
+	// Check that all.log contains all test results with the new format
+	assert.Contains(t, allLogsContentStr, "TEST: TestPassingFunction")
+	assert.Contains(t, allLogsContentStr, "Status:   pass")
+	assert.Contains(t, allLogsContentStr, "TEST: TestFailingFunction")
+	assert.Contains(t, allLogsContentStr, "Status:   fail")
+	assert.Contains(t, allLogsContentStr, "TEST: TestSkippedFunction")
+	assert.Contains(t, allLogsContentStr, "Status:   skip")
+
+	// Read the content of summary.log to verify it's concise
+	summaryContent, err := os.ReadFile(summaryFile)
+	require.NoError(t, err)
+	summaryContentStr := string(summaryContent)
+
+	// Check that the summary contains the right statistics
+	assert.Contains(t, summaryContentStr, "TEST SUMMARY")
+	assert.Contains(t, summaryContentStr, "Total:   3")
+	assert.Contains(t, summaryContentStr, "Passed:  1")
+	assert.Contains(t, summaryContentStr, "Failed:  1")
+	assert.Contains(t, summaryContentStr, "Skipped: 1")
+	assert.Contains(t, summaryContentStr, "Failed tests:")
+	assert.Contains(t, summaryContentStr, "github.com/example/package.TestFailingFunction")
+}
+
+func TestLoggerWithEmptyRunID(t *testing.T) {
+	// Create a temporary directory for test logs
+	tmpDir, err := os.MkdirTemp("", "filelogger_empty_runid_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Test that an error is returned when an empty runID is provided to NewFileLogger
+	_, err = NewFileLogger(tmpDir, "")
+	assert.Error(t, err, "Expected error when creating logger with empty runID")
+	assert.Contains(t, err.Error(), "runID is required")
+
+	// Create a valid logger to test the LogTestResult with empty runID
+	logger, err := NewFileLogger(tmpDir, "valid-run-id")
+	require.NoError(t, err)
+
+	// Create a test result
+	testResult := &types.TestResult{
+		Metadata: types.ValidatorMetadata{
+			FuncName: "TestFunction",
+		},
+		Status: types.TestStatusPass,
+	}
+
+	// Test that an error is returned when an empty runID is provided to LogTestResult
+	err = logger.LogTestResult(testResult, "")
+	assert.Error(t, err, "Expected error when logging with empty runID")
+	assert.Contains(t, err.Error(), "runID is required")
+
+	// Test that an error is returned when an empty runID is provided to LogSummary
+	err = logger.LogSummary("Summary", "")
+	assert.Error(t, err, "Expected error when logging summary with empty runID")
+	assert.Contains(t, err.Error(), "runID is required")
+
+	// Test that an error is returned when an empty runID is provided to Complete
+	err = logger.Complete("")
+	assert.Error(t, err, "Expected error when completing with empty runID")
+	assert.Contains(t, err.Error(), "runID is required")
+}
+
+func TestLoggingWithRunID(t *testing.T) {
+	// Create a temporary directory for test logs
+	tmpDir, err := os.MkdirTemp("", "filelogger_runid_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a new FileLogger with a valid runID
+	defaultRunID := "default-run-id"
+	logger, err := NewFileLogger(tmpDir, defaultRunID)
+	require.NoError(t, err)
+
+	// We'll use a different runID for this test
+	differentRunID := "different-run-id"
+
+	// Create a test result
+	testResult := &types.TestResult{
+		Metadata: types.ValidatorMetadata{
+			ID:       "test-id",
+			Gate:     "test-gate",
+			Suite:    "test-suite",
+			FuncName: "TestFunction",
+			Package:  "github.com/example/package",
+		},
+		Status:   types.TestStatusPass,
+		Duration: time.Second * 2,
+		Stdout:   "Test stdout content with runID",
+	}
+
+	// Log the test result with a different runID
+	err = logger.LogTestResult(testResult, differentRunID)
+	require.NoError(t, err)
+
+	// Complete the logging process
+	err = logger.Complete(differentRunID)
+	require.NoError(t, err)
+
+	// Wait a short time to ensure async writes complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Get the directory for the runID
+	runIDDir, err := logger.GetDirectoryForRunID(differentRunID)
+	require.NoError(t, err)
+
+	// Verify the directory structure was created
+	assert.DirExists(t, runIDDir)
+	assert.DirExists(t, filepath.Join(runIDDir, "tests"))
+	assert.DirExists(t, filepath.Join(runIDDir, "failed"))
+
+	// Verify that the runID is used in the directory name
+	expectedDirName := filepath.Join(tmpDir, "testrun-"+differentRunID)
+	assert.Equal(t, expectedDirName, runIDDir)
+
+	// Verify the test log file exists in the runID directory
+	expectedFilename := filepath.Join(runIDDir, "tests", "test-gate-test-suite_package_TestFunction.log")
+	assert.FileExists(t, expectedFilename)
+
+	// Verify all.log file exists for this runID
+	allLogsFile, err := logger.GetAllLogsFileForRunID(differentRunID)
+	require.NoError(t, err)
+	assert.FileExists(t, allLogsFile)
+
+	// Verify summary file exists and contains expected content
+	summaryFilePath, err := logger.GetSummaryFileForRunID(differentRunID)
+	require.NoError(t, err)
+	assert.FileExists(t, summaryFilePath)
+
+	// Test error cases for directory methods with empty runID
+	_, err = logger.GetDirectoryForRunID("")
+	assert.Error(t, err, "Expected error when getting directory with empty runID")
+	assert.Contains(t, err.Error(), "runID is required")
+
+	_, err = logger.GetFailedDirForRunID("")
+	assert.Error(t, err, "Expected error when getting failed directory with empty runID")
+	assert.Contains(t, err.Error(), "runID is required")
+
+	_, err = logger.GetSummaryFileForRunID("")
+	assert.Error(t, err, "Expected error when getting summary file with empty runID")
+	assert.Contains(t, err.Error(), "runID is required")
+
+	_, err = logger.GetAllLogsFileForRunID("")
+	assert.Error(t, err, "Expected error when getting all logs file with empty runID")
+	assert.Contains(t, err.Error(), "runID is required")
+}
+
+func TestAsyncFileWriter(t *testing.T) {
+	// Create a temporary directory
+	tmpDir, err := os.MkdirTemp("", "asyncfile_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a test file path
+	testFilePath := filepath.Join(tmpDir, "async_test.log")
+
+	// Create a new AsyncFile
+	asyncFile, err := NewAsyncFile(testFilePath)
+	require.NoError(t, err)
+
+	// Write some data
+	testData := []byte("Test async write 1\n")
+	err = asyncFile.Write(testData)
+	require.NoError(t, err)
+
+	// Write more data
+	testData2 := []byte("Test async write 2\n")
+	err = asyncFile.Write(testData2)
+	require.NoError(t, err)
+
+	// Close the file
+	err = asyncFile.Close()
+	require.NoError(t, err)
+
+	// Wait a short time to ensure async writes complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify the file exists and contains both writes
+	content, err := os.ReadFile(testFilePath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(content), "Test async write 1")
+	assert.Contains(t, string(content), "Test async write 2")
+
+	// Test writing to a closed AsyncFile
+	err = asyncFile.Write([]byte("This should fail"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "async file is closed")
+}
+
+func TestCustomResultSink(t *testing.T) {
+	// Create a temporary directory for test logs
+	tmpDir, err := os.MkdirTemp("", "custom_sink_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a new FileLogger with a valid runID
+	runID := "custom-sink-test"
+	logger, err := NewFileLogger(tmpDir, runID)
+	require.NoError(t, err)
+
+	// Create a custom sink for testing
+	customSink := &testCustomSink{
+		results: make([]*types.TestResult, 0),
+	}
+
+	// Add the custom sink to the logger
+	logger.sinks = append(logger.sinks, customSink)
+
+	// Create a test result
+	testResult := &types.TestResult{
+		Metadata: types.ValidatorMetadata{
+			FuncName: "TestCustomSink",
+			Package:  "github.com/example/package",
+		},
+		Status: types.TestStatusPass,
+	}
+
+	// Log the test result
+	err = logger.LogTestResult(testResult, runID)
+	require.NoError(t, err)
+
+	// Complete logging
+	err = logger.Complete(runID)
+	require.NoError(t, err)
+
+	// Verify the custom sink received the result
+	assert.Equal(t, 1, len(customSink.results))
+	assert.Equal(t, "TestCustomSink", customSink.results[0].Metadata.FuncName)
+	assert.True(t, customSink.completed)
+}
+
+// Custom sink for testing
+type testCustomSink struct {
+	results   []*types.TestResult
+	completed bool
+}
+
+func (s *testCustomSink) Consume(result *types.TestResult, runID string) error {
+	s.results = append(s.results, result)
+	return nil
+}
+
+func (s *testCustomSink) Complete(runID string) error {
+	s.completed = true
+	return nil
+}

--- a/op-acceptor/nat_test.go
+++ b/op-acceptor/nat_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/infra/op-acceptor/logging"
 	"github.com/ethereum-optimism/infra/op-acceptor/runner"
 	"github.com/ethereum-optimism/infra/op-acceptor/types"
 )
@@ -90,15 +91,21 @@ func setupTest(t *testing.T) (*trackedMockRunner, *nat, context.Context, context
 	// Create a basic logger
 	logger := log.New()
 
+	// Set up a mock file logger
+	mockFileLogger, err := logging.NewFileLogger(t.TempDir(), "test-run-id")
+	require.NoError(t, err)
+
 	// Create service with the mock
 	service := &nat{
 		ctx: ctx,
 		config: &Config{
 			Log:         logger,
 			RunInterval: 25 * time.Millisecond, // Short interval for testing
+			LogDir:      t.TempDir(),
 		},
-		runner: mockRunner,
-		done:   make(chan struct{}),
+		runner:     mockRunner,
+		fileLogger: mockFileLogger,
+		done:       make(chan struct{}),
 	}
 
 	return mockRunner, service, ctx, cancel

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -107,7 +107,6 @@ func NewTestRunner(cfg Config) (TestRunner, error) {
 		cfg.Log = log.New()
 		cfg.Log.Error("No logger provided, using default")
 	}
-	cfg.Log.Info("NewTestRunner()", "targetGate", cfg.TargetGate, "workDir", cfg.WorkDir, "allowSkips", cfg.AllowSkips)
 
 	var validators []types.ValidatorMetadata
 	if len(cfg.TargetGate) > 0 {
@@ -122,6 +121,8 @@ func NewTestRunner(cfg Config) (TestRunner, error) {
 	if cfg.GoBinary == "" {
 		cfg.GoBinary = "go" // Default to "go" if not specified
 	}
+
+	cfg.Log.Debug("NewTestRunner()", "targetGate", cfg.TargetGate, "workDir", cfg.WorkDir, "allowSkips", cfg.AllowSkips, "goBinary", cfg.GoBinary)
 
 	return &runner{
 		registry:   cfg.Registry,


### PR DESCRIPTION
**Description**

This makes op-acceptor output/results easier to interpret at a glance.

- Introduce a file-based logger (fileLogger)
- Remove stdout/stderr logging of tests from op-acceptor's output
- Use fileLogger to log test stdout/stderr to files instead

**Visuals**
<img width="1218" alt="Screenshot 2025-04-01 at 13 18 24" src="https://github.com/user-attachments/assets/bbde67b2-ec24-4d0e-8834-91134bb23deb" />

```
$ ls -lah logs/testrun-29e9d82f-0007-47ae-940b-475fa5e229aa 
total 32
drwxr-xr-x@ 6 stefano  staff   192B Apr  2 14:27 .
drwxr-xr-x@ 4 stefano  staff   128B Apr  2 14:27 ..
-rw-r--r--@ 1 stefano  staff    10K Apr  2 14:27 all.log
drwxr-xr-x@ 3 stefano  staff    96B Apr  2 14:27 failed
-rw-r--r--@ 1 stefano  staff   428B Apr  2 14:27 summary.log
drwxr-xr-x@ 4 stefano  staff   128B Apr  2 14:27 tests


$ cat logs/testrun-29e9d82f-0007-47ae-940b-475fa5e229aa/summary.log 
TEST SUMMARY
============
Run ID: 29e9d82f-0007-47ae-940b-475fa5e229aa
Time: 2025-04-02T14:27:00+11:00
Duration: 434.667µs

Results:
  Total:   2
  Passed:  1
  Failed:  1
  Skipped: 0
  Errors:  0

Pass Rate: 50.0%

Failed tests:
  - github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/....

Full details: see /Users/stefano/code/infra/op-acceptor/logs/testrun-29e9d82f-0007-47ae-940b-475fa5e229aa/all.log
```

<details>
<summary>cat logs/testrun-e4328c5c-5756-49b2-bd41-b6908ced3c2d/summary.log</summary>
<p>

```bash
$ cat logs/testrun-e4328c5c-5756-49b2-bd41-b6908ced3c2d/summary.log

Test Run Results (22.7s):
Total: 13, Passed: 4, Failed: 9, Skipped: 0

Gate: isthmus (22.7s)
├── Status: fail
├── Tests: 4 passed, 9 failed, 0 skipped
├── Test: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/... (20.4s) [status=fail]
│       └── Error: TestERC20Bridge: === RUN   TestERC20Bridge
    systest.go:185: precondition not met: no available wallet with balance of at least of 1000000000000000000
--- FAIL: TestERC20Bridge (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.444s
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.701s

TestPectra: FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.386s
=== RUN   TestPectra
--- FAIL: TestPectra (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.719s

TestWithdrawalsRoot: === RUN   TestWithdrawalsRoot
    systest.go:185: precondition not met: no available wallet with balance of at least of 1000000000000000000
--- FAIL: TestWithdrawalsRoot (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.394s
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.701s

TestBalanceSnapshot_String: === RUN   TestBalanceSnapshot_String
--- PASS: TestBalanceSnapshot_String (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.384s
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.703s

TestBalanceSnapshot_Add: === RUN   TestBalanceSnapshot_Add
--- PASS: TestBalanceSnapshot_Add (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.398s
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.746s

TestBalanceSnapshot_Sub: FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.393s
=== RUN   TestBalanceSnapshot_Sub
--- PASS: TestBalanceSnapshot_Sub (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.723s

TestAssertSnapshotsEqual: FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.386s
=== RUN   TestAssertSnapshotsEqual
--- PASS: TestAssertSnapshotsEqual (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.698s

TestOperatorFee: FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.393s
=== RUN   TestOperatorFee
    operator_fee_test.go:29:    INFO [04-01|13:25:23.403] Starting operator fee test               chain=0
    operator_fee_test.go:35:    INFO [04-01|13:25:23.403] Acquired test wallets with funds
    operator_fee_test.go:40:    INFO [04-01|13:25:23.403] Running system test                      fork=Isthmus nodes=2
    systest.go:185: precondition not met: no available wallet with balance of at least of 1000000000000000000
--- FAIL: TestOperatorFee (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.671s

│       │       ├── Test: TestBalanceSnapshot_String (0.7s) [status=fail]
│       │       └── Error: === RUN   TestBalanceSnapshot_String
--- PASS: TestBalanceSnapshot_String (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.384s
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.703s

│       │       ├── Test: TestBalanceSnapshot_Add (0.7s) [status=fail]
│       │       └── Error: === RUN   TestBalanceSnapshot_Add
--- PASS: TestBalanceSnapshot_Add (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.398s
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.746s

│       │       ├── Test: TestBalanceSnapshot_Sub (0.7s) [status=fail]
│       │       └── Error: FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.393s
=== RUN   TestBalanceSnapshot_Sub
--- PASS: TestBalanceSnapshot_Sub (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.723s

│       │       ├── Test: TestAssertSnapshotsEqual (0.7s) [status=fail]
│       │       └── Error: FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.386s
=== RUN   TestAssertSnapshotsEqual
--- PASS: TestAssertSnapshotsEqual (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.698s

│       │       ├── Test: TestOperatorFee (0.7s) [status=fail]
│       │       └── Error: FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.393s
=== RUN   TestOperatorFee
    operator_fee_test.go:29:    INFO [04-01|13:25:23.403] Starting operator fee test               chain=0
    operator_fee_test.go:35:    INFO [04-01|13:25:23.403] Acquired test wallets with funds
    operator_fee_test.go:40:    INFO [04-01|13:25:23.403] Running system test                      fork=Isthmus nodes=2
    systest.go:185: precondition not met: no available wallet with balance of at least of 1000000000000000000
--- FAIL: TestOperatorFee (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.671s

│       │       ├── Test: TestERC20Bridge (0.7s) [status=fail]
│       │       └── Error: === RUN   TestERC20Bridge
    systest.go:185: precondition not met: no available wallet with balance of at least of 1000000000000000000
--- FAIL: TestERC20Bridge (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.444s
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.701s

│       │       ├── Test: TestPectra (0.7s) [status=fail]
│       │       └── Error: FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.386s
=== RUN   TestPectra
--- FAIL: TestPectra (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.719s

│       │       └── Test: TestWithdrawalsRoot (0.7s) [status=fail]
│       │       └── Error: === RUN   TestWithdrawalsRoot
    systest.go:185: precondition not met: no available wallet with balance of at least of 1000000000000000000
--- FAIL: TestWithdrawalsRoot (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus 0.394s
FAIL
FAIL    github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee    0.701s

├── Test: TestFindRPCEndpoints (2.3s) [status=pass]
│       └── Error: ?    github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/engine   [no test files]
?       github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/fake     [no test files]
?       github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/interfaces       [no test files]
?       github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/wrappers [no test files]
?       github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/deployer/cmd [no test files]
?       github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/depset       [no test files]
?       github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/inspect      [no test files]
?       github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/inspect/cmd  [no test files]
?       github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/interfaces   [no test files]
?       github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/jwt  [no test files]
?       github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/jwt/cmd      [no test files]
=== RUN   TestFindRPCEndpoints
--- PASS: TestFindRPCEndpoints (0.00s)
PASS
ok      github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis      0.534s
testing: warning: no tests to run
PASS
ok      github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/run      0.767s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/spec 0.824s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/deployer     1.254s [no tests to run]

│       │       ├── Test: TestFindRPCEndpoints/find_L1_endpoints (0.0s) [status=pass]
│       │       └── Error: === RUN   TestFindRPCEndpoints/find_L1_endpoints

    --- PASS: TestFindRPCEndpoints/find_L1_endpoints (0.00s)

│       │       ├── Test: TestFindRPCEndpoints/find_op-kurtosis_L2_endpoints (0.0s) [status=pass]
│       │       └── Error: === RUN   TestFindRPCEndpoints/find_op-kurtosis_L2_endpoints

    --- PASS: TestFindRPCEndpoints/find_op-kurtosis_L2_endpoints (0.00s)

│       │       └── Test: TestFindRPCEndpoints/custom_host_in_endpoint (0.0s) [status=pass]
│       │       └── Error: === RUN   TestFindRPCEndpoints/custom_host_in_endpoint

    --- PASS: TestFindRPCEndpoints/custom_host_in_endpoint (0.00s)
```
</p>
</details>

**Metadata**

- Fixes https://github.com/ethereum-optimism/infra/issues/246
