### PR TITLE
feat(proxyd): max block range config

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1708,6 +1708,7 @@ func (bg *BackendGroup) OverwriteConsensusResponses(rpcReqs []*RPCReq, overridde
 		safe:          bg.Consensus.GetSafeBlockNumber(),
 		finalized:     bg.Consensus.GetFinalizedBlockNumber(),
 		maxBlockRange: bg.Consensus.maxBlockRange,
+		consensusMode: true,
 	}
 
 	for i, req := range rpcReqs {
@@ -1748,6 +1749,7 @@ func (bg *BackendGroup) OverwriteNonConsensusRequests(rpcReqs []*RPCReq, overrid
 		safe:          0,
 		finalized:     0,
 		maxBlockRange: bg.maxBlockRange,
+		consensusMode: false,
 	}
 
 	rewrittenReqs := make([]*RPCReq, 0, len(rpcReqs))

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -926,6 +926,7 @@ type BackendGroup struct {
 	FallbackBackends       map[string]bool
 	routingStrategy        RoutingStrategy
 	multicallRPCErrorCheck bool
+	maxBlockRange          uint64
 }
 
 func (bg *BackendGroup) GetRoutingStrategy() RoutingStrategy {
@@ -969,6 +970,8 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 	// We also rewrite block tags to enforce compliance with consensus
 	if bg.Consensus != nil {
 		rpcReqs, overriddenResponses = bg.OverwriteConsensusResponses(rpcReqs, overriddenResponses, rewrittenReqs)
+	} else if bg.maxBlockRange > 0 {
+		rpcReqs, overriddenResponses = bg.OverwriteNonConsensusRequests(rpcReqs, overriddenResponses)
 	}
 
 	rpcRequestsTotal.Inc()
@@ -1725,6 +1728,46 @@ func (bg *BackendGroup) OverwriteConsensusResponses(rpcReqs []*RPCReq, overridde
 				)
 			} else {
 				res.Error = ErrParseErr
+			}
+		case RewriteOverrideResponse:
+			overriddenResponses = append(overriddenResponses, &indexedReqRes{
+				index: i,
+				req:   req,
+				res:   &res,
+			})
+		case RewriteOverrideRequest, RewriteNone:
+			rewrittenReqs = append(rewrittenReqs, req)
+		}
+	}
+	return rewrittenReqs, overriddenResponses
+}
+
+func (bg *BackendGroup) OverwriteNonConsensusRequests(rpcReqs []*RPCReq, overriddenResponses []*indexedReqRes) ([]*RPCReq, []*indexedReqRes) {
+	rctx := RewriteContext{
+		latest:        0,
+		safe:          0,
+		finalized:     0,
+		maxBlockRange: bg.maxBlockRange,
+	}
+
+	rewrittenReqs := make([]*RPCReq, 0, len(rpcReqs))
+
+	for i, req := range rpcReqs {
+		res := RPCRes{JSONRPC: JSONRPCVersion, ID: req.ID}
+		result, err := RewriteTags(rctx, req, &res)
+		switch result {
+		case RewriteOverrideError:
+			overriddenResponses = append(overriddenResponses, &indexedReqRes{
+				index: i,
+				req:   req,
+				res:   &res,
+			})
+			if errors.Is(err, ErrRewriteRangeTooLarge) {
+				res.Error = ErrInvalidParams(
+					fmt.Sprintf("block range greater than %d max", rctx.maxBlockRange),
+				)
+			} else {
+				res.Error = ErrInvalidParams(err.Error())
 			}
 		case RewriteOverrideResponse:
 			overriddenResponses = append(overriddenResponses, &indexedReqRes{

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -189,7 +189,9 @@ type BackendGroupConfig struct {
 	ConsensusMaxBlockLag        uint64       `toml:"consensus_max_block_lag"`
 	ConsensusMaxBlockRange      uint64       `toml:"consensus_max_block_range"`
 	ConsensusMinPeerCount       int          `toml:"consensus_min_peer_count"`
-	MaxBlockRange               uint64       `toml:"max_block_range"`
+	// Will set Max Block Range for non-consensus eth_getLogs and eth_newFilter
+	// Will override consensus_max_block_range if consensus_max_block range is also set
+	MaxBlockRange uint64 `toml:"max_block_range"`
 
 	ConsensusHA                  bool         `toml:"consensus_ha"`
 	ConsensusHAHeartbeatInterval TOMLDuration `toml:"consensus_ha_heartbeat_interval"`

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -189,6 +189,7 @@ type BackendGroupConfig struct {
 	ConsensusMaxBlockLag        uint64       `toml:"consensus_max_block_lag"`
 	ConsensusMaxBlockRange      uint64       `toml:"consensus_max_block_range"`
 	ConsensusMinPeerCount       int          `toml:"consensus_min_peer_count"`
+	MaxBlockRange               uint64       `toml:"max_block_range"`
 
 	ConsensusHA                  bool         `toml:"consensus_ha"`
 	ConsensusHAHeartbeatInterval TOMLDuration `toml:"consensus_ha_heartbeat_interval"`

--- a/proxyd/integration_tests/max_block_range_test.go
+++ b/proxyd/integration_tests/max_block_range_test.go
@@ -1,0 +1,148 @@
+package integration_tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ethereum-optimism/infra/proxyd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxBlockRange(t *testing.T) {
+	goodBackend := NewMockBackend(BatchedResponseHandler(200, goodResponse))
+	defer goodBackend.Close()
+
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	config := ReadConfig("max_block_range")
+	client := NewProxydClient("http://127.0.0.1:8545")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	t.Run("eth_getLogs within max_block_range", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x0","toBlock":"0x50"}],"id":1}`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 200, code)
+		require.NotContains(t, string(res), "block range greater than")
+	})
+
+	t.Run("eth_getLogs exceeds max_block_range", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x0","toBlock":"0xc8"}],"id":1}`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 400, code)
+		require.Contains(t, string(res), "block range greater than 100 max")
+	})
+
+	t.Run("eth_getLogs rejects latest tag", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x0","toBlock":"latest"}],"id":1}`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 400, code)
+		require.Contains(t, string(res), "block tags (latest/pending/safe/finalized) are not allowed")
+	})
+
+	t.Run("eth_newFilter within max_block_range", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","method":"eth_newFilter","params":[{"fromBlock":"0x0","toBlock":"0x50"}],"id":1}`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 200, code)
+		require.NotContains(t, string(res), "block range greater than")
+	})
+
+	t.Run("batched eth_getLogs and eth_newFilter within range", func(t *testing.T) {
+		body := `[
+			{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x0","toBlock":"0x32"}],"id":1},
+			{"jsonrpc":"2.0","method":"eth_newFilter","params":[{"fromBlock":"0x0","toBlock":"0x50"}],"id":2}
+		]`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 200, code)
+		require.NotContains(t, string(res), "block range greater than")
+	})
+
+	t.Run("batched requests with one exceeding limit", func(t *testing.T) {
+		body := `[
+			{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x0","toBlock":"0x32"}],"id":1},
+			{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x0","toBlock":"0xc8"}],"id":2}
+		]`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 200, code)
+		require.Contains(t, string(res), "block range greater than 100 max")
+	})
+
+	t.Run("parseBlockParam error - invalid hex fromBlock", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0xZZZ","toBlock":"0x64"}],"id":1}`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 400, code)
+		require.Contains(t, string(res), "invalid")
+	})
+
+	t.Run("parseBlockParam error - invalid hex toBlock", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x0","toBlock":"0xGGG"}],"id":1}`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 400, code)
+		require.Contains(t, string(res), "invalid")
+	})
+
+	t.Run("parseBlockParam error - malformed block number", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"not_a_number","toBlock":"0x64"}],"id":1}`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 400, code)
+		require.Contains(t, string(res), "hex string")
+	})
+
+	t.Run("batched requests with parseBlockParam error", func(t *testing.T) {
+		body := `[
+			{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x0","toBlock":"0x32"}],"id":1},
+			{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0xABC","toBlock":"invalid_hex"}],"id":2}
+		]`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 200, code)
+		require.Contains(t, string(res), "hex string")
+	})
+}
+
+func TestMaxBlockRangeWithoutConsensus(t *testing.T) {
+	goodBackend := NewMockBackend(BatchedResponseHandler(200, goodResponse))
+	defer goodBackend.Close()
+
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	config := ReadConfig("max_block_range")
+	client := NewProxydClient("http://127.0.0.1:8545")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	t.Run("eth_getLogs within max_block_range - no consensus", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x0","toBlock":"0x50"}],"id":1}`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 200, code)
+		require.NotContains(t, string(res), "block range greater than")
+	})
+
+	t.Run("eth_getLogs exceeds max_block_range - no consensus", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x0","toBlock":"0xc8"}],"id":1}`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 400, code)
+		require.Contains(t, string(res), "block range greater than 100 max")
+	})
+
+	t.Run("eth_getLogs rejects latest tag - no consensus", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x0","toBlock":"latest"}],"id":1}`
+		res, code, err := client.SendRequest([]byte(body))
+		require.NoError(t, err)
+		require.Equal(t, 400, code)
+		require.Contains(t, string(res), "block tags (latest/pending/safe/finalized) are not allowed")
+	})
+}

--- a/proxyd/integration_tests/testdata/max_block_range.toml
+++ b/proxyd/integration_tests/testdata/max_block_range.toml
@@ -1,0 +1,19 @@
+[server]
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 10
+
+[backends]
+[backends.good]
+rpc_url = "$GOOD_BACKEND_RPC_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["good"]
+max_block_range = 100
+
+[rpc_method_mappings]
+eth_getLogs = "main"
+eth_newFilter = "main"
+eth_chainId = "main"

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -300,6 +300,7 @@ func Start(config *Config) (*Server, func(), error) {
 
 		maxBlockRange := bg.ConsensusMaxBlockRange
 		if bg.MaxBlockRange > 0 {
+			log.Info("Overridding consensus max block range with max block range")
 			maxBlockRange = bg.MaxBlockRange
 		}
 

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -298,6 +298,11 @@ func Start(config *Config) (*Server, func(), error) {
 				)
 		}
 
+		maxBlockRange := bg.ConsensusMaxBlockRange
+		if bg.MaxBlockRange > 0 {
+			maxBlockRange = bg.MaxBlockRange
+		}
+
 		backendGroups[bgName] = &BackendGroup{
 			Name:                   bgName,
 			Backends:               backends,
@@ -305,6 +310,7 @@ func Start(config *Config) (*Server, func(), error) {
 			FallbackBackends:       fallbackBackends,
 			routingStrategy:        bg.RoutingStrategy,
 			multicallRPCErrorCheck: bg.MulticallRPCErrorCheck,
+			maxBlockRange:          maxBlockRange,
 		}
 	}
 
@@ -511,8 +517,8 @@ func Start(config *Config) (*Server, func(), error) {
 			if bgcfg.ConsensusMinPeerCount > 0 {
 				copts = append(copts, WithMinPeerCount(uint64(bgcfg.ConsensusMinPeerCount)))
 			}
-			if bgcfg.ConsensusMaxBlockRange > 0 {
-				copts = append(copts, WithMaxBlockRange(bgcfg.ConsensusMaxBlockRange))
+			if bg.maxBlockRange > 0 {
+				copts = append(copts, WithMaxBlockRange(bg.maxBlockRange))
 			}
 			if bgcfg.ConsensusPollerInterval > 0 {
 				copts = append(copts, WithPollerInterval(time.Duration(bgcfg.ConsensusPollerInterval)))

--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -153,13 +153,31 @@ func rewriteRange(rctx RewriteContext, req *RPCReq, res *RPCRes, pos int) (Rewri
 		return RewriteOverrideError, err
 	}
 
-	// if either fromBlock or toBlock is defined, default the other to "latest" if unset
 	_, hasFrom := p[pos]["fromBlock"]
 	_, hasTo := p[pos]["toBlock"]
-	if hasFrom && !hasTo {
-		p[pos]["toBlock"] = "latest"
-	} else if hasTo && !hasFrom {
-		p[pos]["fromBlock"] = "latest"
+
+	nonConsensusMode := rctx.latest == 0
+	defaultsSet := false
+
+	if nonConsensusMode {
+		if rctx.maxBlockRange > 0 && !hasTo {
+			return RewriteOverrideError, errors.New("toBlock must be specified when max_block_range is configured")
+		}
+		if !hasFrom {
+			p[pos]["fromBlock"] = "earliest"
+			hasFrom = true
+			defaultsSet = true
+		}
+	} else {
+		if hasFrom && !hasTo {
+			p[pos]["toBlock"] = "latest"
+			hasTo = true
+			defaultsSet = true
+		} else if hasTo && !hasFrom {
+			p[pos]["fromBlock"] = "latest"
+			hasFrom = true
+			defaultsSet = true
+		}
 	}
 
 	modifiedFrom, err := rewriteTagMap(rctx, p[pos], "fromBlock")
@@ -186,8 +204,7 @@ func rewriteRange(rctx RewriteContext, req *RPCReq, res *RPCRes, pos int) (Rewri
 		}
 	}
 
-	// if any of the fields the request have been changed, re-marshal the params
-	if modifiedFrom || modifiedTo {
+	if modifiedFrom || modifiedTo || defaultsSet {
 		paramsRaw, err := json.Marshal(p)
 		req.Params = paramsRaw
 		if err != nil {
@@ -262,18 +279,27 @@ func rewriteTag(rctx RewriteContext, current string) (string, bool, error) {
 		return current, false, nil
 	}
 
+	nonConsensusMode := rctx.latest == 0
+
 	switch *bnh.BlockNumber {
-	case rpc.PendingBlockNumber,
-		rpc.EarliestBlockNumber:
+	case rpc.EarliestBlockNumber:
 		return current, false, nil
-	case rpc.FinalizedBlockNumber:
-		return rctx.finalized.String(), true, nil
-	case rpc.SafeBlockNumber:
-		return rctx.safe.String(), true, nil
-	case rpc.LatestBlockNumber:
-		return rctx.latest.String(), true, nil
+	case rpc.PendingBlockNumber, rpc.FinalizedBlockNumber, rpc.SafeBlockNumber, rpc.LatestBlockNumber:
+		if nonConsensusMode {
+			return "", false, errors.New("block tags (latest/pending/safe/finalized) are not allowed when max_block_range is configured")
+		}
+		switch *bnh.BlockNumber {
+		case rpc.PendingBlockNumber:
+			return current, false, nil
+		case rpc.FinalizedBlockNumber:
+			return rctx.finalized.String(), true, nil
+		case rpc.SafeBlockNumber:
+			return rctx.safe.String(), true, nil
+		case rpc.LatestBlockNumber:
+			return rctx.latest.String(), true, nil
+		}
 	default:
-		if bnh.BlockNumber.Int64() > int64(rctx.latest) {
+		if rctx.latest > 0 && bnh.BlockNumber.Int64() > int64(rctx.latest) {
 			return "", false, ErrRewriteBlockOutOfRange
 		}
 	}

--- a/proxyd/rewriter_test.go
+++ b/proxyd/rewriter_test.go
@@ -31,7 +31,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs fromBlock latest",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": "latest"}})},
 				res:  nil,
 			},
@@ -46,7 +46,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs fromBlock within range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": hexutil.Uint64(55).String()}})},
 				res:  nil,
 			},
@@ -61,7 +61,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs fromBlock out of range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": hexutil.Uint64(111).String()}})},
 				res:  nil,
 			},
@@ -71,7 +71,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs toBlock latest",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"toBlock": "latest"}})},
 				res:  nil,
 			},
@@ -86,7 +86,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs toBlock within range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"toBlock": hexutil.Uint64(55).String()}})},
 				res:  nil,
 			},
@@ -101,7 +101,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs toBlock out of range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"toBlock": hexutil.Uint64(111).String()}})},
 				res:  nil,
 			},
@@ -111,7 +111,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs fromBlock, toBlock latest",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": "latest", "toBlock": "latest"}})},
 				res:  nil,
 			},
@@ -127,7 +127,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs fromBlock, toBlock within range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": hexutil.Uint64(55).String(), "toBlock": hexutil.Uint64(77).String()}})},
 				res:  nil,
 			},
@@ -143,7 +143,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs fromBlock, toBlock out of range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": hexutil.Uint64(111).String(), "toBlock": hexutil.Uint64(222).String()}})},
 				res:  nil,
 			},
@@ -153,7 +153,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs fromBlock -> toBlock above max range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100), maxBlockRange: 30},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), maxBlockRange: 30, consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": hexutil.Uint64(20).String(), "toBlock": hexutil.Uint64(80).String()}})},
 				res:  nil,
 			},
@@ -163,7 +163,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs earliest -> latest above max range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100), maxBlockRange: 30},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), maxBlockRange: 30, consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": "earliest", "toBlock": "latest"}})},
 				res:  nil,
 			},
@@ -173,7 +173,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs earliest -> pending above max range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100), maxBlockRange: 30},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), maxBlockRange: 30, consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": "earliest", "toBlock": "pending"}})},
 				res:  nil,
 			},
@@ -183,7 +183,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs earliest -> default above max range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100), maxBlockRange: 30},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), maxBlockRange: 30, consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": "earliest"}})},
 				res:  nil,
 			},
@@ -193,7 +193,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getLogs default -> latest within range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100), maxBlockRange: 30},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), maxBlockRange: 30, consensusMode: true},
 				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"toBlock": "latest"}})},
 				res:  nil,
 			},
@@ -210,7 +210,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "debug_getRawReceipts latest",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "debug_getRawReceipts", Params: mustMarshalJSON([]string{"latest"})},
 				res:  nil,
 			},
@@ -226,7 +226,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "debug_getRawReceipts within range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "debug_getRawReceipts", Params: mustMarshalJSON([]string{hexutil.Uint64(55).String()})},
 				res:  nil,
 			},
@@ -242,7 +242,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "debug_getRawReceipts out of range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "debug_getRawReceipts", Params: mustMarshalJSON([]string{hexutil.Uint64(111).String()})},
 				res:  nil,
 			},
@@ -252,7 +252,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "debug_getRawReceipts missing parameter",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "debug_getRawReceipts", Params: mustMarshalJSON([]string{})},
 				res:  nil,
 			},
@@ -261,7 +261,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "debug_getRawReceipts with block hash",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "debug_getRawReceipts", Params: mustMarshalJSON([]string{"0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b"})},
 				res:  nil,
 			},
@@ -278,7 +278,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getCode omit block, should add",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getCode", Params: mustMarshalJSON([]string{"0x123"})},
 				res:  nil,
 			},
@@ -297,7 +297,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getCode not enough params, should do nothing",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getCode", Params: mustMarshalJSON([]string{})},
 				res:  nil,
 			},
@@ -312,7 +312,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getCode latest",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getCode", Params: mustMarshalJSON([]string{"0x123", "latest"})},
 				res:  nil,
 			},
@@ -331,7 +331,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getCode within range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getCode", Params: mustMarshalJSON([]string{"0x123", hexutil.Uint64(55).String()})},
 				res:  nil,
 			},
@@ -348,7 +348,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getCode out of range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getCode", Params: mustMarshalJSON([]string{"0x123", hexutil.Uint64(111).String()})},
 				res:  nil,
 			},
@@ -359,7 +359,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getStorageAt omit block, should add",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getStorageAt", Params: mustMarshalJSON([]string{"0x123", "5"})},
 				res:  nil,
 			},
@@ -379,7 +379,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getStorageAt latest",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getStorageAt", Params: mustMarshalJSON([]string{"0x123", "5", "latest"})},
 				res:  nil,
 			},
@@ -399,7 +399,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getStorageAt within range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getStorageAt", Params: mustMarshalJSON([]string{"0x123", "5", hexutil.Uint64(55).String()})},
 				res:  nil,
 			},
@@ -417,7 +417,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getStorageAt out of range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getStorageAt", Params: mustMarshalJSON([]string{"0x123", "5", hexutil.Uint64(111).String()})},
 				res:  nil,
 			},
@@ -428,7 +428,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getBlockByNumber omit block, should add",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getBlockByNumber", Params: mustMarshalJSON([]string{})},
 				res:  nil,
 			},
@@ -444,7 +444,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getBlockByNumber latest",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getBlockByNumber", Params: mustMarshalJSON([]string{"latest"})},
 				res:  nil,
 			},
@@ -460,7 +460,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getBlockByNumber finalized",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100), finalized: hexutil.Uint64(55)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), finalized: hexutil.Uint64(55), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getBlockByNumber", Params: mustMarshalJSON([]string{"finalized"})},
 				res:  nil,
 			},
@@ -476,7 +476,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getBlockByNumber safe",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100), safe: hexutil.Uint64(50)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), safe: hexutil.Uint64(50), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getBlockByNumber", Params: mustMarshalJSON([]string{"safe"})},
 				res:  nil,
 			},
@@ -492,7 +492,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getBlockByNumber within range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getBlockByNumber", Params: mustMarshalJSON([]string{hexutil.Uint64(55).String()})},
 				res:  nil,
 			},
@@ -508,7 +508,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getBlockByNumber out of range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_getBlockByNumber", Params: mustMarshalJSON([]string{hexutil.Uint64(111).String()})},
 				res:  nil,
 			},
@@ -518,7 +518,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getStorageAt using rpc.BlockNumberOrHash",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req: &RPCReq{Method: "eth_getStorageAt", Params: mustMarshalJSON([]string{
 					"0xae851f927ee40de99aabb7461c00f9622ab91d60",
 					"0x65a7ed542fb37fe237fdfbdd70b31598523fe5b32879e307bae27a0bd9581c08",
@@ -531,7 +531,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getStorageAt using rpc.BlockNumberOrHash at genesis (blockNumber)",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req: &RPCReq{Method: "eth_getStorageAt", Params: mustMarshalJSON([]interface{}{
 					"0xae851f927ee40de99aabb7461c00f9622ab91d60",
 					"10",
@@ -545,7 +545,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getStorageAt using rpc.BlockNumberOrHash at genesis (hash)",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req: &RPCReq{Method: "eth_getStorageAt", Params: mustMarshalJSON([]interface{}{
 					"0xae851f927ee40de99aabb7461c00f9622ab91d60",
 					"10",
@@ -572,7 +572,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getStorageAt using rpc.BlockNumberOrHash at latest (blockNumber)",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req: &RPCReq{Method: "eth_getStorageAt", Params: mustMarshalJSON([]interface{}{
 					"0xae851f927ee40de99aabb7461c00f9622ab91d60",
 					"10",
@@ -597,7 +597,7 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getStorageAt using rpc.BlockNumberOrHash out of range",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req: &RPCReq{Method: "eth_getStorageAt", Params: mustMarshalJSON([]interface{}{
 					"0xae851f927ee40de99aabb7461c00f9622ab91d60",
 					"10",
@@ -694,7 +694,7 @@ func TestRewriteResponse(t *testing.T) {
 		{
 			name: "eth_blockNumber latest",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_blockNumber"},
 				res:  &RPCRes{Result: hexutil.Uint64(200)},
 			},
@@ -708,6 +708,98 @@ func TestRewriteResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := RewriteResponse(tt.args.rctx, tt.args.req, tt.args.res)
 			require.Nil(t, err)
+			require.Equal(t, tt.expected, result)
+			if tt.check != nil {
+				tt.check(t, tt.args)
+			}
+		})
+	}
+}
+
+func TestRewriteRequest_NonConsensusMode(t *testing.T) {
+	tests := []rewriteTest{
+		{
+			name: "eth_getLogs with latest tag should error",
+			args: args{
+				rctx: RewriteContext{consensusMode: false},
+				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": "latest"}})},
+				res:  nil,
+			},
+			expected: RewriteOverrideError,
+		},
+		{
+			name: "eth_getLogs missing toBlock with maxBlockRange should error",
+			args: args{
+				rctx: RewriteContext{consensusMode: false, maxBlockRange: 100},
+				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": hexutil.Uint64(50).String()}})},
+				res:  nil,
+			},
+			expected: RewriteOverrideError,
+		},
+		{
+			name: "eth_getLogs with valid range should work",
+			args: args{
+				rctx: RewriteContext{consensusMode: false, maxBlockRange: 100},
+				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": hexutil.Uint64(50).String(), "toBlock": hexutil.Uint64(100).String()}})},
+				res:  nil,
+			},
+			expected: RewriteNone,
+		},
+		{
+			name: "eth_getLogs with range exceeding maxBlockRange should error",
+			args: args{
+				rctx: RewriteContext{consensusMode: false, maxBlockRange: 10},
+				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": hexutil.Uint64(50).String(), "toBlock": hexutil.Uint64(100).String()}})},
+				res:  nil,
+			},
+			expected:    RewriteOverrideError,
+			expectedErr: ErrRewriteRangeTooLarge,
+		},
+		{
+			name: "eth_getLogs missing fromBlock should default to earliest",
+			args: args{
+				rctx: RewriteContext{consensusMode: false, maxBlockRange: 100},
+				req:  &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"toBlock": hexutil.Uint64(50).String()}})},
+				res:  nil,
+			},
+			expected: RewriteOverrideRequest,
+			check: func(t *testing.T, args args) {
+				var p []map[string]interface{}
+				err := json.Unmarshal(args.req.Params, &p)
+				require.Nil(t, err)
+				require.Equal(t, "earliest", p[0]["fromBlock"])
+			},
+		},
+		{
+			name: "eth_getBlockByNumber with latest tag should error",
+			args: args{
+				rctx: RewriteContext{consensusMode: false},
+				req:  &RPCReq{Method: "eth_getBlockByNumber", Params: mustMarshalJSON([]interface{}{"latest", true})},
+				res:  nil,
+			},
+			expected: RewriteOverrideError,
+		},
+		{
+			name: "eth_getBlockByNumber with block number should work",
+			args: args{
+				rctx: RewriteContext{consensusMode: false},
+				req:  &RPCReq{Method: "eth_getBlockByNumber", Params: mustMarshalJSON([]interface{}{hexutil.Uint64(100).String(), true})},
+				res:  nil,
+			},
+			expected: RewriteNone,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := RewriteRequest(tt.args.rctx, tt.args.req, tt.args.res)
+			if tt.expectedErr != nil {
+				require.NotNil(t, err)
+				require.Equal(t, tt.expectedErr.Error(), err.Error())
+			} else if tt.expected == RewriteOverrideError {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
 			require.Equal(t, tt.expected, result)
 			if tt.check != nil {
 				tt.check(t, tt.args)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Max block range config to limit block range for potentially expensive rpc requests like `eth_getLogs` and `eth_newFilter`. The config applies across all routing strategies, and will only be applied if the config value is set. Otherwise, it reverts to original behavior, with limits for `consensus_aware` backends only if `consensus_max_block_range` is set.

Note, if `max_block_range` is set, the above two requests will not accept block tags, to prevent unbounded queries.

Max block range will override `ConsensusMaxBlockRange` if set.

**Tests**

Integration test for `eth_getLogs/eth_newFilter` to test that the config value is working as intended.

**Additional context**

This is from a Spearbit audit in Cantina that Unichain recently did.

```
Description
Some operations like eth_getLogs can take quite a while, especially if a user requests abnormally large block ranges.

This can be problematic when the proxyd service considers a timeout of 5 seconds for any requests that it has forwarded. It will mark down an error case if any backend takes longer than 5 seconds to service such a request. A backend with too many errors will eventually be considered an "unhealthy" backend and proxyd will stop using that backend.

A user can intentionally send many requests that result in a timeout. This is the cae because the nodes used in the Unichain deployment do not have limits configured needed to ensure that nodes are able to guarantee the 5 second latency contract that proxyd expects.

Executing this approach on a large scale can cause proxyd to consider an entire backend group as unhealthy, and stop servicing (some) legitimate requests.

Recommendation
Execute a range of simple benchmarks that can be used to inform an initial set of limits for the rpc calls that are prone to long execution times.

An alternative approach is to leverage monitoring of the RPC nodes and basing the limits on historical observations.

It might also be possible to leverage the existing monitoring stack to detect attacks attempting to exploit this flaw.
```

**Metadata**

- Fixes #[Link to Issue]
