### PR TITLE
feat(proxyd) support forwarding headers for requests

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -740,6 +740,13 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 		return nil, wrapErr(err, "error creating backend request")
 	}
 
+	headersToForward := GetHeadersToForward(ctx)
+	if len(headersToForward) != 0 {
+		for k, v := range headersToForward {
+			httpReq.Header[k] = v
+		}
+	}
+
 	if b.authPassword != "" {
 		httpReq.SetBasicAuth(b.authUsername, b.authPassword)
 	}

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -134,6 +134,7 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 		}, // limiterFactory
 		InteropValidationConfig{},              // interopValidatingConfig
 		NewFirstSupervisorStrategy([]string{}), // interopStrategy
+		NewHeadersForwarder([]string{}),
 	)
 	require.NoError(t, err)
 

--- a/proxyd/cache_test.go
+++ b/proxyd/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"testing"
 
@@ -127,6 +128,16 @@ func TestRPCCacheImmutableRPCs(t *testing.T) {
 			cachedRes, err := cache.GetRPC(ctx, rpc.req)
 			require.NoError(t, err)
 			require.Equal(t, rpc.res, cachedRes)
+
+			ctxWithHeaders := context.WithValue(ctx, ContextKeyHeadersToForward, http.Header{"header": []string{"A"}}) // nolint:staticcheck
+
+			err = cache.PutRPC(ctxWithHeaders, rpc.req, rpc.res)
+			require.NoError(t, err)
+
+			cachedRes, err = cache.GetRPC(ctxWithHeaders, rpc.req)
+			require.NoError(t, err)
+			require.Equal(t, rpc.res, cachedRes)
+
 		})
 	}
 }

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -225,6 +225,7 @@ type Config struct {
 	BackendGroups           BackendGroupsConfig     `toml:"backend_groups"`
 	RPCMethodMappings       map[string]string       `toml:"rpc_method_mappings"`
 	WSMethodWhitelist       []string                `toml:"ws_method_whitelist"`
+	AllowedHeadersToForward []string                `toml:"allowed_headers_to_forward"`
 	WhitelistErrorMessage   string                  `toml:"whitelist_error_message"`
 	SenderRateLimit         SenderRateLimitConfig   `toml:"sender_rate_limit"`
 	InteropValidationConfig InteropValidationConfig `toml:"interop_validation"`

--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a
 	github.com/xaionaro-go/weightedshuffle v0.0.0-20211213010739-6a74fbc7d24a
+	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/sync v0.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -130,7 +131,6 @@ require (
 	github.com/yuin/gopher-lua v1.1.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.28.0 // indirect

--- a/proxyd/headers_forwarder.go
+++ b/proxyd/headers_forwarder.go
@@ -1,0 +1,47 @@
+package proxyd
+
+import (
+	"errors"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+var ErrAllowedHeaderNotFound = errors.New("allowed header to forward not found")
+
+type HeadersForwarder struct {
+	allowedHeaders []string
+}
+
+func NewHeadersForwarder(allowedHeaders []string) *HeadersForwarder {
+	return &HeadersForwarder{
+		allowedHeaders: allowedHeaders,
+	}
+}
+
+func (hf *HeadersForwarder) Forward(req http.Header) (http.Header, error) {
+	allowedHeaders := hf.filterNormilized(req)
+	headers := make(http.Header, len(allowedHeaders))
+	for _, h := range allowedHeaders {
+		v, ok := req[h]
+		if !ok {
+			// this should be not happened
+			return nil, ErrAllowedHeaderNotFound
+		}
+		headers[h] = v
+	}
+
+	return headers, nil
+}
+
+func (hf *HeadersForwarder) filterNormilized(reqHeaders http.Header) []string {
+	filtered := make([]string, 0, len(reqHeaders))
+	for header := range reqHeaders {
+		norm := strings.ToLower(header)
+		if slices.Contains(hf.allowedHeaders, norm) {
+			filtered = append(filtered, header)
+		}
+	}
+
+	return filtered
+}

--- a/proxyd/headers_forwarder_test.go
+++ b/proxyd/headers_forwarder_test.go
@@ -1,0 +1,42 @@
+package proxyd
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"slices"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeadersToForward(t *testing.T) {
+	headersToForward := []string{
+		"custom_header",
+		"custom_header2",
+		"custom_header3",
+	}
+	forwarder := NewHeadersForwarder(headersToForward)
+
+	testHeaders := http.Header{
+		"custOm_headeR":  []string{"A", "B", "C"},
+		"custom_header2": []string{"A", "B", "C"},
+		"customHeader3":  []string{"A"},
+		"cUstom_header3": []string{"B", "C"},
+	}
+
+	forwarded, err := forwarder.Forward(testHeaders)
+	require.NoError(t, err)
+
+	for h := range forwarded {
+		var exists bool
+		if slices.Contains(headersToForward, strings.ToLower(h)) {
+			exists = true
+		}
+		require.True(t, exists)
+	}
+
+	_, ok := forwarded["customHeader3"] // nolint:staticcheck
+	require.False(t, ok)
+
+}

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -330,6 +331,13 @@ func Start(config *Config) (*Server, func(), error) {
 		}
 	}
 
+	var allowedHeadersToForward []string
+	// normilize headers
+	for _, h := range config.AllowedHeadersToForward {
+		allowedHeadersToForward = append(allowedHeadersToForward, strings.ToLower(h))
+	}
+	headersForwarder := NewHeadersForwarder(allowedHeadersToForward)
+
 	var (
 		cache    Cache
 		rpcCache RPCCache
@@ -417,6 +425,7 @@ func Start(config *Config) (*Server, func(), error) {
 		limiterFactory,
 		config.InteropValidationConfig,
 		interopStrategy,
+		headersForwarder,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)


### PR DESCRIPTION
**Description**
We at Flashbots would like to leverage `proxyd` across our infra. Even though JSON-RPC standard is transport agnostic, in practice it is mostly used over HTTP, so we as well as some other projects make use of http headers (such as `X-Flashbots-Signature`) to serve customer-authenticated requests. We’d like to be able to resolve header based logic in our application level services, so simply proxying preconfigured set of headers will suffice for us. We’ll be happy to hear your input on this feature, thanks!

**Tests**
Adds test for `HeadersForwarder` and also populates ctx in cache tests to verify that logic of creating `cache-key` is correct.

**Additional context**

**Metadata**

- Fixes #[Link to Issue]
