### PR TITLE
proxyd: test regexp based UA/Origin exemptions

### DIFF
--- a/proxyd/integration_tests/rate_limit_test.go
+++ b/proxyd/integration_tests/rate_limit_test.go
@@ -49,7 +49,7 @@ func TestFrontendMaxRPSLimit(t *testing.T) {
 
 	t.Run("exempt origin over limit", func(t *testing.T) {
 		h := make(http.Header)
-		h.Set("Origin", "exempt_origin")
+		h.Set("Origin", "exempt.origin.example")
 		client := NewProxydClientWithHeaders("http://127.0.0.1:8545", h)
 		_, codes := spamReqs(t, client, ethChainID, 429, 3)
 		require.Equal(t, 3, codes[200])

--- a/proxyd/integration_tests/testdata/frontend_rate_limit.toml
+++ b/proxyd/integration_tests/testdata/frontend_rate_limit.toml
@@ -21,8 +21,8 @@ eth_baz = "main"
 [rate_limit]
 base_rate = 2
 base_interval = "1s"
-exempt_origins = ["exempt_origin"]
-exempt_user_agents = ["exempt_agent"]
+exempt_origins = ["origin.example"]
+exempt_user_agents = ["exempt_.*"]
 error_message = "over rate limit with special message"
 
 [rate_limit.method_overrides.eth_foobar]


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

In the rate-limit integration test, switch to using a regexp exemption. This both tests the functionality, and serves as documentation surrogate (until the documentation itself mentions the `rate_limit` block).

**Tests**

Changed the `testdata` of the `rate_limit_test`.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
