### PR TITLE
feat(op-acceptor): stricter exclude-gates.

### DIFF
--- a/op-acceptor/README.md
+++ b/op-acceptor/README.md
@@ -60,11 +60,11 @@ DEVNET_ENV_URL=kt://isthmus-devnet op-acceptor \
 ```
 
 ## Excluding tests via skip gates
-You can exclude tests that belong to one or more gates from every run.
+You can exclude tests that belong to one or more gates from every run. Excluded gates act as a global blacklist across all selection modes (gate and gateless). Any test/package listed in excluded gates will not run, even if included elsewhere or discovered via filesystem.
 
-- **Flag**: `--exclude-gates` (comma-separated gate IDs). Default: no exclusions.
+- **Flag**: `--exclude-gates` (comma-separated gate IDs). Default: no exclusions. If a selected `--gate` is also listed in `--exclude-gates`, an error is returned.
 - **Env var**: `ACCEPTOR_EXCLUDE_GATES` overrides the flag if set. Set to an empty string to disable all exclusions.
-- **Gateless note**: in gateless mode, exclusions are applied only if a validators YAML is provided (so gate membership can be resolved).
+- **Gateless note**: exclusions are applied using the provided validators YAML; package-only entries blacklist by import-path prefix segment match.
 
 Examples:
 

--- a/op-acceptor/cmd/main_test.go
+++ b/op-acceptor/cmd/main_test.go
@@ -58,7 +58,7 @@ func TestExitCodeBehavior(t *testing.T) {
 				return gateID, validatorPath, testDir
 			},
 			expectedStatus: exitcodes.Success,
-			defaultTimeout: 5 * time.Second,
+			defaultTimeout: 15 * time.Second,
 		},
 		{
 			name: "Failing tests should exit with code 1",

--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -104,6 +104,15 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 
 	excludeGates := parseExcludeGates(ctx.String(flags.ExcludeGates.Name))
 
+	// Conflict: selected gate is also excluded
+	if gate != "" {
+		for _, eg := range excludeGates {
+			if eg == gate {
+				return nil, fmt.Errorf("the selected gate '%s' is also specified in --exclude-gates; remove it from exclusions or choose a different gate", gate)
+			}
+		}
+	}
+
 	return &Config{
 		TestDir:              absTestDir,
 		ValidatorConfig:      absValidatorConfig,

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -177,7 +177,7 @@ var (
 		Name:    "exclude-gates",
 		Value:   "",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "EXCLUDE_GATES"),
-		Usage:   "Comma-separated list of gate IDs whose tests are excluded from execution.",
+		Usage:   "Comma-separated list of gate IDs to blacklist globally across all modes.",
 	}
 )
 

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -486,6 +486,16 @@ func (n *nat) runTests(ctx context.Context) error {
 			return NewRuntimeError(err)
 		}
 		n.result = result
+
+		// If blacklist removed all selected tests, report and exit successfully
+		if n.result != nil && n.result.Stats.Total == 0 {
+			n.config.Log.Info("No tests to run after applying blacklist")
+			// Complete the file logging to close writers
+			if n.fileLogger != nil {
+				_ = n.fileLogger.CompleteWithTiming(n.result.RunID, n.result.WallClockTime)
+			}
+			return nil
+		}
 	}
 
 	// We should have the same runID from the test run result (skip for flake-shake mode)

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -176,9 +176,6 @@ func NewTestRunner(cfg Config) (TestRunner, error) {
 	} else {
 		validators = cfg.Registry.GetValidators()
 	}
-	if len(validators) == 0 {
-		return nil, fmt.Errorf("no validators found")
-	}
 
 	if cfg.GoBinary == "" {
 		cfg.GoBinary = "go" // Default to "go" if not specified


### PR DESCRIPTION
Makes the existing `--exclude-gates` stricter, by blacklisting all tests within it - even if they're explicitly mentioned or found in other gates.