### PR TITLE
feat(proxyd): interop message validation optimizations

### DIFF
--- a/proxyd/Makefile
+++ b/proxyd/Makefile
@@ -18,6 +18,7 @@ test:
 
 lint:
 	go vet ./...
+	goimports -w . 
 .PHONY: test
 
 test-%:

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -113,6 +113,12 @@ var (
 		HTTPErrorCode: 500,
 	}
 
+	ErrInteropAccessListOutOfBounds = &RPCErr{
+		Code:          JSONRPCErrorInternal - 22,
+		Message:       "access list out of bounds",
+		HTTPErrorCode: 413,
+	}
+
 	ErrBackendUnexpectedJSONRPC = errors.New("backend returned an unexpected JSON-RPC response")
 
 	ErrConsensusGetReceiptsCantBeBatched = errors.New("consensus_getReceipts cannot be batched")

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -229,8 +229,11 @@ type Config struct {
 }
 
 type InteropValidationConfig struct {
-	Urls     []string                  `toml:"urls"`
-	Strategy InteropValidationStrategy `toml:"strategy"`
+	Urls                   []string                  `toml:"urls"`
+	Strategy               InteropValidationStrategy `toml:"strategy"`
+	ReqParamsSizeLimit     int                       `toml:"req_params_size_limit"`
+	AccessListSizeLimit    int                       `toml:"access_list_size_limit"`
+	SkipUnprocessedEntries bool                      `toml:"skip_unprocessed_entries"`
 }
 
 type InteropValidationStrategy string

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -229,11 +229,11 @@ type Config struct {
 }
 
 type InteropValidationConfig struct {
-	Urls                   []string                  `toml:"urls"`
-	Strategy               InteropValidationStrategy `toml:"strategy"`
-	ReqParamsSizeLimit     int                       `toml:"req_params_size_limit"`
-	AccessListSizeLimit    int                       `toml:"access_list_size_limit"`
-	SkipUnprocessedEntries bool                      `toml:"skip_unprocessed_entries"`
+	Urls                []string                  `toml:"urls"`
+	Strategy            InteropValidationStrategy `toml:"strategy"`
+	ReqParamsSizeLimit  int                       `toml:"req_params_size_limit"`
+	AccessListSizeLimit int                       `toml:"access_list_size_limit"`
+	RateLimit           SenderRateLimitConfig     `toml:"sender_rate_limit"`
 }
 
 type InteropValidationStrategy string

--- a/proxyd/integration_tests/testdata/interop_validation.toml
+++ b/proxyd/integration_tests/testdata/interop_validation.toml
@@ -22,6 +22,10 @@ urls = [
 "$VALIDATING_BACKEND_RPC_URL_1",
 "$VALIDATING_BACKEND_RPC_URL_2"
 ]
+# strategy = "first-supervisor"
+# access_list_size_limit = 1000000
+# skip_unprocessed_entries = true
+# req_params_size_limit = 131072 ## 128KB
 
 [sender_rate_limit]
 allowed_chain_ids = [0, 420120003] # adding 0 allows pre-EIP-155 transactions

--- a/proxyd/integration_tests/testdata/interop_validation.toml
+++ b/proxyd/integration_tests/testdata/interop_validation.toml
@@ -22,10 +22,16 @@ urls = [
 "$VALIDATING_BACKEND_RPC_URL_1",
 "$VALIDATING_BACKEND_RPC_URL_2"
 ]
-# strategy = "first-supervisor"
-# access_list_size_limit = 1000000
-# skip_unprocessed_entries = true
-# req_params_size_limit = 131072 ## 128KB
+strategy = "first-supervisor"
+access_list_size_limit = 1000000
+skip_unprocessed_entries = true
+req_params_size_limit = 131072 ## 128KB
+
+[interop_validation.sender_rate_limit]
+allowed_chain_ids = [0, 420120003] # adding 0 allows pre-EIP-155 transactions
+enabled = true
+interval = "1s"
+limit = 99999
 
 [sender_rate_limit]
 allowed_chain_ids = [0, 420120003] # adding 0 allows pre-EIP-155 transactions

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -225,6 +225,16 @@ func Start(config *Config) (*Server, func(), error) {
 		config.InteropValidationConfig.Strategy = defaultInteropValidationStrategy
 	}
 
+	if config.InteropValidationConfig.ReqParamsSizeLimit == 0 {
+		log.Warn("no interop validation request params size limit provided, using default size limit", "size_limit", defaultInteropReqParamsSizeLimit)
+		config.InteropValidationConfig.ReqParamsSizeLimit = defaultInteropReqParamsSizeLimit
+	}
+
+	if config.InteropValidationConfig.AccessListSizeLimit == 0 {
+		log.Warn("no interop validation access list size limit provided, using default size limit", "size_limit", defaultInteropAccessListSizeLimit)
+		config.InteropValidationConfig.AccessListSizeLimit = defaultInteropAccessListSizeLimit
+	}
+
 	log.Info("configured interop validation urls", "urls", config.InteropValidationConfig.Urls)
 	log.Info("configured interop validation strategy", "strategy", config.InteropValidationConfig.Strategy)
 

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -370,6 +370,7 @@ func Start(config *Config) (*Server, func(), error) {
 		rpcCache,
 		config.RateLimit,
 		config.SenderRateLimit,
+		config.InteropValidationConfig.RateLimit,
 		config.Server.EnableRequestLog,
 		config.Server.MaxRequestBodyLogLen,
 		config.BatchConfig.MaxSize,

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -966,7 +966,7 @@ func (s *Server) rateLimitSender(ctx context.Context, req *RPCReq) error {
 	if s.senderLim == nil {
 		log.Warn("sender rate limiter is not enabled, skipping", "req_id", GetReqID(ctx))
 		return nil
-	}	
+	}
 	return s.genericRateLimitSender(ctx, req, s.senderLim)
 }
 


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR introduces where optimizations and guard-rails to reduce the calls made to supervisor for interop validations, including reducing DoS vectors.

- Req Body params size limit check
- Access List size limit check
- Ordered deduplication of access list inbox entries
- Supervisor-independent early-exit on non-zero unparseable inbox entries.
- Interop-specific sender rate limit
- Early-exit on the situation when encountering an interop transaction with no supervisor backends to validate against.

**Tests**

All the tests included in this PR.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
