### PR TITLE
feat(op-acceptor): gateless mode

### DIFF
--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -63,16 +63,16 @@ var (
 	ValidatorConfig = &cli.StringFlag{
 		Name:     "validators",
 		Value:    "",
-		Required: true,
+		Required: false,
 		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "VALIDATORS"),
-		Usage:    "Path to validator config file (eg. 'validators.yaml')",
+		Usage:    "Path to validator config file (eg. 'validators.yaml'). Optional - if not provided, gateless mode will auto-discover tests in the test directory.",
 	}
 	Gate = &cli.StringFlag{
 		Name:     "gate",
 		Value:    "",
-		Required: true,
+		Required: false,
 		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "GATE"),
-		Usage:    "Gate to run (eg. 'alphanet')",
+		Usage:    "Gate to run (eg. 'alphanet'). Optional - if not provided, gateless mode will run all discovered tests.",
 	}
 	GoBinary = &cli.StringFlag{
 		Name:    "go-binary",
@@ -97,6 +97,11 @@ var (
 		Value:   5 * time.Minute,
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "DEFAULT_TIMEOUT"),
 		Usage:   "Default timeout of an individual test (e.g. '30s', '5m', etc.). This setting is superseded by test or suite level timeout configuration. Set to '0' to disable any default timeout. Defaults to '5m'.",
+	}
+	Timeout = &cli.DurationFlag{
+		Name:    "timeout",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "TIMEOUT"),
+		Usage:   "Timeout for all tests in gateless mode (e.g. '30s', '5m', etc.). If not specified, falls back to --default-timeout. Only applies in gateless mode.",
 	}
 	LogDir = &cli.StringFlag{
 		Name:    "logdir",
@@ -135,15 +140,16 @@ var (
 
 var requiredFlags = []cli.Flag{
 	TestDir,
-	ValidatorConfig,
-	Gate,
 }
 
 var optionalFlags = []cli.Flag{
+	ValidatorConfig,
+	Gate,
 	GoBinary,
 	RunInterval,
 	AllowSkips,
 	DefaultTimeout,
+	Timeout,
 	LogDir,
 	TestLogLevel,
 	OutputRealtimeLogs,

--- a/op-acceptor/registry/registry.go
+++ b/op-acceptor/registry/registry.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum-optimism/infra/op-acceptor/testlist"
 	"github.com/ethereum-optimism/infra/op-acceptor/types"
 	"github.com/ethereum/go-ethereum/log"
 	"gopkg.in/yaml.v3"
@@ -23,13 +24,14 @@ type Config struct {
 	Log                 log.Logger
 	ValidatorConfigFile string
 	DefaultTimeout      time.Duration
+	Timeout             time.Duration // Timeout for gateless mode tests (if specified)
+	// Gateless mode fields
+	GatelessMode bool
+	TestDir      string
 }
 
 // NewRegistry creates a new registry instance
 func NewRegistry(cfg Config) (*Registry, error) {
-	if cfg.ValidatorConfigFile == "" {
-		return nil, fmt.Errorf("validator config file is required")
-	}
 	if cfg.Log == nil {
 		cfg.Log = log.New()
 		cfg.Log.Error("No logger provided, using default")
@@ -40,14 +42,81 @@ func NewRegistry(cfg Config) (*Registry, error) {
 		config: cfg,
 	}
 
-	// Load the source
-	if err := r.loadValidators(cfg.ValidatorConfigFile); err != nil {
-		return nil, fmt.Errorf("failed to load source: %w", err)
+	// Load validators based on mode
+	if cfg.GatelessMode {
+		if cfg.TestDir == "" {
+			return nil, fmt.Errorf("test directory is required for gateless mode")
+		}
+		if err := r.loadGatelessValidators(); err != nil {
+			return nil, fmt.Errorf("failed to load gateless validators: %w", err)
+		}
+	} else {
+		if cfg.ValidatorConfigFile == "" {
+			return nil, fmt.Errorf("validator config file is required")
+		}
+		if err := r.loadValidators(cfg.ValidatorConfigFile); err != nil {
+			return nil, fmt.Errorf("failed to load validators: %w", err)
+		}
 	}
 
-	cfg.Log.Debug("Registry loaded", "len(validators)", len(r.validators))
+	cfg.Log.Debug("Registry loaded", "len(validators)", len(r.validators), "gatelessMode", cfg.GatelessMode)
 
 	return r, nil
+}
+
+// loadGatelessValidators auto-discovers test packages and creates synthetic validators
+func (r *Registry) loadGatelessValidators() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.config.Log.Info("Auto-discovering test packages in gateless mode", "testDir", r.config.TestDir)
+
+	// Get the current working directory for relative path resolution
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	// Discover test packages
+	packages, err := testlist.FindTestPackages(r.config.TestDir, workingDir)
+	if err != nil {
+		return fmt.Errorf("failed to discover test packages: %w", err)
+	}
+
+	if len(packages) == 0 {
+		return fmt.Errorf("no test packages found in directory: %s", r.config.TestDir)
+	}
+
+	r.config.Log.Info("Found test packages", "count", len(packages), "packages", packages)
+
+	// Create synthetic validators for each discovered package
+	var validators []types.ValidatorMetadata
+	for _, pkg := range packages {
+		// For gateless mode, use the discovered package paths directly
+		adjustedPkg := pkg
+
+		// Determine which timeout to use: prefer Timeout flag, fall back to DefaultTimeout
+		timeout := r.config.DefaultTimeout
+		if r.config.Timeout > 0 {
+			timeout = r.config.Timeout
+		}
+
+		validator := types.ValidatorMetadata{
+			ID:      adjustedPkg, // Use the discovered package path as ID
+			Gate:    "gateless",  // Use a synthetic gate name
+			Suite:   "",          // No suite in gateless mode
+			Package: adjustedPkg,
+			RunAll:  true, // Always run all tests in package for gateless mode
+			Type:    types.ValidatorTypeTest,
+			Timeout: timeout,
+		}
+		validators = append(validators, validator)
+	}
+
+	r.validators = validators
+	r.config.Log.Info("Created synthetic validators for gateless mode", "count", len(validators))
+
+	return nil
 }
 
 // loadValidators loads a test source and its configuration

--- a/op-acceptor/testlist/testlist.go
+++ b/op-acceptor/testlist/testlist.go
@@ -12,6 +12,94 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
+// FindTestPackages recursively discovers all directories containing *_test.go files
+// within the given directory. It returns a list of relative package paths that can
+// be used with "go test" commands. It supports Go's "..." notation for the input path.
+func FindTestPackages(testDir string, workingDir string) ([]string, error) {
+	// Handle "..." notation (e.g., "./acceptance-tests/...")
+	testDir = strings.TrimSuffix(testDir, "/...")
+
+	// Convert to absolute path for consistent processing
+	var searchPath string
+	if filepath.IsAbs(testDir) {
+		searchPath = testDir
+	} else {
+		searchPath = filepath.Join(workingDir, testDir)
+	}
+
+	// Clean the path to avoid issues with ".." components
+	searchPath = filepath.Clean(searchPath)
+
+	// Verify the search path exists
+	if _, err := os.Stat(searchPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("test directory does not exist: %s", searchPath)
+	}
+
+	var packages []string
+
+	// Walk the directory tree
+	err := filepath.WalkDir(searchPath, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip if this isn't a directory
+		if !d.IsDir() {
+			return nil
+		}
+
+		// Check if this directory contains test files
+		hasTestFiles, err := hasGoTestFiles(path)
+		if err != nil {
+			return err
+		}
+
+		if hasTestFiles {
+			// Convert back to a relative path from workingDir
+			relPath, err := filepath.Rel(workingDir, path)
+			if err != nil {
+				return fmt.Errorf("failed to get relative path for %s: %w", path, err)
+			}
+
+			// Clean the relative path to remove any ".." components
+			relPath = filepath.Clean(relPath)
+
+			// Normalize to use "./" prefix for relative paths, but avoid problematic paths
+			if relPath == "." {
+				relPath = "."
+			} else if !strings.HasPrefix(relPath, "./") && !strings.HasPrefix(relPath, "../") {
+				relPath = "./" + relPath
+			}
+
+			packages = append(packages, relPath)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk test directory: %w", err)
+	}
+
+	return packages, nil
+}
+
+// hasGoTestFiles checks if a directory contains any *_test.go files
+func hasGoTestFiles(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), "_test.go") {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // FindTestFunctions takes a package path and working directory, and returns a list of test function names
 func FindTestFunctions(pkgPath string, workingDir string) ([]string, error) {
 	var relPath string
@@ -20,8 +108,12 @@ func FindTestFunctions(pkgPath string, workingDir string) ([]string, error) {
 	if strings.HasPrefix(pkgPath, "./") {
 		relPath = strings.TrimPrefix(pkgPath, "./")
 	} else {
-		// Read and parse go.mod
-		goModPath := filepath.Join(workingDir, "go.mod")
+		// Find go.mod by searching up the directory tree from workingDir
+		goModPath, err := findGoMod(workingDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find go.mod: %w", err)
+		}
+
 		goModContent, err := os.ReadFile(goModPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read go.mod: %w", err)
@@ -42,10 +134,19 @@ func FindTestFunctions(pkgPath string, workingDir string) ([]string, error) {
 			return nil, fmt.Errorf("package %s is not in module %s", pkgPath, moduleName)
 		}
 
+		// Get the directory containing go.mod (module root)
+		moduleRoot := filepath.Dir(goModPath)
+
+		// Calculate relative path from module root to package
 		relPath = strings.TrimPrefix(pkgPath, moduleName)
 		if relPath == "" {
 			relPath = "."
+		} else if strings.HasPrefix(relPath, "/") {
+			relPath = strings.TrimPrefix(relPath, "/")
 		}
+
+		// Update workingDir to be the module root for path resolution
+		workingDir = moduleRoot
 	}
 
 	// Find all test files in the package directory
@@ -84,4 +185,24 @@ func FindTestFunctions(pkgPath string, workingDir string) ([]string, error) {
 	}
 
 	return testFunctions, nil
+}
+
+// findGoMod searches for go.mod file starting from the given directory and moving up the directory tree
+func findGoMod(startDir string) (string, error) {
+	dir := startDir
+	for {
+		goModPath := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(goModPath); err == nil {
+			return goModPath, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached the root directory
+			break
+		}
+		dir = parent
+	}
+
+	return "", fmt.Errorf("go.mod not found in %s or any parent directory", startDir)
 }

--- a/op-acceptor/testlist/testlist_test.go
+++ b/op-acceptor/testlist/testlist_test.go
@@ -92,7 +92,7 @@ func TestFindTestFunctionsErrors(t *testing.T) {
 			name:       "missing go.mod for module path",
 			pkgPath:    "github.com/test/module/pkg",
 			workingDir: "nonexistent",
-			wantErr:    "failed to read go.mod",
+			wantErr:    "failed to find go.mod",
 		},
 		{
 			name:       "invalid go.mod",
@@ -137,6 +137,91 @@ func TestFindTestFunctionsErrors(t *testing.T) {
 			require.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
+}
+
+func TestFindTestPackages(t *testing.T) {
+	// Create temporary directory for the test
+	tmpDir := t.TempDir()
+
+	// Create a structure with multiple test packages
+	// tmpDir/
+	//   ├── pkg1/
+	//   │   └── pkg1_test.go
+	//   ├── pkg2/
+	//   │   └── pkg2_test.go
+	//   ├── subdir/
+	//   │   └── pkg3/
+	//   │       └── pkg3_test.go
+	//   └── regular_file.go (not a test)
+
+	// Create directories
+	pkg1Dir := filepath.Join(tmpDir, "pkg1")
+	pkg2Dir := filepath.Join(tmpDir, "pkg2")
+	pkg3Dir := filepath.Join(tmpDir, "subdir", "pkg3")
+
+	require.NoError(t, os.MkdirAll(pkg1Dir, 0755))
+	require.NoError(t, os.MkdirAll(pkg2Dir, 0755))
+	require.NoError(t, os.MkdirAll(pkg3Dir, 0755))
+
+	// Create test files
+	testContent := `package test
+import "testing"
+func TestExample(t *testing.T) {}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(pkg1Dir, "pkg1_test.go"), []byte(testContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkg2Dir, "pkg2_test.go"), []byte(testContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkg3Dir, "pkg3_test.go"), []byte(testContent), 0644))
+
+	// Create a non-test file (should be ignored)
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "regular_file.go"), []byte("package main"), 0644))
+
+	// Test finding packages
+	packages, err := FindTestPackages(tmpDir, tmpDir)
+	require.NoError(t, err)
+
+	// Should find all three test packages
+	expected := []string{"./pkg1", "./pkg2", "./subdir/pkg3"}
+	require.ElementsMatch(t, expected, packages)
+}
+
+func TestFindTestPackagesWithEllipsis(t *testing.T) {
+	// Create temporary directory for the test
+	tmpDir := t.TempDir()
+
+	// Create test package
+	pkgDir := filepath.Join(tmpDir, "testpkg")
+	require.NoError(t, os.MkdirAll(pkgDir, 0755))
+
+	testContent := `package test
+import "testing"
+func TestExample(t *testing.T) {}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "test_test.go"), []byte(testContent), 0644))
+
+	// Test with "..." notation
+	packages, err := FindTestPackages(tmpDir+"/...", tmpDir)
+	require.NoError(t, err)
+
+	expected := []string{"./testpkg"}
+	require.ElementsMatch(t, expected, packages)
+}
+
+func TestFindTestPackagesEmpty(t *testing.T) {
+	// Create temporary directory with no test files
+	tmpDir := t.TempDir()
+
+	packages, err := FindTestPackages(tmpDir, tmpDir)
+	require.NoError(t, err)
+	require.Empty(t, packages)
+}
+
+func TestFindTestPackagesNonExistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	nonExistentDir := filepath.Join(tmpDir, "nonexistent")
+
+	_, err := FindTestPackages(nonExistentDir, tmpDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not exist")
 }
 
 // Helper function to create test files


### PR DESCRIPTION
Introduce a gateless mode which tries to find and run all tests within a directory.

Running all tests, in sysgo mode:
<img width="841" height="496" alt="Screenshot 2025-07-23 at 16 31 36" src="https://github.com/user-attachments/assets/d06000c6-660c-4708-8d52-6e07d052ebb8" />

