### PR TITLE
proxyd: fixes mutlicall test flake

### DIFF
--- a/proxyd/integration_tests/multicall_test.go
+++ b/proxyd/integration_tests/multicall_test.go
@@ -118,7 +118,7 @@ func setServerBackend(s *proxyd.Server, nm map[string]nodeContext) *proxyd.Serve
 }
 
 func nodeBackendRequestCount(nodes map[string]nodeContext, node string) int {
-	return len(nodes[node].mockBackend.requests)
+	return len(nodes[node].mockBackend.Requests())
 }
 
 func TestMulticall(t *testing.T) {


### PR DESCRIPTION
Changed the nodeBackendRequestCount function to use the thread-safe Requests() method