### PR TITLE
explicitly handle some backend responses so we don't mark as unservic…

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1429,47 +1429,33 @@ func (bg *BackendGroup) ForwardRequestToBackendGroup(
 			res, err = back.Forward(ctx, rpcReqs, isBatch)
 
 			// below are errors that we explicitly handle so that we don't
-			// want to mark this request as unserviceable (unserviceable
-			// requests indicate a problem with our backends, but there is
-			// nothing wrong with our backends in this case)
+			// mark this request as unserviceable (unserviceable requests
+			// indicate a problem with our backends, but there is nothing
+			// wrong with our backends for these errors)
 
 			if errors.Is(err, ErrConsensusGetReceiptsCantBeBatched) ||
 				errors.Is(err, ErrConsensusGetReceiptsInvalidTarget) ||
+				// context canceled happens when either the client cancels the request
+				// or proxyd cancels the request. Proxyd only cancels requests when
+				// the server is shutting down, so this must be the client cancelling
+				// the request.
+				errors.Is(err, context.Canceled) {
+				return &BackendGroupRPCResponse{
+					RPCRes:   nil,
+					ServedBy: "",
+					error:    err,
+				}
+			}
+
+			if errors.Is(err, ErrBackendResponseTooLarge) ||
+				// we check for "request body too large" when first serving a request,
+				// so this is a special case where the backend has its own rules around
+				// request body size and returns a 413 error. We've seen this with quicknode
+				errors.Is(err, ErrRequestBodyTooLarge) ||
 				errors.Is(err, ErrMethodNotWhitelisted) {
 				return &BackendGroupRPCResponse{
 					RPCRes:   nil,
-					ServedBy: "",
-					error:    err,
-				}
-			}
-			if errors.Is(err, ErrBackendResponseTooLarge) {
-				return &BackendGroupRPCResponse{
-					RPCRes:   nil,
-					ServedBy: "",
-					error:    err,
-				}
-			}
-			// we check for "request body too large" when first serving a request,
-			// so this is a special case where the backend has its own rules around
-			// request body size and returns a 413 error. We've seen this with quicknode
-			if errors.Is(err, ErrRequestBodyTooLarge) {
-				return &BackendGroupRPCResponse{
-					RPCRes:   nil,
 					ServedBy: servedBy,
-					error:    err,
-				}
-			}
-			// context canceled happens when either the client cancels the request
-			// or proxyd cancels the request. Proxyd only cancels requests when
-			// the server is shutting down, so this must be the client cancelling
-			// the request.
-			//
-			// We catch this error here so that we don't mark this request as
-			// unserviceable
-			if errors.Is(err, context.Canceled) {
-				return &BackendGroupRPCResponse{
-					RPCRes:   nil,
-					ServedBy: "",
 					error:    err,
 				}
 			}


### PR DESCRIPTION
…eable

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

I added handling for additional error types from our backends so that we can reduce the number of unserviceable requests.

**Tests**

I couldn't find any existing tests for this functionality, and it's not adding new functionality (but rather constraining existing functionality)

**Additional context**

After some closer looks at how we handle unserviceable requests in proxyd, and the error logs that involve unserviceable requests, I think handling these 2 types of errors will eliminate 2 of the 3 main categories of unserviceable requests we (Unichain) see. The 3rd category involves problems with how we deploy and swap out old backends with new backends, and we will not handle that PR here.
