### PR TITLE
chore: remove unused min func

### DIFF
--- a/op-acceptor/logging/raw_json_sink_test.go
+++ b/op-acceptor/logging/raw_json_sink_test.go
@@ -395,14 +395,6 @@ func TestFail(t *testing.T) {
 		passCount, failCount)
 }
 
-// min returns the smaller of x or y - for test use only
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 // TestRawJSONSink_ComprehensiveLogging tests that raw JSON logging works for all test scenarios
 func TestRawJSONSink_ComprehensiveLogging(t *testing.T) {
 	// Create a temporary directory for test logs


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 


**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
