### PR TITLE
refactor(op-acceptor): logging; split per-test logs into separate files

### DIFF
--- a/op-acceptor/reporting/html_sink.go
+++ b/op-acceptor/reporting/html_sink.go
@@ -66,7 +66,7 @@ func (s *ReportingHTMLSink) CompleteWithTiming(runID string, wallClockTime time.
 	builder := types.NewTestTreeBuilder().
 		WithSubtests(true).
 		WithLogPathGenerator(func(test *types.TestResult, isSubtest bool, parentName string) string {
-			filename := s.getReadableTestFilename(test.Metadata) + ".log"
+			filename := s.getReadableTestFilename(test.Metadata) + ".txt"
 			var subdir string
 			if test.Status == types.TestStatusFail || test.Status == types.TestStatusError {
 				subdir = "failed"


### PR DESCRIPTION
Split the single per-test log file into three distinct files:
- .txt file containing plaintext output only
- .json file containing raw JSON test output
- .log file containing test result summary

Also updates the HTML report to link to plaintext files.
