### PR TITLE
fix(op-acceptor): don't run N*N tests

### DIFF
--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -467,6 +467,7 @@ func (r *runner) runTestList(metadata types.ValidatorMetadata, testNames []strin
 	for _, testName := range testNames {
 		// Create a new metadata with the specific test name
 		testMetadata := metadata
+		testMetadata.RunAll = false
 		testMetadata.FuncName = testName
 
 		// Run the individual test


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This fixes an issue where specifying test packages result in all N
tests in that package running N times each.

Coming from the package specification, RunAll=true

But then we omitted to set it to false for runSingleTest, which
skipped specifying the "-run Test..." part of the command line
invocation, effectively running all the tests in the package
