### PR TITLE
fix(op-acceptor): add build dependencies and increase logs

### DIFF
--- a/op-acceptor/Dockerfile
+++ b/op-acceptor/Dockerfile
@@ -14,7 +14,7 @@ RUN just build
 
 FROM golang:1.23.5-alpine3.21
 
-RUN apk add --no-cache ca-certificates build-base
+RUN apk add --no-cache ca-certificates build-base git
 
 # Increase the proxy connect timeout to 60 seconds
 ENV GOPROXYCONNECTTIMEOUT=60s
@@ -27,6 +27,7 @@ ENV GOPATH="/go"
 ENV PATH="${GOPATH}/bin:${PATH}"
 
 WORKDIR /app
+
 RUN addgroup -S app && adduser -S app -G app && \
     mkdir -p /devnets && \
     chown -R app:app /devnets

--- a/op-acceptor/Dockerfile
+++ b/op-acceptor/Dockerfile
@@ -14,6 +14,8 @@ RUN just build
 
 FROM alpine:3.21
 
+RUN apk add --no-cache ca-certificates
+
 # Increase the proxy connect timeout to 60 seconds
 ENV GOPROXYCONNECTTIMEOUT=60s
 

--- a/op-acceptor/Dockerfile
+++ b/op-acceptor/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.23.5-alpine3.21 AS builder
 
+# Increase the proxy connect timeout to 60 seconds
+ENV GOPROXYCONNECTTIMEOUT=60s
+
 WORKDIR /app
 
 # Install dependencies first for better caching
@@ -10,6 +13,9 @@ COPY op-acceptor/ .
 RUN just build
 
 FROM alpine:3.21
+
+# Increase the proxy connect timeout to 60 seconds
+ENV GOPROXYCONNECTTIMEOUT=60s
 
 # Install Go binary
 # (we copy Go directly from the builder stage for simplicity and consistency)
@@ -30,7 +36,12 @@ chown -R app:app /go
 
 COPY --from=builder /app/bin/op-acceptor /app/
 COPY op-acceptor/example-validators.yaml /app/
+
+# Set ownership of the /app directory to allow the application to write logs and other files at runtime
+RUN chown -R app:app /app/
+
 USER app
 
 VOLUME /devnets
+
 ENTRYPOINT ["/app/op-acceptor"]

--- a/op-acceptor/Dockerfile
+++ b/op-acceptor/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:1.23.5-alpine3.21 AS builder
 
-# Increase the proxy connect timeout to 60 seconds
-ENV GOPROXYCONNECTTIMEOUT=60s
-
 WORKDIR /app
 
 # Install dependencies first for better caching
@@ -15,9 +12,6 @@ RUN just build
 FROM golang:1.23.5-alpine3.21
 
 RUN apk add --no-cache ca-certificates build-base git
-
-# Increase the proxy connect timeout to 60 seconds
-ENV GOPROXYCONNECTTIMEOUT=60s
 
 # Install Go binary
 # (we copy Go directly from the builder stage for simplicity and consistency)

--- a/op-acceptor/Dockerfile
+++ b/op-acceptor/Dockerfile
@@ -12,9 +12,9 @@ COPY op-acceptor/ .
 
 RUN just build
 
-FROM alpine:3.21
+FROM golang:1.23.5-alpine3.21
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates build-base
 
 # Increase the proxy connect timeout to 60 seconds
 ENV GOPROXYCONNECTTIMEOUT=60s

--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -22,8 +22,9 @@ type Config struct {
 	AllowSkips      bool          // Allow tests to be skipped instead of failing when preconditions are not met
 	DefaultTimeout  time.Duration // Default timeout for individual tests, can be overridden by test config
 	LogDir          string        // Directory to store test logs
-
-	Log log.Logger
+	OutputTestLogs  bool          // Whether to output test logs to the console
+	TestLogLevel    string        // Log level to be used for the tests
+	Log             log.Logger
 }
 
 // NewConfig creates a new Config instance
@@ -72,6 +73,8 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 		RunOnce:         runOnce,
 		AllowSkips:      ctx.Bool(flags.AllowSkips.Name),
 		DefaultTimeout:  ctx.Duration(flags.DefaultTimeout.Name),
+		OutputTestLogs:  ctx.Bool(flags.OutputTestLogs.Name),
+		TestLogLevel:    ctx.String(flags.TestLogLevel.Name),
 		LogDir:          logDir,
 		Log:             log,
 	}, nil

--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -13,18 +13,18 @@ import (
 )
 
 type Config struct {
-	TestDir         string
-	ValidatorConfig string
-	TargetGate      string
-	GoBinary        string
-	RunInterval     time.Duration // Interval between test runs
-	RunOnce         bool          // Indicates if the service should exit after one test run
-	AllowSkips      bool          // Allow tests to be skipped instead of failing when preconditions are not met
-	DefaultTimeout  time.Duration // Default timeout for individual tests, can be overridden by test config
-	LogDir          string        // Directory to store test logs
-	OutputTestLogs  bool          // Whether to output test logs to the console
-	TestLogLevel    string        // Log level to be used for the tests
-	Log             log.Logger
+	TestDir            string
+	ValidatorConfig    string
+	TargetGate         string
+	GoBinary           string
+	RunInterval        time.Duration // Interval between test runs
+	RunOnce            bool          // Indicates if the service should exit after one test run
+	AllowSkips         bool          // Allow tests to be skipped instead of failing when preconditions are not met
+	DefaultTimeout     time.Duration // Default timeout for individual tests, can be overridden by test config
+	LogDir             string        // Directory to store test logs
+	OutputRealtimeLogs bool          // If enabled, test logs will be outputted in realtime
+	TestLogLevel       string        // Log level to be used for the tests
+	Log                log.Logger
 }
 
 // NewConfig creates a new Config instance
@@ -65,17 +65,17 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 	}
 
 	return &Config{
-		TestDir:         absTestDir,
-		ValidatorConfig: absValidatorConfig,
-		TargetGate:      gate,
-		GoBinary:        ctx.String(flags.GoBinary.Name),
-		RunInterval:     runInterval,
-		RunOnce:         runOnce,
-		AllowSkips:      ctx.Bool(flags.AllowSkips.Name),
-		DefaultTimeout:  ctx.Duration(flags.DefaultTimeout.Name),
-		OutputTestLogs:  ctx.Bool(flags.OutputTestLogs.Name),
-		TestLogLevel:    ctx.String(flags.TestLogLevel.Name),
-		LogDir:          logDir,
-		Log:             log,
+		TestDir:            absTestDir,
+		ValidatorConfig:    absValidatorConfig,
+		TargetGate:         gate,
+		GoBinary:           ctx.String(flags.GoBinary.Name),
+		RunInterval:        runInterval,
+		RunOnce:            runOnce,
+		AllowSkips:         ctx.Bool(flags.AllowSkips.Name),
+		DefaultTimeout:     ctx.Duration(flags.DefaultTimeout.Name),
+		OutputRealtimeLogs: ctx.Bool(flags.OutputRealtimeLogs.Name),
+		TestLogLevel:       ctx.String(flags.TestLogLevel.Name),
+		LogDir:             logDir,
+		Log:                log,
 	}, nil
 }

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -72,7 +72,7 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "TEST_LOG_LEVEL"),
 		Usage:   "Log level to be used for the tests. Defaults to 'info'.",
 	}
-	OutputTestLogs = &cli.BoolFlag{
+	OutputRealtimeLogs = &cli.BoolFlag{
 		Name:    "output-test-logs",
 		Value:   false,
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "OUTPUT_TEST_LOGS"),
@@ -93,7 +93,7 @@ var optionalFlags = []cli.Flag{
 	DefaultTimeout,
 	LogDir,
 	TestLogLevel,
-	OutputTestLogs,
+	OutputRealtimeLogs,
 }
 var Flags []cli.Flag
 

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -66,6 +66,18 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "LOGDIR"),
 		Usage:   "Directory to store test logs. Defaults to 'logs' if not specified.",
 	}
+	TestLogLevel = &cli.StringFlag{
+		Name:    "test-log-level",
+		Value:   "info",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "TEST_LOG_LEVEL"),
+		Usage:   "Log level to be used for the tests. Defaults to 'info'.",
+	}
+	OutputTestLogs = &cli.BoolFlag{
+		Name:    "output-test-logs",
+		Value:   false,
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "OUTPUT_TEST_LOGS"),
+		Usage:   "Output test logs to the console. Defaults to false.",
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -80,6 +92,8 @@ var optionalFlags = []cli.Flag{
 	AllowSkips,
 	DefaultTimeout,
 	LogDir,
+	TestLogLevel,
+	OutputTestLogs,
 }
 var Flags []cli.Flag
 

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -73,10 +73,10 @@ var (
 		Usage:   "Log level to be used for the tests. Defaults to 'info'.",
 	}
 	OutputRealtimeLogs = &cli.BoolFlag{
-		Name:    "output-test-logs",
+		Name:    "output-realtime-logs",
 		Value:   false,
-		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "OUTPUT_TEST_LOGS"),
-		Usage:   "Output test logs to the console. Defaults to false.",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "OUTPUT_REALTIME_LOGS"),
+		Usage:   "If enabled, test logs will be outputted to the console in realtime. Defaults to false.",
 	}
 )
 

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -76,16 +76,16 @@ func New(ctx context.Context, config *Config, version string, shutdownCallback f
 
 	// Create runner with registry
 	testRunner, err := runner.NewTestRunner(runner.Config{
-		Registry:       reg,
-		WorkDir:        config.TestDir,
-		Log:            config.Log,
-		TargetGate:     config.TargetGate,
-		GoBinary:       config.GoBinary,
-		AllowSkips:     config.AllowSkips,
-		OutputTestLogs: config.OutputTestLogs,
-		TestLogLevel:   config.TestLogLevel,
-		NetworkName:    networkName,
-		DevnetEnv:      env,
+		Registry:           reg,
+		WorkDir:            config.TestDir,
+		Log:                config.Log,
+		TargetGate:         config.TargetGate,
+		GoBinary:           config.GoBinary,
+		AllowSkips:         config.AllowSkips,
+		OutputRealtimeLogs: config.OutputRealtimeLogs,
+		TestLogLevel:       config.TestLogLevel,
+		NetworkName:        networkName,
+		DevnetEnv:          env,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test runner: %w", err)

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -76,14 +76,16 @@ func New(ctx context.Context, config *Config, version string, shutdownCallback f
 
 	// Create runner with registry
 	testRunner, err := runner.NewTestRunner(runner.Config{
-		Registry:    reg,
-		WorkDir:     config.TestDir,
-		Log:         config.Log,
-		TargetGate:  config.TargetGate,
-		GoBinary:    config.GoBinary,
-		AllowSkips:  config.AllowSkips,
-		NetworkName: networkName,
-		DevnetEnv:   env,
+		Registry:       reg,
+		WorkDir:        config.TestDir,
+		Log:            config.Log,
+		TargetGate:     config.TargetGate,
+		GoBinary:       config.GoBinary,
+		AllowSkips:     config.AllowSkips,
+		OutputTestLogs: config.OutputTestLogs,
+		TestLogLevel:   config.TestLogLevel,
+		NetworkName:    networkName,
+		DevnetEnv:      env,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test runner: %w", err)

--- a/op-acceptor/runner/logging_test.go
+++ b/op-acceptor/runner/logging_test.go
@@ -205,8 +205,8 @@ func (l *testLogger) Write(level slog.Level, msg string, attrs ...any) {
 	l.logFn(l.formatMessage(msg, attrs...))
 }
 
-// TestOutputTestLogsRealtime verifies that test logs are output in real-time when outputTestLogs is enabled
-func TestOutputTestLogsRealtime(t *testing.T) {
+// TestOutputRealtimeLogs verifies that test logs are output in real-time when outputRealtimeLogs is enabled
+func TestOutputRealtimeLogs(t *testing.T) {
 	// Create a test file that outputs logs over time
 	testContent := []byte(`
 package feature_test
@@ -248,7 +248,7 @@ gates:
 	}
 
 	r := setupTestRunner(t, testContent, configContent)
-	r.outputTestLogs = true
+	r.outputRealtimeLogs = true
 	r.log = customLogger
 
 	// Run the test in a goroutine
@@ -293,8 +293,8 @@ gates:
 	}
 }
 
-// TestOutputTestLogsRealtimeDisabled verifies that test logs are output in real-time when outputTestLogs is disabled
-func TestOutputTestLogsRealtimeDisabled(t *testing.T) {
+// TestOutputRealtimeLogsDisabled verifies that test logs are output in real-time when outputRealtimeLogs is disabled
+func TestOutputRealtimeLogsDisabled(t *testing.T) {
 	// Create a test file that outputs logs over time
 	testContent := []byte(`
 package feature_test
@@ -336,7 +336,7 @@ gates:
 	}
 
 	r := setupTestRunner(t, testContent, configContent)
-	r.outputTestLogs = false
+	r.outputRealtimeLogs = false
 	r.log = customLogger
 
 	// Run the test in a goroutine
@@ -350,7 +350,7 @@ gates:
 
 	time.Sleep(10 * time.Millisecond)
 
-	// With outputTestLogs disabled, we should not receive any messages in real-time
+	// With outputRealtimeLogs disabled, we should not receive any messages in real-time
 	// Wait for the running message to be logged
 	// go test ./feature -run ^TestWithRealtimeLogs$
 	timeout := time.After(1000 * time.Millisecond)

--- a/op-acceptor/runner/logging_test.go
+++ b/op-acceptor/runner/logging_test.go
@@ -2,6 +2,8 @@ package runner
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ethereum-optimism/infra/op-acceptor/types"
@@ -67,4 +69,134 @@ gates:
 	assert.NotEmpty(t, failingTest.Stdout)
 	assert.Contains(t, failingTest.Stdout, "This is some stdout output that should be captured")
 	assert.Contains(t, failingTest.Stdout, "This is a second line of output")
+}
+
+// TestLogLevelEnvironment verifies that the TEST_LOG_LEVEL environment variable is correctly set and used
+func TestLogLevelEnvironment(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a simple test file in the work directory
+	testContent := []byte(`
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLogLevelEnvironment(t *testing.T) {
+    // Get log level from environment
+    logLevel := os.Getenv("TEST_LOG_LEVEL")
+    if logLevel == "" {
+		t.Log("TEST_LOG_LEVEL not set")
+    } else {
+		t.Log("TEST_LOG_LEVEL set to", logLevel)
+	}
+}
+`)
+	configContent := []byte(`
+gates:
+  - id: logging-gate
+    description: "Gate with a test that outputs logs"
+    suites:
+      logging-suite:
+        description: "Suite with a test that outputs logs"
+        tests:
+          - name: TestLogLevelEnvironment
+            package: "./main"
+`)
+
+	r := setupTestRunner(t, testContent, configContent)
+	r.testLogLevel = "debug"
+	err := os.WriteFile(filepath.Join(r.workDir, "main_test.go"), testContent, 0644)
+	require.NoError(t, err)
+
+	result, err := r.RunTest(ctx, types.ValidatorMetadata{
+		ID:       "test1",
+		Gate:     "logging-gate",
+		FuncName: "TestLogLevelEnvironment",
+		Package:  ".",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, types.TestStatusPass, result.Status)
+	assert.Equal(t, "test1", result.Metadata.ID)
+	assert.Equal(t, "logging-gate", result.Metadata.Gate)
+	assert.Equal(t, ".", result.Metadata.Package)
+	assert.False(t, result.Metadata.RunAll)
+	assert.Contains(t, result.Stdout, "TEST_LOG_LEVEL set to debug")
+}
+
+// TestOutputTestLogs verifies that test logs are properly captured and output when enabled
+func TestOutputTestLogs(t *testing.T) {
+	// Create a test file that outputs logs at different levels
+	testContent := []byte(`
+package feature_test
+
+import (
+	"testing"
+)
+
+func TestWithLogs(t *testing.T) {
+	t.Log("This is a test output")
+}
+`)
+
+	configContent := []byte(`
+gates:
+  - id: logging-gate
+    description: "Gate with a test that outputs logs"
+    suites:
+      logging-suite:
+        description: "Suite with a test that outputs logs"
+        tests:
+          - name: TestWithLogs
+            package: "./feature"
+`)
+
+	// Setup the test runner with OutputTestLogs enabled
+	r := setupTestRunner(t, testContent, configContent)
+	r.outputTestLogs = true
+
+	// Run the test
+	result, err := r.RunAllTests(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, types.TestStatusPass, result.Status)
+
+	// Verify the structure
+	require.Contains(t, result.Gates, "logging-gate")
+	gate := result.Gates["logging-gate"]
+	require.Contains(t, gate.Suites, "logging-suite")
+	suite := gate.Suites["logging-suite"]
+
+	// Get the test result
+	var testResult *types.TestResult
+	for _, test := range suite.Tests {
+		testResult = test
+		break
+	}
+	require.NotNil(t, testResult)
+
+	// Verify the test passed and has logs captured
+	assert.Equal(t, types.TestStatusPass, testResult.Status)
+	assert.NotEmpty(t, testResult.Stdout)
+	assert.Contains(t, testResult.Stdout, "This is a test output")
+
+	// Now run with OutputTestLogs disabled
+	r.outputTestLogs = false
+	result, err = r.RunAllTests(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, types.TestStatusPass, result.Status)
+
+	// Get the test result again
+	var testResult2 *types.TestResult
+	for _, test := range result.Gates["logging-gate"].Suites["logging-suite"].Tests {
+		testResult2 = test
+		break
+	}
+	require.NotNil(t, testResult)
+
+	// Verify that logs are not captured when OutputTestLogs is disabled
+	assert.Equal(t, types.TestStatusPass, testResult2.Status)
+	assert.Contains(t, testResult2.Stdout, "This is a test output")
 }

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -441,7 +441,6 @@ func (r *runner) runAllTestsInPackage(ctx context.Context, metadata types.Valida
 }
 
 // listTestsInPackage returns all test names in a package
-// This may take a while to run as it needs to download all the dependencies
 func (r *runner) listTestsInPackage(pkg string) ([]string, error) {
 	return testlist.FindTestFunctions(pkg, r.workDir)
 }
@@ -1213,6 +1212,7 @@ func (r *runner) testCommandContext(ctx context.Context, name string, arg ...str
 			fmt.Sprintf("%s=%s", env.EnvURLVar, envFile.Name()),
 			// override the control resolution scheme with the original one
 			fmt.Sprintf("%s=%s", env.EnvCtrlVar, url.Scheme),
+			// Set DEVNET_EXPECT_PRECONDITIONS_MET=true to make tests fail instead of skip when preconditions are not met
 			"DEVNET_EXPECT_PRECONDITIONS_MET=true",
 		)
 		cmd.Env = telemetry.InstrumentEnvironment(ctx, runEnv)

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -1186,8 +1186,8 @@ func (r *runner) testCommandContext(ctx context.Context, name string, arg ...str
 	cmd := exec.CommandContext(ctx, name, arg...)
 	cmd.Dir = r.workDir
 
-	// Always set the LOG_LEVEL environment variable
-	runEnv := append([]string{fmt.Sprintf("LOG_LEVEL=%s", r.testLogLevel)}, os.Environ()...)
+	// Always set the TEST_LOG_LEVEL environment variable
+	runEnv := append([]string{fmt.Sprintf("TEST_LOG_LEVEL=%s", r.testLogLevel)}, os.Environ()...)
 
 	if r.env == nil {
 		cmd.Env = telemetry.InstrumentEnvironment(ctx, runEnv)

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -94,34 +94,34 @@ type TestRunnerWithFileLogger interface {
 
 // runner struct implements TestRunner interface
 type runner struct {
-	registry       *registry.Registry
-	validators     []types.ValidatorMetadata
-	workDir        string // Directory for running tests
-	log            log.Logger
-	runID          string
-	goBinary       string              // Path to the Go binary
-	allowSkips     bool                // Whether to allow skipping tests when preconditions are not met
-	outputTestLogs bool                // Whether to output test logs to the console
-	testLogLevel   string              // Log level to be used for the tests
-	fileLogger     *logging.FileLogger // Logger for storing test results
-	networkName    string              // Name of the network being tested
-	env            *env.DevnetEnv
-	tracer         trace.Tracer
+	registry           *registry.Registry
+	validators         []types.ValidatorMetadata
+	workDir            string // Directory for running tests
+	log                log.Logger
+	runID              string
+	goBinary           string              // Path to the Go binary
+	allowSkips         bool                // Whether to allow skipping tests when preconditions are not met
+	outputRealtimeLogs bool                // If enabled, test logs will be outputted in realtime
+	testLogLevel       string              // Log level to be used for the tests
+	fileLogger         *logging.FileLogger // Logger for storing test results
+	networkName        string              // Name of the network being tested
+	env                *env.DevnetEnv
+	tracer             trace.Tracer
 }
 
 // Config holds configuration for creating a new runner
 type Config struct {
-	Registry       *registry.Registry
-	TargetGate     string
-	WorkDir        string
-	Log            log.Logger
-	GoBinary       string              // path to the Go binary
-	AllowSkips     bool                // Whether to allow skipping tests when preconditions are not met
-	OutputTestLogs bool                // Whether to output test logs to the console
-	TestLogLevel   string              // Log level to be used for the tests
-	FileLogger     *logging.FileLogger // Logger for storing test results
-	NetworkName    string              // Name of the network being tested
-	DevnetEnv      *env.DevnetEnv
+	Registry           *registry.Registry
+	TargetGate         string
+	WorkDir            string
+	Log                log.Logger
+	GoBinary           string              // path to the Go binary
+	AllowSkips         bool                // Whether to allow skipping tests when preconditions are not met
+	OutputRealtimeLogs bool                // Whether to output test logs to the console
+	TestLogLevel       string              // Log level to be used for the tests
+	FileLogger         *logging.FileLogger // Logger for storing test results
+	NetworkName        string              // Name of the network being tested
+	DevnetEnv          *env.DevnetEnv
 }
 
 // NewTestRunner creates a new test runner instance
@@ -161,18 +161,18 @@ func NewTestRunner(cfg Config) (TestRunner, error) {
 		"allowSkips", cfg.AllowSkips, "goBinary", cfg.GoBinary, "networkName", networkName)
 
 	return &runner{
-		registry:       cfg.Registry,
-		validators:     validators,
-		workDir:        cfg.WorkDir,
-		log:            cfg.Log,
-		goBinary:       cfg.GoBinary,
-		allowSkips:     cfg.AllowSkips,
-		outputTestLogs: cfg.OutputTestLogs,
-		testLogLevel:   cfg.TestLogLevel,
-		fileLogger:     cfg.FileLogger,
-		networkName:    networkName,
-		env:            cfg.DevnetEnv,
-		tracer:         otel.Tracer("test runner"),
+		registry:           cfg.Registry,
+		validators:         validators,
+		workDir:            cfg.WorkDir,
+		log:                cfg.Log,
+		goBinary:           cfg.GoBinary,
+		allowSkips:         cfg.AllowSkips,
+		outputRealtimeLogs: cfg.OutputRealtimeLogs,
+		testLogLevel:       cfg.TestLogLevel,
+		fileLogger:         cfg.FileLogger,
+		networkName:        networkName,
+		env:                cfg.DevnetEnv,
+		tracer:             otel.Tracer("test runner"),
 	}, nil
 }
 
@@ -542,7 +542,7 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 	defer cleanup()
 
 	var stdout, stderr bytes.Buffer
-	if r.outputTestLogs {
+	if r.outputRealtimeLogs {
 		stdoutLogger := &logWriter{logFn: func(msg string) {
 			r.log.Info("Test output", "test", metadata.FuncName, "output", msg)
 		}}

--- a/op-acceptor/runner/runner_test.go
+++ b/op-acceptor/runner/runner_test.go
@@ -1593,14 +1593,12 @@ func TestRunTest_PackagePath_Local(t *testing.T) {
 	testCases := []struct {
 		name         string
 		packagePath  string
-		setupGit     bool // if false, PATH is emptied to simulate missing git
 		expectStatus types.TestStatus
 		expectErrMsg string
 	}{
 		{
 			name:         "Local path does not exist",
 			packagePath:  "./does-not-exist",
-			setupGit:     true, // doesn't matter for local
 			expectStatus: types.TestStatusFail,
 			expectErrMsg: "local package path does not exist",
 		},
@@ -1608,11 +1606,6 @@ func TestRunTest_PackagePath_Local(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.setupGit {
-				os.Setenv("PATH", origPath)
-			} else {
-				os.Setenv("PATH", "")
-			}
 			result, err := r.RunTest(context.Background(), types.ValidatorMetadata{
 				ID:       "test",
 				Gate:     "test-gate",

--- a/op-acceptor/runner/runner_test.go
+++ b/op-acceptor/runner/runner_test.go
@@ -1584,7 +1584,7 @@ gates:
 	require.NotEmpty(t, validators, "Registry should have validators")
 }
 
-func TestRunTest_PackagePath_GitAndLocalScenarios(t *testing.T) {
+func TestRunTest_PackagePath_Local(t *testing.T) {
 	r := setupDefaultTestRunner(t)
 
 	origPath := os.Getenv("PATH")
@@ -1603,48 +1603,6 @@ func TestRunTest_PackagePath_GitAndLocalScenarios(t *testing.T) {
 			setupGit:     true, // doesn't matter for local
 			expectStatus: types.TestStatusFail,
 			expectErrMsg: "local package path does not exist",
-		},
-		{
-			name:         "GitHub path, git present",
-			packagePath:  "github.com/optimism/does-not-exist", // this package should not exist
-			setupGit:     true,
-			expectStatus: types.TestStatusFail,
-			expectErrMsg: "no required module provides package",
-		},
-		{
-			name:         "GitHub path, git missing",
-			packagePath:  "github.com/optimism/does-not-exist",
-			setupGit:     false,
-			expectStatus: types.TestStatusFail,
-			expectErrMsg: "git is not installed",
-		},
-		{
-			name:         "Bitbucket path, git missing",
-			packagePath:  "bitbucket.org/optimism/does-not-exist",
-			setupGit:     false,
-			expectStatus: types.TestStatusFail,
-			expectErrMsg: "git is not installed",
-		},
-		{
-			name:         "Golang.org path, git missing",
-			packagePath:  "golang.org/x/does-not-exist",
-			setupGit:     false,
-			expectStatus: types.TestStatusFail,
-			expectErrMsg: "git is not installed",
-		},
-		{
-			name:         "git:: protocol, git missing",
-			packagePath:  "git::https://github.com/optimism/does-not-exist",
-			setupGit:     false,
-			expectStatus: types.TestStatusFail,
-			expectErrMsg: "git is not installed",
-		},
-		{
-			name:         "git@ protocol, git missing",
-			packagePath:  "git@github.com:example/does-not-exist",
-			setupGit:     false,
-			expectStatus: types.TestStatusFail,
-			expectErrMsg: "git is not installed",
 		},
 	}
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- Add git and other build dependencies to the op-acceptor docker image. 
- Increase the timeout for listing tests as it downloads dependencies and increase logs
- Add extra logging for tests

**Tests**

Added a test to verify the paths checks logic.

**Additional context**

When running the tests sometimes we may want to get extra information on these. Right now we need to ssh into the container, but this PR adds a flag to dump the logs into the console.

Requires https://github.com/ethereum-optimism/optimism/pull/16050 for the test log level.

**Metadata**

- Fixes #[Link to Issue]
