### PR TITLE
fix: interop deduplication of inbox entries of a per-access basis

### DIFF
--- a/proxyd/interop.go
+++ b/proxyd/interop.go
@@ -1,0 +1,64 @@
+package proxyd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	supervisorTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func accessObjectToKey(accessObject supervisorTypes.Access) string {
+	return fmt.Sprintf("%s/%d/%d/%d/%s", accessObject.ChainID, accessObject.BlockNumber, accessObject.LogIndex, accessObject.Timestamp, accessObject.Checksum)
+}
+
+// validateAndDeduplicateInteropAccessList
+// - validates all the interop access list entries by trying to successfully parse them on a per "Access" basis
+// - discard any successfully parsed yet duplicate "Access" objects along the way.
+// This is because op-supervisor does the same for the incoming inbox entries and validates them against its DB on a per "Access" basis.
+// So it makes sense to recognise and discard duplicate "Access" objects early.
+func validateAndDeduplicateInteropAccessList(entriesToParse []common.Hash) ([]common.Hash, error) {
+	if len(entriesToParse) == 0 {
+		return nil, nil
+	}
+
+	var deduplicatedAccessObjects []supervisorTypes.Access
+
+	alreadySeenAccessObjectsSet := map[string]bool{}
+
+	for len(entriesToParse) > 0 {
+		remaining, parsedAccessObject, err := supervisorTypes.ParseAccess(entriesToParse)
+		if err != nil {
+			return nil, err
+		}
+
+		key := accessObjectToKey(parsedAccessObject)
+		if _, alreadySeen := alreadySeenAccessObjectsSet[key]; !alreadySeen {
+			deduplicatedAccessObjects = append(deduplicatedAccessObjects, parsedAccessObject)
+
+			alreadySeenAccessObjectsSet[key] = true
+		}
+
+		entriesToParse = remaining
+	}
+
+	deduplicatedAccessListEntries := supervisorTypes.EncodeAccessList(deduplicatedAccessObjects)
+
+	return deduplicatedAccessListEntries, nil
+}
+
+func getInteropExecutingDescriptorTimestamp() uint64 {
+	// intentionally kept to be slightly in the future (but within the expiryAt of the associated message) to proceed through the access-list time-checks
+	return uint64(time.Now().Second() + 1000)
+}
+
+func (s *Server) rateLimitInteropSender(ctx context.Context, req *RPCReq) error {
+	if s.interopSenderLim == nil {
+		log.Warn("interop sender rate limiter is not enabled, skipping", "req_id", GetReqID(ctx))
+		return nil
+	}
+	return s.genericRateLimitSender(ctx, req, s.interopSenderLim)
+}


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Supervisor doesn't process inbox entries on a one-by-one entry basis.

Instead, it looks at a two-to-three inbox entries at a time, wraps them into one "Access" object, and processes them overall on a per-Access object basis.

This PR fixes the deduplication logic to respect that.

in simple words,

Before this PR

["0x01", "0x02", "0x03", "0x01", "0x03", "0x01", "0x03"] inbox entries (hashes of access lists) would be wrongfully deduplicated to ["0x01", "0x02", "0x03"]

After this PR

["0x01", "0x02", "0x03", "0x01", "0x03", "0x01", "0x03"] inbox entries would be rightfully deduplicated to ["0x01", "0x02", "0x03", "0x01", "0x03"]

This is because the sub list ["0x01", "0x02", "0x03"] and ["0x01", "0x03"] which clearly aren't duplicates.



**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
