### PR TITLE
feat(op-acceptor): tuned log levels for test running.

### DIFF
--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -350,7 +350,6 @@ func (r *runner) RunTest(ctx context.Context, metadata types.ValidatorMetadata) 
 	// Use defer and recover to catch panics and convert them to errors
 	var result *types.TestResult
 	var err error
-
 	defer func() {
 		if rec := recover(); rec != nil {
 			errMsg := fmt.Sprintf("runtime error: %v", rec)
@@ -374,9 +373,8 @@ func (r *runner) RunTest(ctx context.Context, metadata types.ValidatorMetadata) 
 		}
 	}()
 
+	r.log.Info("Running validator", "validator", metadata.ID)
 	start := time.Now()
-	r.log.Info("Running test", "validator", metadata.ID)
-
 	if metadata.RunAll {
 		result, err = r.runAllTestsInPackage(ctx, metadata)
 	} else {
@@ -402,7 +400,7 @@ func (r *runner) runAllTestsInPackage(ctx context.Context, metadata types.Valida
 		return nil, fmt.Errorf("listing tests in package %s: %w", metadata.Package, err)
 	}
 
-	r.log.Info("Found tests in package",
+	r.log.Debug("Found tests in package",
 		"package", metadata.Package,
 		"count", len(testNames),
 		"tests", strings.Join(testNames, ", "))
@@ -574,6 +572,7 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
+	r.log.Info("Running test", "test", metadata.FuncName)
 	r.log.Debug("Running test command",
 		"dir", cmd.Dir,
 		"package", metadata.Package,


### PR DESCRIPTION
**Description**

- Clear distinction between validators and tests
- Moved #tests in a package log to DEBUG level

The output should be neater and more understandable.

<img width="1322" alt="Screenshot 2025-05-13 at 13 57 05" src="https://github.com/user-attachments/assets/6e7f165a-6a26-4e6f-974c-61ada16ceb70" />

