### PR TITLE
fix(ci): path-filtering version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@1.0.0
+  path-filtering: circleci/path-filtering@1.3.0
 
 workflows:
   check-updated-files:


### PR DESCRIPTION
**Description**

Bumps path-filtering to 1.3.0.
Attempts to use python3.9 instead of 3.8 as path-filtering no longer supports 3.8. ([context](https://github.com/CircleCI-Public/path-filtering-orb/pull/110))

Should fix the build issues such as:
https://app.circleci.com/pipelines/github/ethereum-optimism/infra/1146/workflows/f3759614-0671-4d65-85b9-79056ed9f73f/jobs/6375
