### PR TITLE
record the logs of transaction not found error

### DIFF
--- a/op-ufm/pkg/provider/heartbeat.go
+++ b/op-ufm/pkg/provider/heartbeat.go
@@ -58,8 +58,15 @@ func (p *Provider) Heartbeat(ctx context.Context) {
 		hash := st.Hash.Hex()
 
 		_, isPending, err := client.TransactionByHash(ctx, st.Hash)
-		if err != nil && !errors.Is(err, ethereum.NotFound) {
-			log.Error("cant check transaction",
+		if err != nil {
+			var errorPrefix string
+			if errors.Is(err, ethereum.NotFound) {
+				errorPrefix = "transaction not found"
+			} else {
+				errorPrefix = "cant check transaction"
+			}
+
+			log.Error(errorPrefix,
 				"provider", p.name,
 				"hash", hash,
 				"url", p.config.URL,

--- a/op-ufm/pkg/provider/roundtrip.go
+++ b/op-ufm/pkg/provider/roundtrip.go
@@ -167,8 +167,14 @@ func (p *Provider) RoundTrip(ctx context.Context) {
 				"elapsed", time.Since(sentAt))
 		}
 		receipt, err = client.TransactionReceipt(ctx, txHash)
-		if err != nil && !errors.Is(err, ethereum.NotFound) {
-			log.Error("cant get receipt for transaction",
+		if err != nil {
+			var errorPrefix string
+			if errors.Is(err, ethereum.NotFound) {
+				errorPrefix = "transaction or transaction receipt not found"
+			} else {
+				errorPrefix = "cant get receipt for transaction"
+			}
+			log.Error(errorPrefix,
 				"provider", p.name,
 				"hash", txHash.Hex(),
 				"nonce", nonce,


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This is step 1 in the process of getting rid of ethereum.NotFound as an ignorable error without causing a spike in alerts.

The plan is to merge this PR, observe the logs of ufm over a period for "not found" errors and make a judgement on how do we wanna proceed.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
