### PR TITLE
feat: add support for op-conductor-ops to get builder sync status and rollup-boost execution-mode if enabled in the conductor ops config

### DIFF
--- a/op-conductor-ops/config.py
+++ b/op-conductor-ops/config.py
@@ -14,12 +14,15 @@ def read_config(config_path: str) -> tuple[dict[str, Sequencer], str]:
     # load sequencers into a map
     sequencers = {}
     for name, seq_config in config["sequencers"].items():
+
         sequencers[name] = Sequencer(
             sequencer_id=name,
             raft_addr=seq_config["raft_addr"],
             conductor_rpc_url=seq_config["conductor_rpc_url"],
             node_rpc_url=seq_config["node_rpc_url"],
             voting=seq_config["voting"],
+            builder_rpc_url=seq_config.get("builder_rpc_url"),
+            rollup_boost_rpc_url=seq_config.get("rollup_boost_debug_rpc_url"),
         )
 
     # Initialize network, with list of sequencers

--- a/op-conductor-ops/sequencer.py
+++ b/op-conductor-ops/sequencer.py
@@ -8,12 +8,21 @@ from utils import make_rpc_payload
 
 class Sequencer:
     def __init__(
-        self, sequencer_id, raft_addr, conductor_rpc_url, node_rpc_url, voting
+        self,
+        sequencer_id,
+        raft_addr,
+        conductor_rpc_url,
+        node_rpc_url,
+        voting,
+        rollup_boost_rpc_url=None,
+        builder_rpc_url=None,
     ):
         self.sequencer_id = sequencer_id
         self.raft_addr = raft_addr
         self.conductor_rpc_url = conductor_rpc_url
         self.node_rpc_url = node_rpc_url
+        self.rollup_boost_rpc_url = rollup_boost_rpc_url
+        self.builder_rpc_url = builder_rpc_url
         self.voting = voting
         self.conductor_active = None
         self.conductor_leader = None
@@ -21,7 +30,10 @@ class Sequencer:
         self.sequencer_active = None
         self.unsafe_l2_hash = None
         self.unsafe_l2_number = None
+        self.builder_unsafe_l2_number = None
+        self.builder_unsafe_l2_hash = None
         self.update_successful = False
+        self.rollup_boost_execution_mode = None
 
     def _get_sequencer_active(self):
         resp = requests.post(
@@ -67,6 +79,30 @@ class Sequencer:
             return None
         self.conductor_leader = resp.json()["result"]
 
+    def _get_rollup_boost_execution_mode(self):
+        resp = requests.post(
+            self.rollup_boost_rpc_url,
+            json=make_rpc_payload("debug_getExecutionMode"),
+        )
+        try:
+            resp.raise_for_status()
+        except Exception as e:
+            return None
+        self.rollup_boost_execution_mode = resp.json()["result"]["execution_mode"]
+
+    def _get_builder_unsafe_l2(self):
+        resp = requests.post(
+            self.builder_rpc_url,
+            json=make_rpc_payload("optimism_syncStatus"),
+        )
+        try:
+            resp.raise_for_status()
+        except Exception as e:
+            return None
+        result = resp.json()["result"]
+        self.builder_unsafe_l2_number = result["unsafe_l2"]["number"]
+        self.builder_unsafe_l2_hash = result["unsafe_l2"]["hash"]
+
     def _get_unsafe_l2(self):
         resp = requests.post(
             self.node_rpc_url,
@@ -96,6 +132,12 @@ class Sequencer:
             self._get_sequencer_active,
             self._get_unsafe_l2,
         ]
+
+        if self.builder_rpc_url:
+            functions.append(self._get_builder_unsafe_l2)
+        if self.rollup_boost_rpc_url:
+            functions.append(self._get_rollup_boost_execution_mode)
+
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = {executor.submit(func): func for func in functions}
             for future in concurrent.futures.as_completed(futures):


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* add support for op-conductor-ops to get builder sync status and rollup-boost execution-mode if enabled in the conductor ops config 
* Adds debug logging support 

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

### Flashblocks Enabled Network
```
╭─ ~/workspace/ethereum-optimism/infra/op-conductor-ops jelias2/flas…pdates-final *6 ?2                                                                                                                     10:01:43
╰─❯ ./op-conductor-ops  status flashblocks-alpha
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
┃ Sequencer ID                                       ┃ Active ┃ Healthy ┃ Leader ┃ Sequencing ┃ Voting ┃ Unsafe Number ┃ Unsafe Hash                                           ┃ Builder Synced ┃ Rollup Boost Mode ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
│ dev-infra-flashblocks-alpha-opn-geth-f-sequencer-0 │ ✅     │ ✅      │ ❌     │ ❌         │ ✅     │ 123656        │ 0x8bed4aef21ec9ca798f28d7afb86cab8428289119d1157a944… │ ✅             │ dry_run           │
│ dev-infra-flashblocks-alpha-opn-geth-f-sequencer-1 │ ✅     │ ✅      │ ✅     │ ✅         │ ✅     │ 123656        │ 0x8bed4aef21ec9ca798f28d7afb86cab8428289119d1157a944… │ ✅             │ dry_run           │
│ dev-infra-flashblocks-alpha-opn-reth-f-sequencer-2 │ ✅     │ ✅      │ ❌     │ ❌         │ ✅     │ 123656        │ 0x8bed4aef21ec9ca798f28d7afb86cab8428289119d1157a944… │ ✅             │ dry_run           │
└────────────────────────────────────────────────────┴────────┴─────────┴────────┴────────────┴────────┴───────────────┴───────────────────────────────────────────────────────┴────────────────┴───────────────────┘
```

### Non-Flashblocks Network
```
╭─ ~/workspace/ethereum-optimism/infra/op-conductor-ops jelias2/flas…pdates-final *6 ?2                                                                                                                     10:02:47
╰─❯ ./op-conductor-ops  status deimos-0
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Sequencer ID                              ┃ Active ┃ Healthy ┃ Leader ┃ Sequencing ┃ Voting ┃ Unsafe Number ┃ Unsafe Hash                                                        ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ dev-infra-deimos-0-opn-geth-f-sequencer-0 │ ✅     │ ✅      │ ✅     │ ✅         │ ✅     │ 939115        │ 0xd7bac788da54dd0d0121c0535fdad883174a78c5d5004ab17f49d545c1218d63 │
│ dev-infra-deimos-0-opn-geth-f-sequencer-1 │ ✅     │ ✅      │ ❌     │ ❌         │ ✅     │ 939115        │ 0xd7bac788da54dd0d0121c0535fdad883174a78c5d5004ab17f49d545c1218d63 │
│ dev-infra-deimos-0-opn-reth-f-sequencer-2 │ ✅     │ ✅      │ ❌     │ ❌         │ ✅     │ 939115        │ 0xd7bac788da54dd0d0121c0535fdad883174a78c5d5004ab17f49d545c1218d63 │
└───────────────────────────────────────────┴────────┴─────────┴────────┴────────────┴────────┴───────────────┴────────────────────────────────────────────────────────────────────┘
```

**Metadata**

- Fixes #[Link to Issue]
