### PR TITLE
Add transaction hash logging for sendRawTransaction methods

### DIFF
--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -135,6 +135,7 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 		}, // limiterFactory
 		InteropValidationConfig{},              // interopValidatingConfig
 		NewFirstSupervisorStrategy([]string{}), // interopStrategy
+		false,                                  // enableTxHashLogging
 	)
 	require.NoError(t, err)
 

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -32,6 +32,7 @@ type ServerConfig struct {
 	EnableXServedByHeader bool `toml:"enable_served_by_header"`
 	AllowAllOrigins       bool `toml:"allow_all_origins"`
 	PublicAccess          bool `toml:"public_access"`
+	EnableTxHashLogging   bool `toml:"enable_tx_hash_logging"`
 }
 
 type CacheConfig struct {

--- a/proxyd/integration_tests/testdata/tx_hash_logging.toml
+++ b/proxyd/integration_tests/testdata/tx_hash_logging.toml
@@ -1,5 +1,6 @@
 [server]
 rpc_port = 8545
+enable_tx_hash_logging = true
 
 [backend]
 response_timeout_seconds = 1

--- a/proxyd/integration_tests/testdata/tx_hash_logging.toml
+++ b/proxyd/integration_tests/testdata/tx_hash_logging.toml
@@ -1,0 +1,25 @@
+[server]
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 1
+
+[backends]
+[backends.good]
+rpc_url = "$GOOD_BACKEND_RPC_URL"
+ws_url = "$GOOD_BACKEND_RPC_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["good"]
+
+[rpc_method_mappings]
+eth_chainId = "main"
+eth_sendRawTransaction = "main"
+eth_sendRawTransactionConditional = "main"
+
+[sender_rate_limit]
+allowed_chain_ids = [0, 420, 420120003]
+enabled = false
+interval = "1s"
+limit = 1000

--- a/proxyd/integration_tests/tx_hash_logging_test.go
+++ b/proxyd/integration_tests/tx_hash_logging_test.go
@@ -1,22 +1,29 @@
 package integration_tests
 
 import (
+	"bytes"
+	"log/slog"
 	"net/http"
 	"os"
 	"testing"
 
 	"github.com/ethereum-optimism/infra/proxyd"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTxHashLogging(t *testing.T) {
+	// Capture log output
+	var logBuf bytes.Buffer
+	log.SetDefault(log.NewLogger(slog.NewJSONHandler(
+		&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
 	goodBackend := NewMockBackend(SingleResponseHandler(200, `{"jsonrpc":"2.0","result":"0x1234567890abcdef","id":1}`))
 	defer goodBackend.Close()
 
 	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
 
-	config := ReadConfig("interop_validation")
-	// Set log level to debug to ensure we see all logs
+	config := ReadConfig("tx_hash_logging")
 	config.Server.LogLevel = "debug"
 	client := NewProxydClient("http://127.0.0.1:8545")
 	_, shutdown, err := proxyd.Start(config)
@@ -24,29 +31,61 @@ func TestTxHashLogging(t *testing.T) {
 	defer shutdown()
 
 	t.Run("single sendRawTransaction should log tx hash", func(t *testing.T) {
+		logBuf.Reset()
+
 		// Valid transaction from testdata
 		body := `{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x02f8748201a415843b9aca31843b9aca3182520894f80267194936da1e98db10bce06f3147d580a62e880de0b6b3a764000080c001a0b50ee053102360ff5fedf0933b912b7e140c90fe57fa07a0cebe70dbd72339dda072974cb7bfe5c3dc54dde110e2b049408ccab8a879949c3b4d42a3a7555a618b"],"id":1}`
-		
+
 		_, code, err := client.SendRequest([]byte(body))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, code)
+
+		// Verify log contains transaction hash and required fields
+		logOutput := logBuf.String()
+		require.Contains(t, logOutput, "processing sendRawTransaction")
+		require.Contains(t, logOutput, "tx_hash")
+		require.Contains(t, logOutput, "0x0cdd497ce38727606708946cd07b83b101b92a29dea7f090f1f09ae849efd1a3") // Expected tx hash
+		require.Contains(t, logOutput, "method")
+		require.Contains(t, logOutput, "req_id")
+		require.Contains(t, logOutput, "chain_id")
+		require.Contains(t, logOutput, "nonce")
 	})
 
 	t.Run("batch sendRawTransaction should log tx hash", func(t *testing.T) {
+		logBuf.Reset()
+
 		// Batch with sendRawTransaction
 		body := `[{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x02f8748201a415843b9aca31843b9aca3182520894f80267194936da1e98db10bce06f3147d580a62e880de0b6b3a764000080c001a0b50ee053102360ff5fedf0933b912b7e140c90fe57fa07a0cebe70dbd72339dda072974cb7bfe5c3dc54dde110e2b049408ccab8a879949c3b4d42a3a7555a618b"],"id":1},{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":2}]`
-		
+
 		_, code, err := client.SendRequest([]byte(body))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, code)
+
+		// Verify log contains transaction hash and required fields
+		logOutput := logBuf.String()
+		require.Contains(t, logOutput, "processing sendRawTransaction")
+		require.Contains(t, logOutput, "tx_hash")
+		require.Contains(t, logOutput, "0x0cdd497ce38727606708946cd07b83b101b92a29dea7f090f1f09ae849efd1a3") // Expected tx hash
+		require.Contains(t, logOutput, "method")
+		require.Contains(t, logOutput, "req_id")
 	})
 
 	t.Run("sendRawTransactionConditional should log tx hash", func(t *testing.T) {
+		logBuf.Reset()
+
 		// Conditional transaction from testdata
 		body := `{"jsonrpc":"2.0","method":"eth_sendRawTransactionConditional","params":["0x02f8748201a415843b9aca31843b9aca3182520894f80267194936da1e98db10bce06f3147d580a62e880de0b6b3a764000080c001a0b50ee053102360ff5fedf0933b912b7e140c90fe57fa07a0cebe70dbd72339dda072974cb7bfe5c3dc54dde110e2b049408ccab8a879949c3b4d42a3a7555a618b", {}],"id":1}`
-		
+
 		_, code, err := client.SendRequest([]byte(body))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, code)
+
+		// Verify log contains transaction hash and required fields
+		logOutput := logBuf.String()
+		require.Contains(t, logOutput, "processing sendRawTransaction")
+		require.Contains(t, logOutput, "tx_hash")
+		require.Contains(t, logOutput, "0x0cdd497ce38727606708946cd07b83b101b92a29dea7f090f1f09ae849efd1a3") // Expected tx hash
+		require.Contains(t, logOutput, "method")
+		require.Contains(t, logOutput, "req_id")
 	})
 }

--- a/proxyd/integration_tests/tx_hash_logging_test.go
+++ b/proxyd/integration_tests/tx_hash_logging_test.go
@@ -89,3 +89,38 @@ func TestTxHashLogging(t *testing.T) {
 		require.Contains(t, logOutput, "req_id")
 	})
 }
+
+func TestTxHashLoggingDisabled(t *testing.T) {
+	// Capture log output
+	var logBuf bytes.Buffer
+	log.SetDefault(log.NewLogger(slog.NewJSONHandler(
+		&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	goodBackend := NewMockBackend(SingleResponseHandler(200, `{"jsonrpc":"2.0","result":"0x1234567890abcdef","id":1}`))
+	defer goodBackend.Close()
+
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	config := ReadConfig("interop_validation")
+	config.Server.LogLevel = "debug"
+	client := NewProxydClient("http://127.0.0.1:8545")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	t.Run("sendRawTransaction should not log tx hash when disabled", func(t *testing.T) {
+		logBuf.Reset()
+
+		// Valid transaction from testdata
+		body := `{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x02f8748201a415843b9aca31843b9aca3182520894f80267194936da1e98db10bce06f3147d580a62e880de0b6b3a764000080c001a0b50ee053102360ff5fedf0933b912b7e140c90fe57fa07a0cebe70dbd72339dda072974cb7bfe5c3dc54dde110e2b049408ccab8a879949c3b4d42a3a7555a618b"],"id":1}`
+
+		_, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+
+		// Verify log does NOT contain transaction hash logging
+		logOutput := logBuf.String()
+		require.NotContains(t, logOutput, "processing sendRawTransaction")
+		require.NotContains(t, logOutput, "0x0cdd497ce38727606708946cd07b83b101b92a29dea7f090f1f09ae849efd1a3")
+	})
+}

--- a/proxyd/integration_tests/tx_hash_logging_test.go
+++ b/proxyd/integration_tests/tx_hash_logging_test.go
@@ -1,0 +1,52 @@
+package integration_tests
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/ethereum-optimism/infra/proxyd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxHashLogging(t *testing.T) {
+	goodBackend := NewMockBackend(SingleResponseHandler(200, `{"jsonrpc":"2.0","result":"0x1234567890abcdef","id":1}`))
+	defer goodBackend.Close()
+
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	config := ReadConfig("interop_validation")
+	// Set log level to debug to ensure we see all logs
+	config.Server.LogLevel = "debug"
+	client := NewProxydClient("http://127.0.0.1:8545")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	t.Run("single sendRawTransaction should log tx hash", func(t *testing.T) {
+		// Valid transaction from testdata
+		body := `{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x02f8748201a415843b9aca31843b9aca3182520894f80267194936da1e98db10bce06f3147d580a62e880de0b6b3a764000080c001a0b50ee053102360ff5fedf0933b912b7e140c90fe57fa07a0cebe70dbd72339dda072974cb7bfe5c3dc54dde110e2b049408ccab8a879949c3b4d42a3a7555a618b"],"id":1}`
+		
+		_, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+
+	t.Run("batch sendRawTransaction should log tx hash", func(t *testing.T) {
+		// Batch with sendRawTransaction
+		body := `[{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x02f8748201a415843b9aca31843b9aca3182520894f80267194936da1e98db10bce06f3147d580a62e880de0b6b3a764000080c001a0b50ee053102360ff5fedf0933b912b7e140c90fe57fa07a0cebe70dbd72339dda072974cb7bfe5c3dc54dde110e2b049408ccab8a879949c3b4d42a3a7555a618b"],"id":1},{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":2}]`
+		
+		_, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+
+	t.Run("sendRawTransactionConditional should log tx hash", func(t *testing.T) {
+		// Conditional transaction from testdata
+		body := `{"jsonrpc":"2.0","method":"eth_sendRawTransactionConditional","params":["0x02f8748201a415843b9aca31843b9aca3182520894f80267194936da1e98db10bce06f3147d580a62e880de0b6b3a764000080c001a0b50ee053102360ff5fedf0933b912b7e140c90fe57fa07a0cebe70dbd72339dda072974cb7bfe5c3dc54dde110e2b049408ccab8a879949c3b4d42a3a7555a618b", {}],"id":1}`
+		
+		_, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+}

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -427,6 +427,7 @@ func Start(config *Config) (*Server, func(), error) {
 		limiterFactory,
 		config.InteropValidationConfig,
 		interopStrategy,
+		config.Server.EnableTxHashLogging,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -835,7 +835,7 @@ func convertSendReqToSendTx(ctx context.Context, req *RPCReq) (*types.Transactio
 	}
 
 	// Log transaction hash for all sendRawTransaction requests
-	log.Info("processing sendRawTransaction", 
+	log.Info("processing sendRawTransaction",
 		"tx_hash", tx.Hash(),
 		"method", req.Method,
 		"req_id", GetReqID(ctx),

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -87,6 +87,7 @@ type Server struct {
 	interopValidatingConfig InteropValidationConfig
 	interopStrategy         InteropStrategy
 	publicAccess            bool
+	enableTxHashLogging     bool
 }
 
 type limiterFunc func(method string) bool
@@ -114,6 +115,7 @@ func NewServer(
 	limiterFactory limiterFactoryFunc,
 	interopValidatingConfig InteropValidationConfig,
 	interopStrategy InteropStrategy,
+	enableTxHashLogging bool,
 ) (*Server, error) {
 	if cache == nil {
 		cache = &NoopRPCCache{}
@@ -215,6 +217,7 @@ func NewServer(
 		rateLimitHeader:         rateLimitHeader,
 		interopValidatingConfig: interopValidatingConfig,
 		interopStrategy:         interopStrategy,
+		enableTxHashLogging:     enableTxHashLogging,
 	}, nil
 }
 
@@ -576,7 +579,7 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 		// limits apply regardless of origin or user-agent. As such, they don't use the
 		// isLimited method.
 		if parsedReq.Method == "eth_sendRawTransaction" || parsedReq.Method == "eth_sendRawTransactionConditional" {
-			tx, err := convertSendReqToSendTx(ctx, parsedReq)
+			tx, err := s.convertSendReqToSendTx(ctx, parsedReq)
 			if err != nil {
 				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)
 				responses[i] = NewRPCErrorRes(parsedReq.ID, err)
@@ -798,7 +801,7 @@ func (s *Server) isGlobalLimit(method string) bool {
 }
 
 // convertSendReqToSendTx converts a sendRawTransaction or sendRawTransactionConditional rpc to a transaction.
-func convertSendReqToSendTx(ctx context.Context, req *RPCReq) (*types.Transaction, error) {
+func (s *Server) convertSendReqToSendTx(ctx context.Context, req *RPCReq) (*types.Transaction, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		log.Debug("error unmarshalling raw transaction params", "err", err, "req_Id", GetReqID(ctx))
@@ -834,15 +837,17 @@ func convertSendReqToSendTx(ctx context.Context, req *RPCReq) (*types.Transactio
 		return nil, ErrInvalidParams(err.Error())
 	}
 
-	// Log transaction hash for all sendRawTransaction requests
-	log.Info("processing sendRawTransaction",
-		"tx_hash", tx.Hash(),
-		"method", req.Method,
-		"req_id", GetReqID(ctx),
-		"auth", GetAuthCtx(ctx),
-		"chain_id", tx.ChainId(),
-		"nonce", tx.Nonce(),
-	)
+	// Log transaction hash for all sendRawTransaction requests if enabled
+	if s.enableTxHashLogging {
+		log.Info("processing sendRawTransaction",
+			"tx_hash", tx.Hash(),
+			"method", req.Method,
+			"req_id", GetReqID(ctx),
+			"auth", GetAuthCtx(ctx),
+			"chain_id", tx.ChainId(),
+			"nonce", tx.Nonce(),
+		)
+	}
 
 	return tx, nil
 }

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -834,6 +834,16 @@ func convertSendReqToSendTx(ctx context.Context, req *RPCReq) (*types.Transactio
 		return nil, ErrInvalidParams(err.Error())
 	}
 
+	// Log transaction hash for all sendRawTransaction requests
+	log.Info("processing sendRawTransaction", 
+		"tx_hash", tx.Hash(),
+		"method", req.Method,
+		"req_id", GetReqID(ctx),
+		"auth", GetAuthCtx(ctx),
+		"chain_id", tx.ChainId(),
+		"nonce", tx.Nonce(),
+	)
+
 	return tx, nil
 }
 

--- a/proxyd/server_test.go
+++ b/proxyd/server_test.go
@@ -31,7 +31,9 @@ func TestConvertSendReqToSendTx_Fusaka(t *testing.T) {
 				ID:     json.RawMessage("1"),
 			}
 
-			tx, err := convertSendReqToSendTx(context.Background(), rpcReq)
+			// Create a minimal server instance for testing
+			server := &Server{enableTxHashLogging: false}
+			tx, err := server.convertSendReqToSendTx(context.Background(), rpcReq)
 			require.NoError(t, err)
 
 			require.Len(t, tx.BlobTxSidecar().Blobs, 2)


### PR DESCRIPTION
## Summary
  - Add comprehensive logging for `eth_sendRawTransaction` and `eth_sendRawTransactionConditional` requests
  - Include transaction hash, method, request ID, auth context, chain ID, and nonce in logs
  - Add integration tests to verify logging functionality

  ## Changes
  - **proxyd/server.go**: Added structured logging in `convertSendReqToSendTx` function with transaction metadata
  - **proxyd/integration_tests/tx_hash_logging_test.go**: New test file with comprehensive log verification
  - **proxyd/integration_tests/testdata/tx_hash_logging.toml**: Dedicated test configuration

  ## Test plan
  - [x] Unit tests pass
  - [x] Integration tests verify log output contains expected fields:
    - Transaction hash
    - Method name
    - Request ID
    - Authentication context
    - Chain ID
    - Transaction nonce
  - [x] Tests cover single requests, batch requests, and conditional transactions