### PR TITLE
fix(op-acceptor): unblock faucet for persistent devnets

### DIFF
--- a/op-acceptor/addons/faucet/faucet.go
+++ b/op-acceptor/addons/faucet/faucet.go
@@ -171,7 +171,11 @@ func getELRPC(c *descriptors.Chain) (string, error) {
 			if !ok {
 				return "", fmt.Errorf("rpc endpoint not found")
 			}
-			return fmt.Sprintf("%s://%s:%d", ep.Scheme, ep.Host, ep.Port), nil
+			scheme := ep.Scheme
+			if scheme == "" {
+				scheme = "http"
+			}
+			return fmt.Sprintf("%s://%s:%d", scheme, ep.Host, ep.Port), nil
 		}
 	}
 
@@ -184,5 +188,9 @@ func getELRPC(c *descriptors.Chain) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("rpc endpoint not found")
 	}
-	return fmt.Sprintf("%s://%s:%d", ep.Scheme, ep.Host, ep.Port), nil
+	scheme := ep.Scheme
+	if scheme == "" {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s:%d", scheme, ep.Host, ep.Port), nil
 }

--- a/op-acceptor/addons/faucet/faucet.go
+++ b/op-acceptor/addons/faucet/faucet.go
@@ -3,6 +3,7 @@ package faucet
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"strconv"
@@ -96,10 +97,7 @@ func (s *Service) Stop(ctx context.Context) error {
 }
 
 func chainFaucet(chain *descriptors.Chain, wallet *descriptors.Wallet) *fconf.FaucetEntry {
-	chainID, err := eth.ParseDecimalChainID(chain.ID)
-	if err != nil {
-		return nil
-	}
+	chainID := eth.ChainIDFromBig(chain.Config.ChainID)
 	elRPC, err := getELRPC(chain)
 	if err != nil {
 		return nil
@@ -147,6 +145,10 @@ func (s *Service) faucetsConfig(env *env.DevnetEnv) *fconf.Config {
 		}
 		faucetID := types.FaucetID(fmt.Sprintf("%s-faucet", l2.ID))
 		faucetEntry := chainFaucet(l2.Chain, wallet)
+		if faucetEntry == nil {
+			log.Println("failed to create faucet entry", "chainID", l2.ID)
+			continue
+		}
 		cfg.Faucets[faucetID] = faucetEntry
 		cfg.Defaults[faucetEntry.ChainID] = faucetID
 	}

--- a/op-acceptor/addons/faucet/faucet.go
+++ b/op-acceptor/addons/faucet/faucet.go
@@ -156,8 +156,9 @@ func (s *Service) faucetsConfig(env *env.DevnetEnv) *fconf.Config {
 	if l1Wallet != nil {
 		l1 := env.Env.L1
 		faucetEntry := chainFaucet(l1, l1Wallet)
-		cfg.Faucets[types.FaucetID("l1-faucet")] = faucetEntry
-		cfg.Defaults[faucetEntry.ChainID] = types.FaucetID("l1-faucet")
+		faucetID := types.FaucetID(fmt.Sprintf("%s-faucet", l1.ID))
+		cfg.Faucets[faucetID] = faucetEntry
+		cfg.Defaults[faucetEntry.ChainID] = faucetID
 	}
 
 	return cfg
@@ -170,7 +171,7 @@ func getELRPC(c *descriptors.Chain) (string, error) {
 			if !ok {
 				return "", fmt.Errorf("rpc endpoint not found")
 			}
-			return fmt.Sprintf("http://%s:%d", ep.Host, ep.Port), nil
+			return fmt.Sprintf("%s://%s:%d", ep.Scheme, ep.Host, ep.Port), nil
 		}
 	}
 
@@ -183,5 +184,5 @@ func getELRPC(c *descriptors.Chain) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("rpc endpoint not found")
 	}
-	return fmt.Sprintf("http://%s:%d", ep.Host, ep.Port), nil
+	return fmt.Sprintf("%s://%s:%d", ep.Scheme, ep.Host, ep.Port), nil
 }

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"slices"
 	"strings"
 	"sync"
@@ -164,6 +165,7 @@ func (n *nat) Start(ctx context.Context) error {
 	defer func() {
 		if r := recover(); r != nil {
 			n.config.Log.Error("Runtime error occurred", "error", r)
+			debug.PrintStack()
 			os.Exit(exitcodes.RuntimeErr)
 		}
 	}()


### PR DESCRIPTION
**Description**

This change does 2 things:
- stop swallowing stack traces in case of panic, which is not helpful for debugging
- fix faucet chain ID calculation

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
