### PR TITLE
feat(op-acceptor): improved metrics.

### DIFF
--- a/op-acceptor/docker-compose.yml
+++ b/op-acceptor/docker-compose.yml
@@ -34,9 +34,12 @@ services:
       dockerfile: op-acceptor/Dockerfile
     volumes:
       - ./devnets:/devnets
+      - ../../optimism/op-acceptance-tests:/acceptance-tests
+    tmpfs:
+      - /app/logs:exec,mode=0777
     environment:
       - DEVNET_ENV_URL=/devnets/simple-devnet.json
-    command: ["--gate", "localnet", "--testdir", "../../optimism", "--validators", "example-validators.yaml", "--log.level", "debug"]
+    command: ["--gate", "base", "--testdir", "/acceptance-tests", "--validators", "/acceptance-tests/acceptance-tests.yaml", "--log.level", "debug", "--run-interval", "60s"]
     depends_on:
       - prometheus
       - grafana
@@ -50,7 +53,7 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
-    restart: unless-stopped
+    restart: "no"
 
 networks:
   monitoring:

--- a/op-acceptor/metrics/metrics.go
+++ b/op-acceptor/metrics/metrics.go
@@ -22,18 +22,20 @@ var (
 	validResults              = []types.TestStatus{types.TestStatusPass, types.TestStatusFail, types.TestStatusSkip}
 	nonAlphanumericRegex      = regexp.MustCompile(`[^a-zA-Z ]+`)
 
-	errorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	// Tracks errors that occur during execution
+	errorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "errors_total",
-		Help:      "Count of errors",
+		Help:      "Total count of errors by type",
 	}, []string{
 		"error",
 	})
 
-	validationsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	// Tracks each validator execution
+	validationTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "validations_total",
-		Help:      "Count of validations",
+		Help:      "Total count of validator executions",
 	}, []string{
 		"network_name",
 		"run_id",
@@ -42,50 +44,118 @@ var (
 		"result",
 	})
 
-	acceptanceResults = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	// Run-level metrics with run_id
+	testRunStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
-		Name:      "acceptance_results",
-		Help:      "Result of acceptance tests",
+		Name:      "test_run_status",
+		Help:      "Status of test runs (value is always 1, results indicated by the 'result' label)",
 	}, []string{
 		"network_name",
 		"run_id",
 		"result",
 	})
 
-	acceptanceTestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	testRunTestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
-		Name:      "acceptance_test_total",
-		Help:      "Total number of acceptance tests",
+		Name:      "test_run_tests_total",
+		Help:      "Total number of tests in a run",
 	}, []string{
 		"network_name",
 		"run_id",
 	})
 
-	acceptanceTestPassed = promauto.NewCounterVec(prometheus.CounterOpts{
+	testRunTestsPassed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
-		Name:      "acceptance_test_passed",
-		Help:      "Number of passed acceptance tests",
+		Name:      "test_run_tests_passed",
+		Help:      "Number of passed tests in a run",
 	}, []string{
 		"network_name",
 		"run_id",
 	})
 
-	acceptanceTestFailed = promauto.NewCounterVec(prometheus.CounterOpts{
+	testRunTestsFailed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
-		Name:      "acceptance_test_failed",
-		Help:      "Number of failed acceptance tests",
+		Name:      "test_run_tests_failed",
+		Help:      "Number of failed tests in a run",
 	}, []string{
 		"network_name",
 		"run_id",
 	})
 
-	acceptanceTestDuration = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	testRunTestsSkipped = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
-		Name:      "acceptance_test_duration",
-		Help:      "Duration of acceptance tests",
+		Name:      "test_run_tests_skipped",
+		Help:      "Number of skipped tests in a run",
 	}, []string{
 		"network_name",
 		"run_id",
+	})
+
+	testRunDurationSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "test_run_duration_seconds",
+		Help:      "Duration of test runs in seconds",
+	}, []string{
+		"network_name",
+		"run_id",
+	})
+
+	// Aggregate counters without run_id for time-based aggregation
+	testsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "tests_total",
+		Help:      "Total number of tests run (aggregate counter without run_id)",
+	}, []string{
+		"network_name",
+	})
+
+	testsPassed = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "tests_passed_total",
+		Help:      "Total number of passed tests (aggregate counter without run_id)",
+	}, []string{
+		"network_name",
+	})
+
+	testsFailed = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "tests_failed_total",
+		Help:      "Total number of failed tests (aggregate counter without run_id)",
+	}, []string{
+		"network_name",
+	})
+
+	testsSkipped = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "tests_skipped_total",
+		Help:      "Total number of skipped tests (aggregate counter without run_id)",
+	}, []string{
+		"network_name",
+	})
+
+	// Metrics for individual test tracking
+	testStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "test_status",
+		Help:      "Status of individual tests (1=pass, 0=fail, -1=skip)",
+	}, []string{
+		"network_name",
+		"run_id",
+		"test_name",
+		"gate",
+		"suite",
+	})
+
+	testDurationSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "test_duration_seconds",
+		Help:      "Duration of individual tests in seconds",
+	}, []string{
+		"network_name",
+		"run_id",
+		"test_name",
+		"gate",
+		"suite",
 	})
 )
 
@@ -100,6 +170,7 @@ func errToLabel(err error) string {
 	return errClean
 }
 
+// RecordError increments the error counter for a specific error type
 func RecordError(error string) {
 	if Debug {
 		log.Debug("metric inc",
@@ -107,7 +178,7 @@ func RecordError(error string) {
 			"error", error,
 		)
 	}
-	errorsTotal.WithLabelValues(error).Inc()
+	errorTotal.WithLabelValues(error).Inc()
 }
 
 // RecordErrorDetails concats the error message to the label
@@ -120,6 +191,7 @@ func RecordErrorDetails(label string, err error) {
 	RecordError(label)
 }
 
+// RecordValidation records metrics for a single validator execution
 func RecordValidation(network string, runID string, valName string, valType string, result types.TestStatus) {
 	if !isValidResult(result) {
 		log.Error("RecordValidation - invalid result", "result", result)
@@ -134,9 +206,10 @@ func RecordValidation(network string, runID string, valName string, valType stri
 			"type", valType,
 			"result", result)
 	}
-	validationsTotal.WithLabelValues(network, runID, valName, valType, string(result)).Inc()
+	validationTotal.WithLabelValues(network, runID, valName, valType, string(result)).Inc()
 }
 
+// RecordAcceptance records metrics for a complete test run
 func RecordAcceptance(
 	network string,
 	runID string,
@@ -146,11 +219,52 @@ func RecordAcceptance(
 	failed int,
 	duration time.Duration,
 ) {
-	acceptanceResults.WithLabelValues(network, runID, result).Set(1)
-	acceptanceTestTotal.WithLabelValues(network, runID).Add(float64(total))
-	acceptanceTestPassed.WithLabelValues(network, runID).Add(float64(passed))
-	acceptanceTestFailed.WithLabelValues(network, runID).Add(float64(failed))
-	acceptanceTestDuration.WithLabelValues(network, runID).Set(duration.Seconds())
+	// Record per-run metrics with run_id
+	testRunStatus.WithLabelValues(network, runID, result).Set(1)
+	testRunTestsTotal.WithLabelValues(network, runID).Add(float64(total))
+	testRunTestsPassed.WithLabelValues(network, runID).Add(float64(passed))
+	testRunTestsFailed.WithLabelValues(network, runID).Add(float64(failed))
+
+	// Calculate skipped tests
+	skipped := total - passed - failed
+	if skipped > 0 {
+		testRunTestsSkipped.WithLabelValues(network, runID).Add(float64(skipped))
+	}
+
+	testRunDurationSeconds.WithLabelValues(network, runID).Set(duration.Seconds())
+
+	// Also record to the continuous counters without run_id
+	testsTotal.WithLabelValues(network).Add(float64(total))
+	testsPassed.WithLabelValues(network).Add(float64(passed))
+	testsFailed.WithLabelValues(network).Add(float64(failed))
+	if skipped > 0 {
+		testsSkipped.WithLabelValues(network).Add(float64(skipped))
+	}
+}
+
+// RecordIndividualTest records metrics for an individual test
+func RecordIndividualTest(
+	network string,
+	runID string,
+	testName string,
+	gate string,
+	suite string,
+	status types.TestStatus,
+	duration time.Duration,
+) {
+	// Convert test status to numeric value (1=pass, 0=fail, -1=skip)
+	var statusValue float64
+	switch status {
+	case types.TestStatusPass:
+		statusValue = 1.0
+	case types.TestStatusSkip:
+		statusValue = -1.0
+	default: // fail or any other status
+		statusValue = 0.0
+	}
+
+	testStatus.WithLabelValues(network, runID, testName, gate, suite).Set(statusValue)
+	testDurationSeconds.WithLabelValues(network, runID, testName, gate, suite).Set(duration.Seconds())
 }
 
 func isValidResult(result types.TestStatus) bool {

--- a/op-acceptor/metrics/metrics_test.go
+++ b/op-acceptor/metrics/metrics_test.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/ethereum-optimism/infra/op-acceptor/types"
 )
 
 func TestErrToLabel(t *testing.T) {
@@ -74,4 +76,11 @@ func TestRecordAcceptance(t *testing.T) {
 	// Test acceptance scenarios
 	RecordAcceptance("test-network", "run1", "pass", 1, 1, 0, time.Second)
 	RecordAcceptance("test-network", "run1", "fail", 1, 0, 1, time.Second)
+}
+
+func TestRecordIndividualTest(t *testing.T) {
+	// Test individual test recording for different status values
+	RecordIndividualTest("test-network", "run1", "TestFoo", "gate1", "", types.TestStatusPass, time.Second)
+	RecordIndividualTest("test-network", "run1", "TestBar", "gate1", "suite1", types.TestStatusFail, 500*time.Millisecond)
+	RecordIndividualTest("test-network", "run1", "TestBaz", "gate1", "suite1", types.TestStatusSkip, 100*time.Millisecond)
 }


### PR DESCRIPTION
# Description

Reviewed the metrics, which were introduced a while ago and haven't really been used. They are now used in the persistent devnets and will also be used to provide one of our DevX KPI Metrics (#tests run per week).
I tried to adhere to the Prometheus metric name conventions.

- More metrics
- Better metric names
- Fixed docker-compose to better test metric emission locally

## Metrics Summary

### Error Tracking
- `errors_total`: Counts errors by type during execution

### Validation Tracking
- `validations_total`: Records individual validator executions with network, run_id, validator name, type, and result labels

### Run-Level Metrics (with run_id)
- `test_run_status`: A gauge that indicates overall run status via the "result" label (value always 1)
- `test_run_tests_total`: Counts total tests in a specific run
- `test_run_tests_passed`: Counts passed tests in a specific run
- `test_run_tests_failed`: Counts failed tests in a specific run
- `test_run_tests_skipped`: Counts skipped tests in a specific run
- `test_run_duration_seconds`: Measures total duration of a test run

### Aggregate Counters (without run_id)
- `tests_total`: Continuously accumulating counter of all tests run
- `tests_passed_total`: Continuously accumulating counter of all passed tests
- `tests_failed_total`: Continuously accumulating counter of all failed tests
- `tests_skipped_total`: Continuously accumulating counter of all skipped tests

### Individual Test Metrics
- `test_status`: Status of each individual test (1=pass, 0=fail, -1=skip)
- `test_duration_seconds`: Duration of each individual test


# Metadata

- Fixes #196
- Fixes #195
- Fixes #194 
- Fixes #299 
- Related to #296 