### PR TITLE
Proxyd: Allow backend ResponseTimeout to be set in ms + to be configurable per backend

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -609,11 +609,14 @@ func (b *Backend) Forward(ctx context.Context, reqs []*RPCReq, isBatch bool) ([]
 				"err", err,
 				"method", metricLabelMethod,
 				"attempt_count", i+1,
-				"max_retries", b.maxRetries+1,
+				"max_attempts", b.maxRetries+1,
 			)
 			timer.ObserveDuration()
 			RecordBatchRPCError(ctx, b.Name, reqs, err)
-			sleepContext(ctx, calcBackoff(i))
+			// perform a backoff if there are more retries for this backend
+			if (i < b.maxRetries) {
+				sleepContext(ctx, calcBackoff(i))
+			}
 			continue
 		}
 		timer.ObserveDuration()

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -614,7 +614,7 @@ func (b *Backend) Forward(ctx context.Context, reqs []*RPCReq, isBatch bool) ([]
 			timer.ObserveDuration()
 			RecordBatchRPCError(ctx, b.Name, reqs, err)
 			// perform a backoff if there are more retries for this backend
-			if (i < b.maxRetries) {
+			if i < b.maxRetries {
 				sleepContext(ctx, calcBackoff(i))
 			}
 			continue

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -115,6 +115,8 @@ type BackendConfig struct {
 	Weight int `toml:"weight"`
 
 	SkipIsSyncingCheck bool `toml:"skip_is_syncing_check"`
+	ResponseTimeoutMilliseconds int `toml:"response_timeout_milliseconds"`
+	MaxRetries *int `toml:"max_retries"`
 
 	SafeBlockDriftThreshold      uint64 `toml:"safe_block_drift_threshold"`
 	FinalizedBlockDriftThreshold uint64 `toml:"finalized_block_drift_threshold"`
@@ -122,6 +124,7 @@ type BackendConfig struct {
 	ConsensusSkipPeerCountCheck bool   `toml:"consensus_skip_peer_count"`
 	ConsensusForcedCandidate    bool   `toml:"consensus_forced_candidate"`
 	ConsensusReceiptsTarget     string `toml:"consensus_receipts_target"`
+
 }
 
 type BackendsConfig map[string]*BackendConfig

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -87,7 +87,9 @@ func (t *TOMLDuration) UnmarshalText(b []byte) error {
 }
 
 type BackendOptions struct {
+	// Deprecated: Use ResponseTimeoutMilliseconds instead. Note this field will be overridden if `ResponseTimeoutMilliseconds` is also set.
 	ResponseTimeoutSeconds      int          `toml:"response_timeout_seconds"`
+	ResponseTimeoutMilliseconds int          `toml:"response_timeout_milliseconds"`
 	MaxResponseSizeBytes        int64        `toml:"max_response_size_bytes"`
 	MaxRetries                  int          `toml:"max_retries"`
 	OutOfServiceSeconds         int          `toml:"out_of_service_seconds"`

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -114,9 +114,9 @@ type BackendConfig struct {
 
 	Weight int `toml:"weight"`
 
-	SkipIsSyncingCheck bool `toml:"skip_is_syncing_check"`
-	ResponseTimeoutMilliseconds int `toml:"response_timeout_milliseconds"`
-	MaxRetries *int `toml:"max_retries"`
+	SkipIsSyncingCheck          bool `toml:"skip_is_syncing_check"`
+	ResponseTimeoutMilliseconds int  `toml:"response_timeout_milliseconds"`
+	MaxRetries                  *int `toml:"max_retries"`
 
 	SafeBlockDriftThreshold      uint64 `toml:"safe_block_drift_threshold"`
 	FinalizedBlockDriftThreshold uint64 `toml:"finalized_block_drift_threshold"`
@@ -124,7 +124,6 @@ type BackendConfig struct {
 	ConsensusSkipPeerCountCheck bool   `toml:"consensus_skip_peer_count"`
 	ConsensusForcedCandidate    bool   `toml:"consensus_forced_candidate"`
 	ConsensusReceiptsTarget     string `toml:"consensus_receipts_target"`
-
 }
 
 type BackendsConfig map[string]*BackendConfig

--- a/proxyd/integration_tests/backend_timeout_test.go
+++ b/proxyd/integration_tests/backend_timeout_test.go
@@ -62,6 +62,8 @@ func TestBackendSpecificTimeout(t *testing.T) {
 
 		// Should take at least 1.8 seconds (time to hit both backends minus a threshold)
 		require.GreaterOrEqual(t, elapsed, 1800*time.Millisecond)
+		// and less than 2.2 seconds (time to hit both backends plus a threshold)
+		require.Less(t, elapsed, 2200*time.Millisecond)
 
 		// Verify that both backends were called
 		// Fast backend should have been called first and timed out
@@ -131,6 +133,8 @@ func TestBackendSpecificTimeout(t *testing.T) {
 		// Slow backend: ~5s timeout
 		// Total: should be at least 5.4 seconds
 		require.GreaterOrEqual(t, elapsed, 5400*time.Millisecond)
+		// and less than 5.6 seconds (time to hit both backends plus a threshold)
+		require.Less(t, elapsed, 5600*time.Millisecond)
 
 		// Verify that both backends were called
 		require.Equal(t, 1, len(fastBackend.Requests()))

--- a/proxyd/integration_tests/backend_timeout_test.go
+++ b/proxyd/integration_tests/backend_timeout_test.go
@@ -1,0 +1,143 @@
+package integration_tests
+
+import (
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/infra/proxyd"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	backendTimeoutResponse = `{"jsonrpc": "2.0", "result": "hello", "id": 999}`
+)
+
+func TestBackendSpecificTimeout(t *testing.T) {
+	// Create mock backends with different response times
+	fastBackend := NewMockBackend(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Fast backend takes 2 seconds (exceeds its 400ms timeout)
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(backendTimeoutResponse))
+	}))
+	defer fastBackend.Close()
+
+	slowBackend := NewMockBackend(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slow backend takes 1.6 seconds (within its 5 second timeout)
+		time.Sleep(1600 * time.Millisecond)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(backendTimeoutResponse))
+	}))
+	defer slowBackend.Close()
+
+	// Set environment variables for backend URLs
+	require.NoError(t, os.Setenv("FAST_BACKEND_RPC_URL", fastBackend.URL()))
+	require.NoError(t, os.Setenv("SLOW_BACKEND_RPC_URL", slowBackend.URL()))
+
+	// Start proxyd with the test configuration
+	config := ReadConfig("backend_timeout")
+	client := NewProxydClient("http://127.0.0.1:8546")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	// Test scenario:
+	// 1. Fast backend (configured with 400ms timeout) is primary but takes 2s (will timeout)
+	// 2. Slow backend (configured with5s timeout) is fallback and takes 1.6s (will succeed)
+	// 3. Request should succeed via the slow backend after fast backend times out
+
+	t.Run("backend timeout fallback behavior", func(t *testing.T) {
+		start := time.Now()
+
+		res, statusCode, err := client.SendRPC("eth_chainId", nil)
+
+		elapsed := time.Since(start)
+
+		// Should succeed (via fallback backend)
+		require.NoError(t, err)
+		require.Equal(t, 200, statusCode)
+		RequireEqualJSON(t, []byte(backendTimeoutResponse), res)
+
+		// Should take at least 1.8 seconds (time to hit both backends minus a threshold)
+		require.GreaterOrEqual(t, elapsed, 1800*time.Millisecond)
+
+		// Verify that both backends were called
+		// Fast backend should have been called first and timed out
+		require.Equal(t, 1, len(fastBackend.Requests()))
+
+		// Slow backend should have been called as fallback
+		require.Equal(t, 1, len(slowBackend.Requests()))
+
+		// Reset for next test
+		fastBackend.Reset()
+		slowBackend.Reset()
+	})
+
+	t.Run("fast backend timeout + slow backend error => 503 Service Unavailable", func(t *testing.T) {
+		// Test that fast backend alone times out
+		fastBackend.SetHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Take longer than the 400ms timeout
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(backendTimeoutResponse))
+		}))
+
+		// Disable slow backend temporarily
+		slowBackend.SetHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(500) // Return error
+		}))
+
+		_, statusCode, err := client.SendRPC("eth_chainId", nil)
+
+		// Should fail due to timeout - expect 503 Service Unavailable
+		require.NoError(t, err)
+		require.Equal(t, 503, statusCode)
+
+		// Reset handlers
+		fastBackend.Reset()
+		slowBackend.Reset()
+	})
+
+	t.Run("both backends timeout => 503 Service Unavailable", func(t *testing.T) {
+		// Test that both backends timeout
+		fastBackend.SetHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Take longer than the 400ms timeout
+			time.Sleep(500 * time.Millisecond)
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(backendTimeoutResponse))
+		}))
+
+		slowBackend.SetHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Take longer than the 5 second timeout
+			time.Sleep(6 * time.Second)
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(backendTimeoutResponse))
+		}))
+
+		start := time.Now()
+
+		_, statusCode, err := client.SendRPC("eth_chainId", nil)
+
+		elapsed := time.Since(start)
+
+		// Should fail due to both backends timing out - expect 503 Service Unavailable
+		require.NoError(t, err)
+		require.Equal(t, 503, statusCode)
+
+		// Should timeout after trying both backends
+		// Fast backend: ~400ms timeout
+		// Slow backend: ~5s timeout
+		// Total: should be at least 5.4 seconds
+		require.GreaterOrEqual(t, elapsed, 5400*time.Millisecond)
+
+		// Verify that both backends were called
+		require.Equal(t, 1, len(fastBackend.Requests()))
+		require.Equal(t, 1, len(slowBackend.Requests()))
+
+		// Reset handlers
+		fastBackend.Reset()
+		slowBackend.Reset()
+	})
+}

--- a/proxyd/integration_tests/backend_timeout_test.go
+++ b/proxyd/integration_tests/backend_timeout_test.go
@@ -78,10 +78,10 @@ func TestBackendSpecificTimeout(t *testing.T) {
 	t.Run("fast backend timeout + slow backend error => 503 Service Unavailable", func(t *testing.T) {
 		// Test that fast backend alone times out
 		fastBackend.SetHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					// Take longer than the 400ms timeout
-		time.Sleep(500 * time.Millisecond)
-		w.WriteHeader(200)
-		_, _ = w.Write([]byte(backendTimeoutResponse))
+			// Take longer than the 400ms timeout
+			time.Sleep(500 * time.Millisecond)
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(backendTimeoutResponse))
 		}))
 
 		// Disable slow backend temporarily

--- a/proxyd/integration_tests/testdata/backend_timeout.toml
+++ b/proxyd/integration_tests/testdata/backend_timeout.toml
@@ -9,6 +9,7 @@ response_timeout_seconds = 10
 rpc_url = "$FAST_BACKEND_RPC_URL"
 ws_url = "$FAST_BACKEND_RPC_URL"
 response_timeout_milliseconds = 400
+max_retries = 0
 
 [backends.slow_timeout]
 rpc_url = "$SLOW_BACKEND_RPC_URL"

--- a/proxyd/integration_tests/testdata/backend_timeout.toml
+++ b/proxyd/integration_tests/testdata/backend_timeout.toml
@@ -1,0 +1,24 @@
+[server]
+rpc_port = 8546
+
+[backend]
+response_timeout_seconds = 10
+
+[backends]
+[backends.fast_timeout]
+rpc_url = "$FAST_BACKEND_RPC_URL"
+ws_url = "$FAST_BACKEND_RPC_URL"
+response_timeout_milliseconds = 400
+
+[backends.slow_timeout]
+rpc_url = "$SLOW_BACKEND_RPC_URL"
+ws_url = "$SLOW_BACKEND_RPC_URL"
+response_timeout_milliseconds = 5000
+
+[backend_groups]
+[backend_groups.main]
+backends = ["fast_timeout", "slow_timeout"]
+fallbacks = ["slow_timeout"]
+
+[rpc_method_mappings]
+eth_chainId = "main"

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -202,6 +202,12 @@ func Start(config *Config) (*Server, func(), error) {
 		if cfg.StripTrailingXFF {
 			opts = append(opts, WithStrippedTrailingXFF())
 		}
+		if cfg.ResponseTimeoutMilliseconds != 0 {
+			opts = append(opts, WithTimeout(millisecondsToDuration(cfg.ResponseTimeoutMilliseconds)))
+		}
+		if cfg.MaxRetries != nil {
+			opts = append(opts, WithMaxRetries(*cfg.MaxRetries))
+		}
 		opts = append(opts, WithProxydIP(os.Getenv("PROXYD_IP")))
 		opts = append(opts, WithSkipIsSyncingCheck(cfg.SkipIsSyncingCheck))
 		opts = append(opts, WithSafeBlockDriftThreshold(cfg.SafeBlockDriftThreshold))

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -141,7 +141,10 @@ func Start(config *Config) (*Server, func(), error) {
 			return nil, nil, fmt.Errorf("must define an RPC URL for backend %s", name)
 		}
 
-		if config.BackendOptions.ResponseTimeoutSeconds != 0 {
+		if config.BackendOptions.ResponseTimeoutMilliseconds != 0 {
+			timeout := millisecondsToDuration(config.BackendOptions.ResponseTimeoutMilliseconds)
+			opts = append(opts, WithTimeout(timeout))
+		} else if config.BackendOptions.ResponseTimeoutSeconds != 0 {
 			timeout := secondsToDuration(config.BackendOptions.ResponseTimeoutSeconds)
 			opts = append(opts, WithTimeout(timeout))
 		}
@@ -578,6 +581,10 @@ func validateReceiptsTarget(val string) (string, error) {
 
 func secondsToDuration(seconds int) time.Duration {
 	return time.Duration(seconds) * time.Second
+}
+
+func millisecondsToDuration(ms int) time.Duration {
+	return time.Duration(ms) * time.Millisecond
 }
 
 func configureBackendTLS(cfg *BackendConfig) (*tls.Config, error) {

--- a/proxyd/proxyd_test.go
+++ b/proxyd/proxyd_test.go
@@ -1,0 +1,69 @@
+package proxyd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMillisecondsToDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		ms       int
+		expected time.Duration
+	}{
+		{"zero milliseconds", 0, 0 * time.Millisecond},
+		{"one millisecond", 1, 1 * time.Millisecond},
+		{"hundred milliseconds", 100, 100 * time.Millisecond},
+		{"one second", 1000, 1 * time.Second},
+		{"five seconds", 5000, 5 * time.Second},
+		{"negative milliseconds", -100, -100 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := millisecondsToDuration(tt.ms)
+			if result != tt.expected {
+				t.Errorf("millisecondsToDuration(%d) = %v, want %v", tt.ms, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSecondsToDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		seconds  int
+		expected time.Duration
+	}{
+		{"zero seconds", 0, 0 * time.Second},
+		{"one second", 1, 1 * time.Second},
+		{"five seconds", 5, 5 * time.Second},
+		{"thirty seconds", 30, 30 * time.Second},
+		{"negative seconds", -10, -10 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := secondsToDuration(tt.seconds)
+			if result != tt.expected {
+				t.Errorf("secondsToDuration(%d) = %v, want %v", tt.seconds, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMillisecondsToDurationIntegration(t *testing.T) {
+	// Test that the duration actually works with time functions
+	ms := 50
+	duration := millisecondsToDuration(ms)
+
+	start := time.Now()
+	time.Sleep(duration)
+	elapsed := time.Since(start)
+
+	// Allow some tolerance for timing (within 10ms)
+	tolerance := 10 * time.Millisecond
+	if elapsed < duration-tolerance || elapsed > duration+tolerance {
+		t.Errorf("Sleep duration was %v, expected approximately %v", elapsed, duration)
+	}
+}

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -641,7 +641,7 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				log.Error(
 					"error forwarding RPC batch",
 					"batch_size", len(elems),
-					"backend_group", group,
+					"backend_group", group.backendGroup,
 					"req_id", GetReqID(ctx),
 					"err", err,
 				)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Rollups often need certain RPC calls to be fast (i.e. faster than 1s). This PR adds a new configuration field intended to replace `ResponseTimeoutSeconds`: `ResponseTimeoutMilliseconds` that allows response time to be tuned more finely

In order to allow this to be configured per RPC method, I had to allow the overriding of the global responsetimeout on a per-backend basis. It is useful to also allow overriding maxRetries, so added that as well.

Finally, I am adding a fix where a backoff was added in even if it's the last or only retry for a backend. I am changing this to only add a backoff if there are more retries pending for that backend.

**Tests**

- smoke testing ✅ 
- having eth_getBlockByNumber point to a new backend group with:
    - the primary backend having a timeout of 2ms, and 
    - a set of fallbacks
    => 100% client errors, and a fallback being attempted

Integration and unit tests added

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
