### PR TITLE
Fix broken Geth silent patch policy link in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ Alongside this policy, we also reserve the right to do either of the following:
 - bypass this policy and publish details on a shorter timeline
 - to directly notify a subset of downstream users prior to making a public announcement
 
-This policy is based the Geth team’s [silent patch policy](https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities#why-silent-patches).
+This policy is based the Geth team’s [silent patch policy](https://geth.ethereum.org/docs/developers/geth-developer/disclosures#why-silent-patches).
 
 ### Defensive measures during an incident
 


### PR DESCRIPTION
**Description**

Replaced the outdated and broken link to the Geth silent patch policy with the current URL, including an anchor to the "Why silent patches" section. This ensures readers are directed to the relevant policy details on the official Geth documentation site.
