### PR TITLE
feat(proxyd): interop access list inbox entries client-side deduplication

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -233,6 +233,7 @@ type InteropValidationConfig struct {
 	Strategy            InteropValidationStrategy `toml:"strategy"`
 	ReqSizeLimit        int                       `toml:"req_size_limit"`
 	AccessListSizeLimit int                       `toml:"access_list_size_limit"`
+	RateLimit           SenderRateLimitConfig     `toml:"sender_rate_limit"`
 }
 
 type InteropValidationStrategy string

--- a/proxyd/integration_tests/testdata/interop_validation.toml
+++ b/proxyd/integration_tests/testdata/interop_validation.toml
@@ -26,6 +26,12 @@ strategy = "first-supervisor"
 req_params_size_limit = 131072 ## 128KB
 access_list_size_limit = 1000000
 
+[interop_validation.sender_rate_limit]
+allowed_chain_ids = [0, 420120003] # adding 0 allows pre-EIP-155 transactions
+enabled = true
+interval = "1s"
+limit = 99999
+
 [sender_rate_limit]
 allowed_chain_ids = [0, 420120003] # adding 0 allows pre-EIP-155 transactions
 enabled = true

--- a/proxyd/interop.go
+++ b/proxyd/interop.go
@@ -1,0 +1,64 @@
+package proxyd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	supervisorTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func accessObjectToKey(accessObject supervisorTypes.Access) string {
+	return fmt.Sprintf("%s/%d/%d/%d/%s", accessObject.ChainID, accessObject.BlockNumber, accessObject.LogIndex, accessObject.Timestamp, accessObject.Checksum)
+}
+
+// validateAndDeduplicateInteropAccessList
+// - validates all the interop access list entries by trying to successfully parse them on a per "Access" basis
+// - discard any successfully parsed yet duplicate "Access" objects along the way.
+// This is because op-supervisor does the same for the incoming inbox entries and validates them against its DB on a per "Access" basis.
+// So it makes sense to recognise and discard duplicate "Access" objects early.
+func validateAndDeduplicateInteropAccessList(entriesToParse []common.Hash) ([]common.Hash, error) {
+	if len(entriesToParse) == 0 {
+		return nil, nil
+	}
+
+	var deduplicatedAccessObjects []supervisorTypes.Access
+
+	alreadySeenAccessObjectsSet := map[string]bool{}
+
+	for len(entriesToParse) > 0 {
+		remaining, parsedAccessObject, err := supervisorTypes.ParseAccess(entriesToParse)
+		if err != nil {
+			return nil, err
+		}
+
+		key := accessObjectToKey(parsedAccessObject)
+		if _, alreadySeen := alreadySeenAccessObjectsSet[key]; !alreadySeen {
+			deduplicatedAccessObjects = append(deduplicatedAccessObjects, parsedAccessObject)
+
+			alreadySeenAccessObjectsSet[key] = true
+		}
+
+		entriesToParse = remaining
+	}
+
+	deduplicatedAccessListEntries := supervisorTypes.EncodeAccessList(deduplicatedAccessObjects)
+
+	return deduplicatedAccessListEntries, nil
+}
+
+func getInteropExecutingDescriptorTimestamp() uint64 {
+	// intentionally kept to be slightly in the future (but within the expiryAt of the associated message) to proceed through the access-list time-checks
+	return uint64(time.Now().Second() + 1000)
+}
+
+func (s *Server) rateLimitInteropSender(ctx context.Context, req *RPCReq) error {
+	if s.interopSenderLim == nil {
+		log.Warn("interop sender rate limiter is not enabled, skipping", "req_id", GetReqID(ctx))
+		return nil
+	}
+	return s.genericRateLimitSender(ctx, req, s.interopSenderLim)
+}

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -235,6 +235,16 @@ func Start(config *Config) (*Server, func(), error) {
 		config.InteropValidationConfig.AccessListSizeLimit = defaultInteropAccessListSizeLimit
 	}
 
+	if config.InteropValidationConfig.AccessListSizeLimit == 0 {
+		log.Warn("no interop validation access list size limit provided, using default size limit", "size_limit", defaultInteropAccessListSizeLimit)
+		config.InteropValidationConfig.AccessListSizeLimit = defaultInteropAccessListSizeLimit
+	}
+
+	if config.InteropValidationConfig.AccessListSizeLimit == 0 {
+		log.Warn("no interop validation access list size limit provided, using default size limit", "size_limit", defaultInteropAccessListSizeLimit)
+		config.InteropValidationConfig.AccessListSizeLimit = defaultInteropAccessListSizeLimit
+	}
+
 	log.Info("configured interop validation urls", "urls", config.InteropValidationConfig.Urls)
 	log.Info("configured interop validation strategy", "strategy", config.InteropValidationConfig.Strategy)
 
@@ -370,6 +380,7 @@ func Start(config *Config) (*Server, func(), error) {
 		rpcCache,
 		config.RateLimit,
 		config.SenderRateLimit,
+		config.InteropValidationConfig.RateLimit,
 		config.Server.EnableRequestLog,
 		config.Server.MaxRequestBodyLogLen,
 		config.BatchConfig.MaxSize,

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -491,6 +491,12 @@ func (s *Server) validateInteropSendRpcRequest(ctx context.Context, rpcReq *RPCR
 		return ErrInteropAccessListOutOfBounds
 	}
 
+	// a pre-validation pre-requisite to the checkAccessList operation
+	_, _, err = supervisorTypes.ParseAccess(interopAccessList)
+	if err != nil {
+		return ParseInteropError(fmt.Errorf("failed to read data: %w", err))
+	}
+
 	performCheckAccessListOp := func(ctx context.Context, accessList []common.Hash, url, strategy string) error {
 		validatingBackend := interop.NewInteropClient(url)
 		err := validatingBackend.CheckAccessList(ctx, accessList, interoptypes.CrossUnsafe, interoptypes.ExecutingDescriptor{


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The following is the old description. Please look at ethereum-optimism/optimism#349 which includes the description of the updated logic.

-----

This PR introduces the capability of performing an ordered deduplication of inbox entries within the access list of an interop transaction.

Context

> Interop transactions are simple sendRawTransaction with one or more AccessList = CrossL2InboxAddress
> Each AccessList further points to multiple StorageHash or InboxEntries.
> As the request arrives at the proxyd, all the AccessList corresponding to CrossL2InboxAddress are parsed and all of their respective StorageHash/InboxEntries are flattened and joined into one list of inboxEntries.
> This list is later sent to the supervisor to evaluate where supervisor evaluates them individually (kind of).

An area of  optimization here is to deduplicate all the inbox entries before sending to the supervisor.

For example, if the incoming payload is

```
method: sendRawTransaction
accessList: [
       {
               Address: CrossL2Inbox,
               StorageHashes: ["a", "b", "a", "a", "b"]
       },
       {
               Address: CrossL2Inbox,
               StorageHashes: ["b", "b"]
       }
]
```

Without deduplication, the following list of inbox entries would go ["a", "b", "a", "a", "b", "b", "b"]

After deduplication, the following list of inbox entries would propagate ["a", "b"]

The order is preserved here for the sake of how inbox entries' order is used on supervisor's end.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes https://github.com/ethereum-optimism/infra/issues/357
