### PR TITLE
fix: shift the req size limit check to happen only upon the interop transaction recognition

### DIFF
--- a/proxyd/integration_tests/interop_validation_test.go
+++ b/proxyd/integration_tests/interop_validation_test.go
@@ -627,7 +627,7 @@ func TestInteropValidation_SenderRateLimit(t *testing.T) {
 	// make a non-interop request to ensure that it succeeds despite the breaked rate limit depicting that the rate limit is not applied to non-interop requests
 	{
 		_, observedCode, err := client.SendRequest(nonInteropSendRawTransaction)
-	
+
 		// ensuring that this call succeeded despite the breached interop rate limit
 		require.NoError(t, err)
 		require.Equal(t, 200, observedCode)

--- a/proxyd/integration_tests/interop_validation_test.go
+++ b/proxyd/integration_tests/interop_validation_test.go
@@ -579,6 +579,7 @@ func TestInteropValidation_SenderRateLimit(t *testing.T) {
 
 	config.InteropValidationConfig.RateLimit.Enabled = true
 	config.InteropValidationConfig.RateLimit.Limit = 1
+	config.InteropValidationConfig.RateLimit.Interval = proxyd.TOMLDuration(2 * time.Second)
 
 	validatingBackend1 := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
 	defer validatingBackend1.Close()
@@ -595,9 +596,18 @@ func TestInteropValidation_SenderRateLimit(t *testing.T) {
 	client := NewProxydClient("http://127.0.0.1:8545")
 	fakeInteropReqParams, err := convertTxToReqParams(fakeTxBuilder())
 	require.NoError(t, err)
-	sendRawTransaction := makeSendRawTransaction(fakeInteropReqParams)
-	_, observedCode1, err1 := client.SendRequest(sendRawTransaction)
-	observedResp2, observedCode2, err2 := client.SendRequest(sendRawTransaction)
+	interopSendRawTransaction := makeSendRawTransaction(fakeInteropReqParams)
+
+	nonInteropReqParams, err := convertTxToReqParams(fakeTxBuilder(
+		func(tx *types.AccessListTx) {
+			tx.AccessList = nil
+		},
+	))
+	require.NoError(t, err)
+	nonInteropSendRawTransaction := makeSendRawTransaction(nonInteropReqParams)
+
+	_, observedCode1, err1 := client.SendRequest(interopSendRawTransaction)
+	observedResp2, observedCode2, err2 := client.SendRequest(interopSendRawTransaction)
 
 	// ensuring the first call succeeded
 	require.NoError(t, err1)
@@ -614,11 +624,27 @@ func TestInteropValidation_SenderRateLimit(t *testing.T) {
 	// ensuring that the second call didn't contribute to additional validating backend (supervisor) requests
 	require.Equal(t, len(validatingBackend1.requests), 1)
 
+	// make a non-interop request to ensure that it succeeds despite the breaked rate limit depicting that the rate limit is not applied to non-interop requests
+	{
+		_, observedCode, err := client.SendRequest(nonInteropSendRawTransaction)
+	
+		// ensuring that this call succeeded despite the breached interop rate limit
+		require.NoError(t, err)
+		require.Equal(t, 200, observedCode)
+
+		// ensure that the rate limit is still breached by making an interop transaction
+		observedResp, observedCode, err := client.SendRequest(interopSendRawTransaction)
+		require.NoError(t, err)
+		require.Equal(t, 429, observedCode)
+		require.Contains(t, string(observedResp), "sender is over rate limit")
+		require.Contains(t, string(observedResp), fmt.Sprintf("\"code\":%d", -32017))
+	}
+
 	// waiting for the rate limit to reset
-	time.Sleep(1100 * time.Millisecond)
+	time.Sleep(2100 * time.Millisecond)
 
 	// ensuring the third call succeeds
-	_, observedCode3, err3 := client.SendRequest(sendRawTransaction)
+	_, observedCode3, err3 := client.SendRequest(interopSendRawTransaction)
 	require.NoError(t, err3)
 	require.Equal(t, 200, observedCode3)
 

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -15,7 +15,7 @@ import (
 )
 
 type InteropStrategy interface {
-	Validate(ctx context.Context, req *RPCReq) error
+	ValidateAccessList(ctx context.Context, interopAccessList []common.Hash) error
 }
 
 type commonInteropStrategy struct {
@@ -72,28 +72,7 @@ var WithSkipOnNoSupervisorBackend = func(skipOnNoSupervisorBackend bool) commonS
 	}
 }
 
-func (s *commonInteropStrategy) preflightChecksToAccessList(ctx context.Context, req *RPCReq) ([]common.Hash, bool, error) {
-	tx, err := convertSendReqToSendTx(ctx, req)
-	if err != nil {
-		return nil, false, err
-	}
-
-	interopAccessList := interoptypes.TxToInteropAccessList(tx)
-	if len(interopAccessList) == 0 {
-		log.Debug(
-			"no interop access list found, inferring the absence of executing messages and skipping interop validation",
-			"source", "rpc",
-			"req_id", GetReqID(ctx),
-			"method", "eth_sendRawTransaction",
-		)
-		return nil, false, nil
-	}
-	// at this point, we know it's an interop transaction worthy of being validated
-
-	if err := reqSizeLimitCheck(ctx, req, s.reqSizeLimit); err != nil {
-		return nil, false, err
-	}
-
+func (s *commonInteropStrategy) preflightChecksAndCleanupAccessList(ctx context.Context, interopAccessList []common.Hash) ([]common.Hash, bool, error) {
 	if len(s.urls) == 0 {
 		if s.skipOnNoSupervisorBackend {
 			log.Info(
@@ -110,7 +89,7 @@ func (s *commonInteropStrategy) preflightChecksToAccessList(ctx context.Context,
 		)
 		return nil, false, supervisorTypes.ErrNoRPCSource
 	}
-
+	var err error
 	if s.validateAndDeduplicateInteropAccessList {
 		interopAccessList, err = validateAndDeduplicateInteropAccessList(interopAccessList)
 		if err != nil {
@@ -144,8 +123,8 @@ func NewFirstSupervisorStrategy(urls []string, opts ...commonStrategyOpt) *first
 	}
 }
 
-func (s *firstSupervisorStrategyImpl) Validate(ctx context.Context, req *RPCReq) error {
-	accessListToValidate, proceedFurther, err := s.preflightChecksToAccessList(ctx, req)
+func (s *firstSupervisorStrategyImpl) ValidateAccessList(ctx context.Context, interopAccessList []common.Hash) error {
+	accessListToValidate, proceedFurther, err := s.preflightChecksAndCleanupAccessList(ctx, interopAccessList)
 	if err != nil {
 		return err
 	}
@@ -171,8 +150,8 @@ func NewMulticallStrategy(urls []string, opts ...commonStrategyOpt) *multicallSt
 	}
 }
 
-func (s *multicallStrategyImpl) Validate(ctx context.Context, req *RPCReq) error {
-	accessListToValidate, proceedFurther, err := s.preflightChecksToAccessList(ctx, req)
+func (s *multicallStrategyImpl) ValidateAccessList(ctx context.Context, interopAccessList []common.Hash) error {
+	accessListToValidate, proceedFurther, err := s.preflightChecksAndCleanupAccessList(ctx, interopAccessList)
 	if err != nil {
 		return err
 	}
@@ -200,7 +179,7 @@ func (s *multicallStrategyImpl) Validate(ctx context.Context, req *RPCReq) error
 			"all interop validating backends have responded",
 			"source", "rpc",
 			"req_id", GetReqID(ctx),
-			"method", req.Method,
+			"method", "eth_sendRawTransaction",
 		)
 		for range resultChan {
 		} // drain the channel
@@ -234,10 +213,10 @@ func NewHealthAwareLoadBalancingStrategy(urls []string, unhealthinessTimeout tim
 	return s
 }
 
-func (s *healthAwareLoadBalancingStrategyImpl) Validate(ctx context.Context, req *RPCReq) error {
+func (s *healthAwareLoadBalancingStrategyImpl) ValidateAccessList(ctx context.Context, interopAccessList []common.Hash) error {
 	defer s.backends.NextBackend() // move to the next backend after the request is done
 
-	accessListToValidate, proceedFurther, err := s.preflightChecksToAccessList(ctx, req)
+	accessListToValidate, proceedFurther, err := s.preflightChecksAndCleanupAccessList(ctx, interopAccessList)
 	if err != nil {
 		return err
 	}
@@ -259,7 +238,7 @@ func (s *healthAwareLoadBalancingStrategyImpl) Validate(ctx context.Context, req
 			continue
 		}
 
-		httpCode, err := backend.Validate(ctx, accessListToValidate, req)
+		httpCode, err := backend.Validate(ctx, accessListToValidate)
 		if err == nil {
 			return nil
 		}
@@ -311,7 +290,7 @@ func (b *healthAwareBackend) MarkUnhealthy() {
 	b.lastUnhealthy = time.Now()
 }
 
-func (b *healthAwareBackend) Validate(ctx context.Context, accessList []common.Hash, req *RPCReq) (int, error) {
+func (b *healthAwareBackend) Validate(ctx context.Context, accessList []common.Hash) (int, error) {
 	httpCode, _, err := performCheckAccessListOp(ctx, accessList, b.url)
 	if err != nil {
 		return httpCode, ParseInteropError(err)

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -78,10 +78,6 @@ func (s *commonInteropStrategy) preflightChecksToAccessList(ctx context.Context,
 		return nil, false, err
 	}
 
-	if err := reqSizeLimitCheck(ctx, req, s.reqSizeLimit); err != nil {
-		return nil, false, err
-	}
-
 	interopAccessList := interoptypes.TxToInteropAccessList(tx)
 	if len(interopAccessList) == 0 {
 		log.Debug(
@@ -92,8 +88,12 @@ func (s *commonInteropStrategy) preflightChecksToAccessList(ctx context.Context,
 		)
 		return nil, false, nil
 	}
-
 	// at this point, we know it's an interop transaction worthy of being validated
+
+	if err := reqSizeLimitCheck(ctx, req, s.reqSizeLimit); err != nil {
+		return nil, false, err
+	}
+
 	if len(s.urls) == 0 {
 		if s.skipOnNoSupervisorBackend {
 			log.Info(

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -247,16 +247,6 @@ func Start(config *Config) (*Server, func(), error) {
 		config.InteropValidationConfig.AccessListSizeLimit = defaultInteropAccessListSizeLimit
 	}
 
-	if config.InteropValidationConfig.AccessListSizeLimit == 0 {
-		log.Warn("no interop validation access list size limit provided, using default size limit", "size_limit", defaultInteropAccessListSizeLimit)
-		config.InteropValidationConfig.AccessListSizeLimit = defaultInteropAccessListSizeLimit
-	}
-
-	if config.InteropValidationConfig.AccessListSizeLimit == 0 {
-		log.Warn("no interop validation access list size limit provided, using default size limit", "size_limit", defaultInteropAccessListSizeLimit)
-		config.InteropValidationConfig.AccessListSizeLimit = defaultInteropAccessListSizeLimit
-	}
-
 	log.Info("configured interop validation urls", "urls", config.InteropValidationConfig.Urls)
 	log.Info("configured interop validation strategy", "strategy", config.InteropValidationConfig.Strategy)
 

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -407,8 +407,8 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 	writeRPCRes(ctx, w, backendRes[0])
 }
 
-// reqSizeLimitCheck is a function which helps define, check and limit the size of the incoming request beyond the "max_request_body_size_bytes" setting.
-// Rest, if you would like this kind of check to happen at the inception of the request (before the request is parsed into RPCReq), it's better to use the "max_request_body_size_bytes"
+// reqSizeLimitCheck is a function which helps define, check and limit the size of the incoming request beyond the "max_body_size_bytes" setting.
+// Rest, if you would like this kind of check to happen at the inception of the request (before the request is parsed into RPCReq), it's better to use the "max_body_size_bytes"
 func reqSizeLimitCheck(ctx context.Context, rpcReq *RPCReq, maxSize int) error {
 	if maxSize <= 0 {
 		return nil


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Shifts the req size limit check to happen after interop message recognition.

**Tests**

Tests added for it.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
