### PR TITLE
Add metric that monitors fallback candidate health

### DIFF
--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -738,7 +738,9 @@ func (cp *ConsensusPoller) getConsensusCandidates() map[*Backend]*backendState {
 		return healthyPrimaries
 	}
 
-	return cp.FilterCandidates(cp.backendGroup.Fallbacks())
+	healthyFallbacks := cp.FilterCandidates(cp.backendGroup.Fallbacks())
+	RecordHealthyFallbackCandidates(cp.backendGroup, len(healthyFallbacks))
+	return healthyFallbacks
 }
 
 // filterCandidates find out what backends are the candidates to be in the consensus group

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -732,14 +732,15 @@ func (cp *ConsensusPoller) setBackendState(be *Backend, peerCount uint64, inSync
 func (cp *ConsensusPoller) getConsensusCandidates() map[*Backend]*backendState {
 
 	healthyPrimaries := cp.FilterCandidates(cp.backendGroup.Primaries())
-
 	RecordHealthyCandidates(cp.backendGroup, len(healthyPrimaries))
+
+	healthyFallbacks := cp.FilterCandidates(cp.backendGroup.Fallbacks())
+	RecordHealthyFallbackCandidates(cp.backendGroup, len(healthyFallbacks))
+
 	if len(healthyPrimaries) > 0 {
 		return healthyPrimaries
 	}
 
-	healthyFallbacks := cp.FilterCandidates(cp.backendGroup.Fallbacks())
-	RecordHealthyFallbackCandidates(cp.backendGroup, len(healthyFallbacks))
 	return healthyFallbacks
 }
 

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -442,6 +442,14 @@ var (
 		"backend_group_name",
 	})
 
+	healthyFallbackCandidates = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "healthy_fallback_candidates",
+		Help:      "Record the number of healthy fallback candidates",
+	}, []string{
+		"backend_group_name",
+	})
+
 	backendGroupFallbackBackend = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
 		Name:      "backend_group_fallback_backenend",
@@ -603,6 +611,10 @@ func RecordConsensusBackendBanned(b *Backend, banned bool) {
 
 func RecordHealthyCandidates(b *BackendGroup, candidates int) {
 	healthyPrimaryCandidates.WithLabelValues(b.Name).Set(float64(candidates))
+}
+
+func RecordHealthyFallbackCandidates(b *BackendGroup, candidates int) {
+	healthyFallbackCandidates.WithLabelValues(b.Name).Set(float64(candidates))
 }
 
 func RecordConsensusBackendPeerCount(b *Backend, peerCount uint64) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

It is useful to be able to alert when all of the fallback candidates are unhealthy or if the healthy fallback candidates have  fallen below a certain level.

This PR adds a gauge to monitor this whenever the primary candidates are all unhealthy

Note that this also adds consensus polling for fallback candidates when there are healthy primary backends available (earlier, consensus polling was only performed if no primary candidates were healthy). I acknowledge that maybe this behavior might be undesired for some people...
I'm open to creating a CLI flag to disable this behavior, but personally think that the default should be to monitor for fallback candidate health so that the metric is by default populated. Open to suggestions about this from core maintainers.

**Tests**

Testing in-progress, but wanted to publish the PR with the note about consensus polling for fallbacks behavior

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
