### PR TITLE
fix(op-acceptor): package timeouts.

### DIFF
--- a/op-acceptor/go.mod
+++ b/op-acceptor/go.mod
@@ -123,7 +123,7 @@ require (
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416 // indirect
 	github.com/nwaples/rardecode v1.1.3 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onsi/gomega v1.27.1 // indirect
+	github.com/onsi/gomega v1.34.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect

--- a/op-acceptor/go.sum
+++ b/op-acceptor/go.sum
@@ -361,8 +361,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/onsi/gomega v1.27.1 h1:rfztXRbg6nv/5f+Raen9RcGoSecHIFgBBLQK3Wdj754=
-github.com/onsi/gomega v1.27.1/go.mod h1:aHX5xOykVYzWOV4WqQy0sy8BQptgukenXpCXfadcIAw=
+github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
+github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=

--- a/op-acceptor/runner/executor.go
+++ b/op-acceptor/runner/executor.go
@@ -92,7 +92,12 @@ func (e *testExecutor) Execute(ctx context.Context, metadata types.ValidatorMeta
 		return nil, fmt.Errorf("package cannot be empty in metadata")
 	}
 
-	log.Info("Running test", "test", metadata.FuncName, "package", metadata.Package, "suite", metadata.Suite)
+	// Choose a meaningful label for logging: function name or package path
+	testLabel := metadata.FuncName
+	if testLabel == "" {
+		testLabel = metadata.Package
+	}
+	log.Info("Running test", "test", testLabel, "package", metadata.Package, "suite", metadata.Suite)
 
 	if metadata.FuncName == "" {
 		return e.ExecutePackage(ctx, metadata)

--- a/op-acceptor/runner/runner_test.go
+++ b/op-acceptor/runner/runner_test.go
@@ -236,7 +236,7 @@ func TestBuildTestArgs(t *testing.T) {
 				Package: "pkg/foo",
 				RunAll:  true,
 			},
-			want: []string{"test", "pkg/foo", "-count", "1", "-v", "-json"},
+			want: []string{"test", "pkg/foo", "-count", "1", "-timeout", "10m0s", "-v", "-json"},
 		},
 		{
 			name: "no package specified",


### PR DESCRIPTION
Some small fixes pertaining to package test runs:
- Adds a default package timeout if one isn't provided
- Also updates a log message to show the package name when its being tested
- Updates go[.mod,.sum] (unrelated change)
