### PR TITLE
feat(proxyd): don't use semaphore if allowing unlimited concurrency

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1489,6 +1489,10 @@ type LimitedHTTPClient struct {
 }
 
 func (c *LimitedHTTPClient) DoLimited(req *http.Request) (*http.Response, error) {
+	if c.sem == nil {
+		return c.Do(req)
+	}
+
 	if err := c.sem.Acquire(req.Context(), 1); err != nil {
 		tooManyRequestErrorsTotal.WithLabelValues(c.backendName).Inc()
 		return nil, wrapErr(err, "too many requests")

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -1,9 +1,15 @@
 package proxyd
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 )
 
 func TestStripXFF(t *testing.T) {
@@ -19,4 +25,57 @@ func TestStripXFF(t *testing.T) {
 		actual := stripXFF(test.in)
 		assert.Equal(t, test.out, actual)
 	}
+}
+
+func TestLimitedHTTPClientDoLimited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Run("unlimited requests", func(t *testing.T) {
+		client := &LimitedHTTPClient{
+			Client:      http.Client{},
+			sem:         nil,
+			backendName: "test-unlimited",
+		}
+
+		req, err := http.NewRequest("GET", server.URL, nil)
+		require.NoError(t, err)
+
+		resp, err := client.DoLimited(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		resp.Body.Close()
+	})
+
+	t.Run("limited requests", func(t *testing.T) {
+		sem := semaphore.NewWeighted(1)
+		client := &LimitedHTTPClient{
+			Client:      http.Client{},
+			sem:         sem,
+			backendName: "test-limited",
+		}
+
+		req, err := http.NewRequest("GET", server.URL, nil)
+		require.NoError(t, err)
+
+		resp, err := client.DoLimited(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		resp.Body.Close()
+
+		// Exhaust semaphore
+		require.True(t, sem.TryAcquire(1))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		req, err = http.NewRequestWithContext(ctx, "GET", server.URL, nil)
+		require.NoError(t, err)
+
+		resp, err = client.DoLimited(req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "context deadline exceeded")
+		require.Nil(t, resp)
+	})
 }

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -61,9 +61,11 @@ func TestLimitedHTTPClientDoLimited(t *testing.T) {
 		require.NoError(t, err)
 
 		resp, err := client.DoLimited(req)
+		if resp != nil {
+			defer resp.Body.Close()
+		}
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		resp.Body.Close()
 
 		// Exhaust semaphore
 		require.True(t, sem.TryAcquire(1))
@@ -74,6 +76,9 @@ func TestLimitedHTTPClientDoLimited(t *testing.T) {
 		require.NoError(t, err)
 
 		resp, err = client.DoLimited(req)
+		if resp != nil {
+			defer resp.Body.Close()
+		}
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "context deadline exceeded")
 		require.Nil(t, resp)

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -17,7 +17,9 @@ type ServerConfig struct {
 	WSPort            int    `toml:"ws_port"`
 	MaxBodySizeBytes  int64  `toml:"max_body_size_bytes"`
 	MaxConcurrentRPCs int64  `toml:"max_concurrent_rpcs"`
-	LogLevel          string `toml:"log_level"`
+	// EnableUnlimitedConcurrentRpcs=true allows unlimited concurrent RPC requests. This takes precedence over MaxConcurrentRPCs.
+	EnableUnlimitedConcurrentRpcs bool   `toml:"enable_unlimited_concurrent_rpcs"`
+	LogLevel                      string `toml:"log_level"`
 
 	// TimeoutSeconds specifies the maximum time spent serving an HTTP request. Note that isn't used for websocket connections
 	TimeoutSeconds int `toml:"timeout_seconds"`

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -17,9 +17,9 @@ type ServerConfig struct {
 	WSPort            int    `toml:"ws_port"`
 	MaxBodySizeBytes  int64  `toml:"max_body_size_bytes"`
 	MaxConcurrentRPCs int64  `toml:"max_concurrent_rpcs"`
-	// EnableUnlimitedConcurrentRpcs=true allows unlimited concurrent RPC requests. This takes precedence over MaxConcurrentRPCs.
-	EnableUnlimitedConcurrentRpcs bool   `toml:"enable_unlimited_concurrent_rpcs"`
-	LogLevel                      string `toml:"log_level"`
+	// DisableConcurrentRequestSemaphore=true allows unlimited concurrent RPC requests. This takes precedence over MaxConcurrentRPCs.
+	DisableConcurrentRequestSemaphore bool   `toml:"disable_concurrent_request_semaphore"`
+	LogLevel                          string `toml:"log_level"`
 
 	// TimeoutSeconds specifies the maximum time spent serving an HTTP request. Note that isn't used for websocket connections
 	TimeoutSeconds int `toml:"timeout_seconds"`

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"os"
 	"time"
@@ -112,11 +113,13 @@ func Start(config *Config) (*Server, func(), error) {
 
 	maxConcurrentRPCs := config.Server.MaxConcurrentRPCs
 	var rpcRequestSemaphore *semaphore.Weighted
-	// Legacy behavior of maxConcurrentRPCs == 0 is to allow unlimited concurrent RPC requests
-	if config.Server.EnableUnlimitedConcurrentRpcs || maxConcurrentRPCs == 0 {
+	if config.Server.DisableConcurrentRequestSemaphore {
 		rpcRequestSemaphore = nil
 		log.Info("Using unlimited RPC concurrency")
 	} else {
+		if maxConcurrentRPCs == 0 {
+			maxConcurrentRPCs = math.MaxInt64
+		}
 		rpcRequestSemaphore = semaphore.NewWeighted(maxConcurrentRPCs)
 		log.Info("Using max concurrent RPCs of", "maxConcurrentRPCs", maxConcurrentRPCs)
 	}

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -112,8 +112,8 @@ func Start(config *Config) (*Server, func(), error) {
 
 	maxConcurrentRPCs := config.Server.MaxConcurrentRPCs
 	var rpcRequestSemaphore *semaphore.Weighted
-	if maxConcurrentRPCs == 0 {
-		// synonymous with unlimited concurrent requests
+	// Legacy behavior of maxConcurrentRPCs == 0 is to allow unlimited concurrent RPC requests
+	if config.Server.EnableUnlimitedConcurrentRpcs || maxConcurrentRPCs == 0 {
 		rpcRequestSemaphore = nil
 		log.Info("Using unlimited RPC concurrency")
 	} else {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Instead of creating semaphore with unlimited weight, just skip using semaphore entirely if we allow unlimited concurrent requests. Also adds a new log on init that explicitly tells us if we're using unlimited or limited concurrent requests.

**Tests**

Unit test to make sure unlimited vs. limited requests works as expected

**Additional context**

Unichain proxyd previously had issues where requests were incorrectly being rate limited due to semaphore exhaustion, despite unlimited concurrency being configured. The RC is still unclear, but having explicit logs on init, and only using the semaphore when necessary will help with future debugging.
