### PR TITLE
feat(op-acceptor): flake shake

### DIFF
--- a/op-acceptor/README.md
+++ b/op-acceptor/README.md
@@ -59,6 +59,44 @@ DEVNET_ENV_URL=kt://isthmus-devnet op-acceptor \
     --log.level INFO
 ```
 
+## Flake‑Shake (stability analysis)
+
+Analyze test stability by running tests multiple times and aggregating results.
+
+### Usage
+
+Gate-based (with validators):
+
+```bash
+op-acceptor \
+  --validators acceptance-tests.yaml \
+  --gate flake-shake \
+  --flake-shake \
+  --flake-shake-iterations 100 \
+  --orchestrator sysgo
+```
+
+Gateless (directory-based):
+
+```bash
+op-acceptor \
+  --testdir ./path/to/tests/... \
+  --flake-shake \
+  --flake-shake-iterations 10 \
+  --orchestrator sysgo
+```
+
+### Output
+
+- Per run, two reports are generated under the run directory `logs/testrun-<runID>/`:
+  - `flake-shake-report.json` (machine-readable)
+  - `flake-shake-report.html` (human-readable)
+- The final console line includes `flake_report_html` and `flake_report_json` fields with absolute paths.
+
+Tests are classified as:
+- **STABLE**: 100% pass rate across all iterations
+- **UNSTABLE**: any failure (<100% pass rate)
+
 ## Concepts
 
 ### Test Discovery

--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -31,9 +31,11 @@ type Config struct {
 	DevnetEnvURL       string                 // URL or path to the devnet environment file
 	Serial             bool                   // Whether to run tests serially instead of in parallel
 	Concurrency        int                    // Number of concurrent test workers (0 = auto-determine)
-	ShowProgress       bool                   // Whether to show periodic progress updates during test execution
-	ProgressInterval   time.Duration          // Interval between progress updates when ShowProgress is 'true'
-	Log                log.Logger
+	ShowProgress         bool                   // Whether to show periodic progress updates during test execution
+	ProgressInterval     time.Duration          // Interval between progress updates when ShowProgress is 'true'
+	FlakeShake           bool                   // Enable flake-shake mode for test stability validation
+	FlakeShakeIterations int                    // Number of times to run each test in flake-shake mode
+	Log                  log.Logger
 }
 
 // NewConfig creates a new Config from cli context
@@ -115,9 +117,11 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 		DevnetEnvURL:       devnetEnvURL,
 		Serial:             ctx.Bool(flags.Serial.Name),
 		Concurrency:        ctx.Int(flags.Concurrency.Name),
-		ShowProgress:       ctx.Bool(flags.ShowProgress.Name),
-		ProgressInterval:   ctx.Duration(flags.ProgressInterval.Name),
-		LogDir:             logDir,
-		Log:                log,
+		ShowProgress:         ctx.Bool(flags.ShowProgress.Name),
+		ProgressInterval:     ctx.Duration(flags.ProgressInterval.Name),
+		FlakeShake:           ctx.Bool(flags.FlakeShake.Name),
+		FlakeShakeIterations: ctx.Int(flags.FlakeShakeIterations.Name),
+		LogDir:               logDir,
+		Log:                  log,
 	}, nil
 }

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -161,6 +161,18 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "CONCURRENCY"),
 		Usage:   "Number of concurrent test workers. 0 (default) auto-determines based on system capabilities.",
 	}
+	FlakeShake = &cli.BoolFlag{
+		Name:    "flake-shake",
+		Value:   false,
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "FLAKE_SHAKE"),
+		Usage:   "Enable flake-shake mode to run tests multiple times for stability validation.",
+	}
+	FlakeShakeIterations = &cli.IntFlag{
+		Name:    "flake-shake-iterations",
+		Value:   100,
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "FLAKE_SHAKE_ITERATIONS"),
+		Usage:   "Number of times to run each test in flake-shake mode. Defaults to 100.",
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -184,6 +196,8 @@ var optionalFlags = []cli.Flag{
 	DevnetEnvURL,
 	Serial,
 	Concurrency,
+	FlakeShake,
+	FlakeShakeIterations,
 }
 var Flags []cli.Flag
 

--- a/op-acceptor/reporting/html_sink.go
+++ b/op-acceptor/reporting/html_sink.go
@@ -88,72 +88,17 @@ func (s *ReportingHTMLSink) CompleteWithTiming(runID string, wallClockTime time.
 	builder := types.NewTestTreeBuilder().
 		WithSubtests(true).
 		WithLogPathGenerator(func(test *types.TestResult, isSubtest bool, parentName string) string {
-			// Try different filename patterns to find the actual file that was created
-			// This handles inconsistencies between how files are created vs how TestTree structures the data
-
-			var possibleFilenames []string
-			baseFilename := s.getReadableTestFilename(test.Metadata)
-
-			// Always prefer the current computed filename first
-			possibleFilenames = append(possibleFilenames, baseFilename)
-
-			// For package tests, also try the legacy doubled package-name variant (e.g., "gateless_base_base")
-			if test.Metadata.RunAll {
-				parts := strings.Split(baseFilename, "_")
-				if len(parts) >= 1 {
-					last := parts[len(parts)-1]
-					if last != "" {
-						doubled := baseFilename + "_" + last
-						// Avoid adding a duplicate entry if base already ends with _last
-						if doubled != baseFilename {
-							possibleFilenames = append(possibleFilenames, doubled)
-						}
-					}
-				}
-
-				// If we somehow still receive a doubled base from generator, also try simplified variant
-				if len(parts) >= 2 && parts[len(parts)-1] == parts[len(parts)-2] {
-					simplifiedName := strings.Join(parts[:len(parts)-1], "_")
-					// Prefer current first, then doubled, then simplified
-					if simplifiedName != baseFilename {
-						possibleFilenames = append(possibleFilenames, simplifiedName)
-					}
-				}
+			// Deterministic: prefer the exact artifact basename produced by the file sink
+			base := test.ArtifactBaseName
+			if base == "" {
+				base = s.getReadableTestFilename(test.Metadata)
 			}
 
-			// For subtests that might be missing parent test name
-			if isSubtest && strings.Contains(parentName, "(package)") && !strings.HasPrefix(test.Metadata.FuncName, "Test") {
-				// Try adding TestRPCConnectivity prefix for known subtests
-				if strings.HasPrefix(test.Metadata.FuncName, "L2_Chain") {
-					withParent := s.getReadableTestFilename(types.ValidatorMetadata{
-						Gate:     test.Metadata.Gate,
-						Suite:    test.Metadata.Suite,
-						Package:  test.Metadata.Package,
-						FuncName: "TestRPCConnectivity/" + test.Metadata.FuncName,
-					})
-					possibleFilenames = append(possibleFilenames, withParent)
-				}
-			}
-
-			var subdir string
+			subdir := "passed"
 			if test.Status == types.TestStatusFail || test.Status == types.TestStatusError {
 				subdir = "failed"
-			} else {
-				subdir = "passed"
 			}
-
-			// Check which file actually exists
-			outputDir := filepath.Join(s.baseDir, "testrun-"+runID)
-			for _, filename := range possibleFilenames {
-				testPath := filepath.Join(outputDir, subdir, filename+".txt")
-				if _, err := os.Stat(testPath); err == nil {
-					// File exists, use this path
-					return filepath.Join(subdir, filename+".txt")
-				}
-			}
-
-			// Fallback to the computed filename
-			return filepath.Join(subdir, baseFilename+".txt")
+			return filepath.Join(subdir, base+".txt")
 		})
 
 	tree := builder.BuildFromTestResults(results, runID, s.networkName)

--- a/op-acceptor/runner/flake_shake.go
+++ b/op-acceptor/runner/flake_shake.go
@@ -1,0 +1,311 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ethereum-optimism/infra/op-acceptor/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// FlakeShakeResult represents aggregated results for a test across multiple runs
+type FlakeShakeResult struct {
+	TestName       string        `json:"test_name"`
+	Package        string        `json:"package"`
+	TotalRuns      int           `json:"total_runs"`
+	Passes         int           `json:"passes"`
+	Failures       int           `json:"failures"`
+	Skipped        int           `json:"skipped"`
+	PassRate       float64       `json:"pass_rate"`
+	AvgDuration    time.Duration `json:"avg_duration"`
+	MinDuration    time.Duration `json:"min_duration"`
+	MaxDuration    time.Duration `json:"max_duration"`
+	FailureLogs    []string      `json:"failure_logs,omitempty"`
+	LastFailure    *time.Time    `json:"last_failure,omitempty"`
+	Recommendation string        `json:"recommendation"`
+}
+
+// FlakeShakeReport contains the complete flake-shake analysis
+type FlakeShakeReport struct {
+	Date        string             `json:"date"`
+	Gate        string             `json:"gate"`
+	TotalRuns   int                `json:"total_runs"`
+	Iterations  int                `json:"iterations"`
+	Tests       []FlakeShakeResult `json:"tests"`
+	GeneratedAt time.Time          `json:"generated_at"`
+	RunID       string             `json:"run_id"`
+}
+
+// FlakeShakeRunner wraps a TestRunner to provide flake-shake functionality
+type FlakeShakeRunner struct {
+	baseRunner TestRunner
+	iterations int
+	log        log.Logger
+}
+
+// NewFlakeShakeRunner creates a new flake-shake runner
+func NewFlakeShakeRunner(baseRunner TestRunner, iterations int, log log.Logger) *FlakeShakeRunner {
+	return &FlakeShakeRunner{
+		baseRunner: baseRunner,
+		iterations: iterations,
+		log:        log,
+	}
+}
+
+// RunFlakeShake runs tests multiple times and generates stability report
+func (f *FlakeShakeRunner) RunFlakeShake(ctx context.Context, gate string) (*FlakeShakeReport, error) {
+	f.log.Info("Starting flake-shake analysis", "gate", gate, "iterations", f.iterations)
+
+	results := make(map[string][]types.TestResult)
+
+	// Run tests multiple times
+	for i := 1; i <= f.iterations; i++ {
+		f.log.Info("Running iteration", "iteration", i, "total", f.iterations)
+
+		// Run all tests once
+		runResult, err := f.baseRunner.RunAllTests(ctx)
+		if err != nil {
+			f.log.Error("Failed to run tests", "iteration", i, "error", err)
+			// Continue with other iterations even if one fails
+			continue
+		}
+
+		// Collect results from all gates/suites/tests
+		for _, gateResult := range runResult.Gates {
+			for testName, testResult := range gateResult.Tests {
+				// For package-level tests, use package name as key
+				key := testResult.Metadata.Package
+				if testName != "" && testName != testResult.Metadata.Package {
+					key = fmt.Sprintf("%s::%s", testResult.Metadata.Package, testName)
+				}
+				results[key] = append(results[key], *testResult)
+			}
+			for _, suiteResult := range gateResult.Suites {
+				for testName, testResult := range suiteResult.Tests {
+					// For package-level tests, use package name as key
+					key := testResult.Metadata.Package
+					if testName != "" && testName != testResult.Metadata.Package {
+						key = fmt.Sprintf("%s::%s", testResult.Metadata.Package, testName)
+					}
+					results[key] = append(results[key], *testResult)
+				}
+			}
+		}
+	}
+
+	// Generate report
+	report := f.generateReport(results, gate)
+
+	return report, nil
+}
+
+// generateReport creates a FlakeShakeReport from aggregated test results
+func (f *FlakeShakeRunner) generateReport(results map[string][]types.TestResult, gate string) *FlakeShakeReport {
+	report := &FlakeShakeReport{
+		Date:        time.Now().Format("2006-01-02"),
+		Gate:        gate,
+		Iterations:  f.iterations,
+		GeneratedAt: time.Now(),
+		RunID:       "", // RunID will be set from environment if available
+	}
+
+	for testKey, testResults := range results {
+		var pkg, name string
+
+		// Parse the key - it's either "package" or "package::testname"
+		if strings.Contains(testKey, "::") {
+			parts := strings.SplitN(testKey, "::", 2)
+			pkg = parts[0]
+			name = parts[1]
+		} else {
+			// Package-level test
+			pkg = testKey
+			// Extract the last component of the package path as the test name
+			pkgParts := strings.Split(pkg, "/")
+			if len(pkgParts) > 0 {
+				name = pkgParts[len(pkgParts)-1]
+			}
+		}
+
+		result := FlakeShakeResult{
+			TestName:    name,
+			Package:     pkg,
+			TotalRuns:   len(testResults),
+			MinDuration: time.Hour, // Start with large value
+		}
+
+		var totalDuration time.Duration
+
+		for _, tr := range testResults {
+			switch tr.Status {
+			case types.TestStatusPass:
+				result.Passes++
+			case types.TestStatusFail:
+				result.Failures++
+				if len(result.FailureLogs) < 5 { // Keep first 5 failure logs
+					result.FailureLogs = append(result.FailureLogs, tr.Stdout)
+				}
+				now := time.Now()
+				result.LastFailure = &now
+			case types.TestStatusSkip:
+				result.Skipped++
+			}
+
+			duration := tr.Duration
+			totalDuration += duration
+			if duration < result.MinDuration {
+				result.MinDuration = duration
+			}
+			if duration > result.MaxDuration {
+				result.MaxDuration = duration
+			}
+		}
+
+		if result.TotalRuns > 0 {
+			result.AvgDuration = totalDuration / time.Duration(result.TotalRuns)
+			result.PassRate = float64(result.Passes) / float64(result.TotalRuns) * 100
+		}
+
+		// Generate recommendation - simple binary classification
+		if result.PassRate == 100 {
+			result.Recommendation = "STABLE"
+		} else {
+			result.Recommendation = "UNSTABLE"
+		}
+
+		report.Tests = append(report.Tests, result)
+		report.TotalRuns += result.TotalRuns
+	}
+
+	return report
+}
+
+// SaveFlakeShakeReport saves the report in both JSON and HTML formats
+func SaveFlakeShakeReport(report *FlakeShakeReport, outputDir string) ([]string, error) {
+	var savedFiles []string
+	var errorsList []error
+
+	// Save JSON report
+	jsonFilename := filepath.Join(outputDir, "flake-shake-report.json")
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		errorsList = append(errorsList, fmt.Errorf("failed to marshal JSON: %w", err))
+	} else {
+		if err := os.WriteFile(jsonFilename, data, 0644); err != nil {
+			errorsList = append(errorsList, fmt.Errorf("failed to write JSON file: %w", err))
+		} else {
+			savedFiles = append(savedFiles, jsonFilename)
+		}
+	}
+
+	// Save HTML report
+	htmlFilename := filepath.Join(outputDir, "flake-shake-report.html")
+	if err := saveHTMLReport(report, htmlFilename); err != nil {
+		errorsList = append(errorsList, fmt.Errorf("failed to save HTML report: %w", err))
+	} else {
+		savedFiles = append(savedFiles, htmlFilename)
+	}
+
+	// Return error if any saves failed
+	if len(errorsList) > 0 {
+		errMsg := "failed to save some report formats:"
+		for _, e := range errorsList {
+			errMsg += "\n  - " + e.Error()
+		}
+		return savedFiles, errors.New(errMsg)
+	}
+
+	return savedFiles, nil
+}
+
+// saveHTMLReport saves the report as HTML
+func saveHTMLReport(report *FlakeShakeReport, filename string) error {
+	htmlTemplate := `<!DOCTYPE html>
+<html>
+<head>
+    <title>Flake-Shake Report - {{.Date}}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        h1 { color: #333; }
+        .summary { background: #f5f5f5; padding: 15px; border-radius: 5px; margin: 20px 0; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ddd; padding: 12px; text-align: left; }
+        th { background: #4CAF50; color: white; }
+        .pass-rate-100 { color: #4CAF50; font-weight: bold; }
+        .pass-rate-low { color: #f44336; }
+        .recommendation-STABLE { color: #4CAF50; font-weight: bold; }
+        .recommendation-UNSTABLE { color: #f44336; font-weight: bold; }
+        details { margin: 10px 0; }
+        summary { cursor: pointer; padding: 5px; background: #f0f0f0; }
+        .failure-log { background: #ffebee; padding: 10px; margin: 5px 0; font-family: monospace; font-size: 12px; white-space: pre-wrap; }
+    </style>
+</head>
+<body>
+    <h1>Flake-Shake Report</h1>
+    <div class="summary">
+        <p><strong>Date:</strong> {{.Date}}</p>
+        <p><strong>Gate:</strong> {{.Gate}}</p>
+        <p><strong>Iterations per Test:</strong> {{.Iterations}}</p>
+        <p><strong>Run ID:</strong> {{.RunID}}</p>
+    </div>
+
+    <h2>Test Results</h2>
+    <table>
+        <tr>
+            <th>Test Name</th>
+            <th>Package</th>
+            <th>Runs</th>
+            <th>Pass Rate</th>
+            <th>Avg Duration</th>
+            <th>Recommendation</th>
+            <th>Details</th>
+        </tr>
+        {{range .Tests}}
+        <tr>
+            <td>{{.TestName}}</td>
+            <td style="font-size: 12px;">{{.Package}}</td>
+            <td>{{.TotalRuns}}</td>
+            <td class="pass-rate-{{if eq .PassRate 100.0}}100{{else}}low{{end}}">
+                {{printf "%.1f" .PassRate}}%
+            </td>
+            <td>{{.AvgDuration}}</td>
+            <td class="recommendation-{{.Recommendation}}">{{.Recommendation}}</td>
+            <td>
+                {{if gt .Failures 0}}
+                <details>
+                    <summary>{{.Failures}} failure(s)</summary>
+                    <!-- Last failure timestamp removed per requirements -->
+                    {{range .FailureLogs}}
+                    <div class="failure-log">{{.}}</div>
+                    {{end}}
+                </details>
+                {{else}}
+                <span style="color: #4CAF50;">✓ All passed</span>
+                {{end}}
+            </td>
+        </tr>
+        {{end}}
+    </table>
+</body>
+</html>`
+
+	tmpl, err := template.New("report").Parse(htmlTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	return tmpl.Execute(file, report)
+}

--- a/op-acceptor/types/test.go
+++ b/op-acceptor/types/test.go
@@ -26,6 +26,10 @@ type TestResult struct {
 	Stdout   string                 // Capture stdout for failing tests
 	TimedOut bool                   // Track if this test timed out
 
+	// Artifact naming propagation: when file sinks create a specific basename for log files,
+	// they can store it here so HTML and other sinks use exactly the same basename
+	ArtifactBaseName string
+
 	// Hierarchy tracking
 	Depth         int      // Nesting depth (0=top-level, 1=first subtest, etc.)
 	HierarchyPath []string // Full path from root to this test (e.g., ["TestParent", "SubTest1", "SubSubTest"])


### PR DESCRIPTION
## Description
Introduces a new runner mode  - "flake-shake", which runs tests many times to identify flaky ones.
HTML and JSON reports are produced for CI artifacts. These will be used to aggregate results across multiple runners and , possibly, runs.

<img width="1106" height="143" alt="Screenshot 2025-09-24 at 09 35 19" src="https://github.com/user-attachments/assets/0d79e5a4-55d0-4b22-9fe7-532e53f20b4d" />
<img width="1904" height="627" alt="Screenshot 2025-09-24 at 09 35 45" src="https://github.com/user-attachments/assets/70ea7eb6-4e51-470d-b744-7a53002890f0" />

