### PR TITLE
feat(proxyd): verify last XFF IP matches client IP

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1583,6 +1583,7 @@ func stripXFF(xff string) string {
 	return strings.TrimSpace(ipList[0])
 }
 
+// getLastXFF extracts the last IP from X-Forwarded-For chain (e.g., "1.2.3.4, 5.6.7.8" -> "5.6.7.8")
 func getLastXFF(xff string) string {
 	if xff == "" {
 		return ""

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1583,6 +1583,27 @@ func stripXFF(xff string) string {
 	return strings.TrimSpace(ipList[0])
 }
 
+func getLastXFF(xff string) string {
+	if xff == "" {
+		return ""
+	}
+	ipList := strings.Split(xff, ",")
+	return strings.TrimSpace(ipList[len(ipList)-1])
+}
+
+// extractIPFromAddr extracts IP from address string (e.g., "1.2.3.4:8080" -> "1.2.3.4")
+func extractIPFromAddr(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	// Split by last colon to handle IPv6 addresses
+	lastColon := strings.LastIndex(addr, ":")
+	if lastColon == -1 {
+		return addr
+	}
+	return addr[:lastColon]
+}
+
 type BackendGroupRPCResponse struct {
 	RPCRes   []*RPCRes
 	ServedBy string

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -29,6 +29,39 @@ func TestStripXFF(t *testing.T) {
 	}
 }
 
+func TestGetLastXFF(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{"1.2.3, 4.5.6, 7.8.9", "7.8.9"},
+		{"1.2.3,4.5.6", "4.5.6"},
+		{" 1.2.3 , 4.5.6 ", "4.5.6"},
+		{"192.168.1.1", "192.168.1.1"},
+		{"", ""},
+	}
+
+	for _, test := range tests {
+		actual := getLastXFF(test.in)
+		assert.Equal(t, test.out, actual)
+	}
+}
+
+func TestExtractIPFromAddr(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{"192.168.1.1:8080", "192.168.1.1"},
+		{"192.168.1.1", "192.168.1.1"},
+		{"[::1]:8080", "[::1]"},
+		{"", ""},
+	}
+
+	for _, test := range tests {
+		actual := extractIPFromAddr(test.in)
+		assert.Equal(t, test.out, actual)
+	}
+}
+
 func TestLimitedHTTPClientDoLimited(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -136,6 +169,7 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 		InteropValidationConfig{},              // interopValidatingConfig
 		NewFirstSupervisorStrategy([]string{}), // interopStrategy
 		false,                                  // enableTxHashLogging
+		false,                                  // enableXFFVerification
 	)
 	require.NoError(t, err)
 

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -33,6 +33,8 @@ type ServerConfig struct {
 	AllowAllOrigins       bool `toml:"allow_all_origins"`
 	PublicAccess          bool `toml:"public_access"`
 	EnableTxHashLogging   bool `toml:"enable_tx_hash_logging"`
+	// EnableXFFVerification enables verification that the last entry in X-Forwarded-For matches the remote address
+	EnableXFFVerification bool `toml:"enable_xff_verification"`
 }
 
 type CacheConfig struct {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -33,7 +33,6 @@ type ServerConfig struct {
 	AllowAllOrigins       bool `toml:"allow_all_origins"`
 	PublicAccess          bool `toml:"public_access"`
 	EnableTxHashLogging   bool `toml:"enable_tx_hash_logging"`
-	// EnableXFFVerification enables verification that the last entry in X-Forwarded-For matches the remote address
 	EnableXFFVerification bool `toml:"enable_xff_verification"`
 }
 

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -428,6 +428,7 @@ func Start(config *Config) (*Server, func(), error) {
 		config.InteropValidationConfig,
 		interopStrategy,
 		config.Server.EnableTxHashLogging,
+		config.Server.EnableXFFVerification,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -187,6 +188,14 @@ func NewServer(
 	rateLimitHeader := defaultRateLimitHeader
 	if rateLimitConfig.IPHeaderOverride != "" {
 		rateLimitHeader = rateLimitConfig.IPHeaderOverride
+	}
+
+	if enableXFFVerification && strings.ToLower(rateLimitHeader) != "x-forwarded-for" {
+		log.Warn(
+			"X-Forwarded-For verification is enabled but rate limit header is not X-Forwarded-For, verification will be disabled",
+			"rate_limit_header", rateLimitHeader,
+		)
+		enableXFFVerification = false
 	}
 
 	return &Server{


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds config to enable XFF verification, which compares the last IP in the XFF address list against the remote address (client IP). This protects against IP spoofing, which attackers can use to exhaust rate limits of other IPs.

Proxyd will automatically disable this verification if the rate limit header is overridden to not be `x-forwarded-for`.

**Tests**

Unit tests added for all new code

**Additional context**

```
Sender Verification
It is possible that attackers might connect to proxyd directly in misconfigured deployments.

To ensure correct functioning proxyd should verify that the last entry in the x-forwarded-for chain is equal to the connection initiator. Without such a check the trust chain control would be less effective, as an attacker could simply mirror a request as if it has the expected trusted proxy IP addresses.
```

**Metadata**

- Fixes #[Link to Issue]
