### PR TITLE
fix(op-acceptor): go releaser

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -419,6 +419,18 @@ jobs:
           oidc_token_file_path: /root/oidc_token.json
       - checkout
       - run:
+          name: Setup mise for op-acceptor
+          command: |
+            # Only install mise tools for op-acceptor which uses mise
+            if [ "<<parameters.module>>" = "op-acceptor" ]; then
+              # Install mise
+              curl -fsSL https://mise.run | sh
+              echo 'eval "$($HOME/.local/bin/mise activate bash)"' >> $BASH_ENV
+              source $BASH_ENV
+              # Install tools from mise.toml
+              mise install
+            fi
+      - run:
           name: Install goreleaser pro
           command: |
             mkdir -p /tmp/goreleaser


### PR DESCRIPTION
When mise is activated, it intercepts the go command through shims. If Go isn't installed via mise, the shim fails even if Go is available in the system.
We make this workaround here for just op-acceptor as only op-acceptor uses mise in this repo at present.