### PR TITLE
feat(proxyd): 499 error code for context canceled

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -594,6 +594,11 @@ func (b *Backend) Forward(ctx context.Context, reqs []*RPCReq, isBatch bool) ([]
 			)
 		case ErrContextCanceled:
 			// return immediately on client cancellation
+			log.Debug("context canceled while forwarding request",
+				"name", b.Name,
+				"req_id", GetReqID(ctx),
+				"err", err,
+			)
 			return nil, err
 		default:
 			lastError = err
@@ -1518,7 +1523,7 @@ func (c *LimitedHTTPClient) DoLimited(req *http.Request) (*http.Response, error)
 			return nil, ErrContextCanceled
 		}
 		tooManyRequestErrorsTotal.WithLabelValues(c.backendName).Inc()
-		return nil, ErrTooManyRequests
+		return nil, wrapErr(err, ErrTooManyRequests.Message)
 	}
 	defer c.sem.Release(1)
 	return c.Do(req)

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -125,6 +125,12 @@ var (
 		HTTPErrorCode: 499,
 	}
 
+	ErrTooManyRequests = &RPCErr{
+		Code:          JSONRPCErrorInternal - 24,
+		Message:       "too many requests",
+		HTTPErrorCode: 429,
+	}
+
 	ErrBackendUnexpectedJSONRPC = errors.New("backend returned an unexpected JSON-RPC response")
 
 	ErrConsensusGetReceiptsCantBeBatched = errors.New("consensus_getReceipts cannot be batched")

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
@@ -83,4 +85,102 @@ func TestLimitedHTTPClientDoLimited(t *testing.T) {
 		require.Contains(t, err.Error(), "context deadline exceeded")
 		require.Nil(t, resp)
 	})
+}
+
+func TestClientDisconnectionFlow499(t *testing.T) {
+	initialCount := getHttpResponseCodeCount("499")
+
+	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			// Context cancelled - return immediately to simulate backend detecting cancellation
+			return
+		case <-time.After(100 * time.Millisecond):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"jsonrpc":"2.0","result":"0x1","id":1}`))
+		}
+	}))
+	defer backendServer.Close()
+
+	backend := NewBackend("test-backend", backendServer.URL, "", semaphore.NewWeighted(1))
+	backendGroup := &BackendGroup{
+		Name:     "test-group",
+		Backends: []*Backend{backend},
+	}
+
+	rpcMethodMappings := map[string]string{
+		"eth_blockNumber": "test-group",
+	}
+
+	proxydServer, err := NewServer(
+		map[string]*BackendGroup{"test-group": backendGroup},
+		backendGroup,
+		NewStringSetFromStrings([]string{"eth_blockNumber"}),
+		rpcMethodMappings,
+		1024*1024,               // maxBodySize
+		map[string]string{},     // authenticatedPaths
+		5*time.Second,           // timeout - longer than our test
+		10,                      // maxUpstreamBatchSize
+		false,                   // enableServedByHeader
+		&NoopRPCCache{},         // cache
+		RateLimitConfig{},       // rateLimitConfig
+		SenderRateLimitConfig{}, // senderRateLimitConfig
+		SenderRateLimitConfig{}, // interopSenderRateLimitConfig
+		false,                   // enableRequestLog
+		0,                       // maxRequestBodyLogLen
+		100,                     // maxBatchSize
+		func(dur time.Duration, max int, prefix string) FrontendRateLimiter {
+			return NoopFrontendRateLimiter
+		}, // limiterFactory
+		InteropValidationConfig{},              // interopValidatingConfig
+		NewFirstSupervisorStrategy([]string{}), // interopStrategy
+	)
+	require.NoError(t, err)
+
+	reqBody := `{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}`
+
+	httpReq := httptest.NewRequest("POST", "/", strings.NewReader(reqBody))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-Forwarded-For", "127.0.0.1")
+
+	ctx, cancel := context.WithCancel(httpReq.Context())
+	httpReq = httpReq.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+
+	// Start the request in a goroutine and cancel it immediately to simulate client disconnection
+	done := make(chan bool)
+	go func() {
+		defer func() { done <- true }()
+		proxydServer.HandleRPC(rr, httpReq)
+	}()
+
+	cancel()
+	<-done
+
+	t.Logf("Response status code: %d", rr.Code)
+
+	finalCount := getHttpResponseCodeCount("499")
+
+	assert.Greater(t, finalCount, initialCount, "httpResponseCodesTotal should be incremented for 499 status code")
+}
+
+func getHttpResponseCodeCount(statusCode string) float64 {
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		return 0
+	}
+
+	for _, mf := range metricFamilies {
+		if mf.GetName() == "proxyd_http_response_codes_total" {
+			for _, metric := range mf.GetMetric() {
+				for _, label := range metric.GetLabel() {
+					if label.GetName() == "status_code" && label.GetValue() == statusCode {
+						return metric.GetCounter().GetValue()
+					}
+				}
+			}
+		}
+	}
+	return 0
 }

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -97,7 +97,7 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 			return
 		case <-time.After(100 * time.Millisecond):
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"jsonrpc":"2.0","result":"0x1","id":1}`))
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","result":"0x1","id":1}`))
 		}
 	}))
 	defer backendServer.Close()

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -82,7 +82,7 @@ func TestLimitedHTTPClientDoLimited(t *testing.T) {
 			defer resp.Body.Close()
 		}
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "context deadline exceeded")
+		require.Contains(t, err.Error(), "too many requests")
 		require.Nil(t, resp)
 	})
 }

--- a/proxyd/errors.go
+++ b/proxyd/errors.go
@@ -1,11 +1,8 @@
 package proxyd
 
 import (
-	"errors"
 	"fmt"
 )
-
-var ErrTooManyRequests = errors.New("too many requests")
 
 func wrapErr(err error, msg string) error {
 	return fmt.Errorf("%s %w", msg, err)

--- a/proxyd/errors.go
+++ b/proxyd/errors.go
@@ -8,5 +8,5 @@ import (
 var ErrTooManyRequests = errors.New("too many requests")
 
 func wrapErr(err error, msg string) error {
-	return fmt.Errorf("%s\n%w", msg, err)
+	return fmt.Errorf("%s %w", msg, err)
 }

--- a/proxyd/errors.go
+++ b/proxyd/errors.go
@@ -1,7 +1,12 @@
 package proxyd
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrTooManyRequests = errors.New("too many requests")
 
 func wrapErr(err error, msg string) error {
-	return fmt.Errorf("%s %w", msg, err)
+	return fmt.Errorf("%s\n%w", msg, err)
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Introducing artificial "499" error code to be included in metrics, for when client cancels the request. This is useful for monitoring, and helps distinguish between genuine server issues (500) vs. client-side issues.

[Cloudflare](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/4xx-client-error/error-499/) already uses this error code to indicate client cancellations.

- new `ErrContextCanceled` error with 499 error code
- bubble up context canceled to correctly be included in httpErrorCodesTotal metric

**Tests**

Unit test to make sure new the metric count is incrementing correctly when 499 is seen.
