### PR TITLE
Fix broken link to op-acceptor README in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository is an extension of the [Optimism monorepo](https://github.com/ethereum-optimism/optimism) and contains the infrastructure that supports the Optimism ecosystem.
 
 ## Components
-- op-acceptor: Network Acceptance Tester: A tool that tests the network acceptance of devnets. (See [op-acceptor/README.md](./acceptor/README.md) or [devdocs/pm](https://devdocs.optimism.io/pm/acceptance-testing.html) for more information)
+- op-acceptor: Network Acceptance Tester: A tool that tests the network acceptance of devnets. (See [op-acceptor/README.md](./op-acceptor/README.md) or [devdocs/pm](https://devdocs.optimism.io/pm/acceptance-testing.html) for more information)
 - op-conductor-mon: Monitors multiple op-conductor instances and provides a unified interface for reporting metrics.
 - op-signer: Thin gateway that supports various RPC endpoints to sign payloads from op-stack components using private key stored in KMS.
 - op-ufm: User facing monitoring creates transactions at regular intervals and observe transaction propagation across different RPC providers.


### PR DESCRIPTION
Corrected the path to the op-acceptor component's README file in the main README. The previous link pointed to a non-existent acceptor/README.md; it now correctly points to op-acceptor/README.md. This resolves the broken link error and ensures users can access the relevant documentation.