### PR TITLE
Jelias2/op acceptor metrics improvements

### DIFF
--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -15,29 +15,30 @@ import (
 
 // Config holds the application configuration
 type Config struct {
-	TestDir              string
-	ValidatorConfig      string
-	TargetGate           string
-	GatelessMode         bool
-	GoBinary             string
-	RunInterval          time.Duration          // Interval between test runs
-	RunOnce              bool                   // Indicates if the service should exit after one test run
-	AllowSkips           bool                   // Allow tests to be skipped instead of failing when preconditions are not met
-	DefaultTimeout       time.Duration          // Default timeout for individual tests, can be overridden by test config
-	Timeout              time.Duration          // Timeout for gateless mode tests (if specified)
-	LogDir               string                 // Directory to store test logs
-	OutputRealtimeLogs   bool                   // If enabled, test logs will be outputted in realtime
-	TestLogLevel         string                 // Log level to be used for the tests
-	Orchestrator         flags.OrchestratorType // Devstack orchestrator type
-	DevnetEnvURL         string                 // URL or path to the devnet environment file
-	Serial               bool                   // Whether to run tests serially instead of in parallel
-	Concurrency          int                    // Number of concurrent test workers (0 = auto-determine)
-	ShowProgress         bool                   // Whether to show periodic progress updates during test execution
-	ProgressInterval     time.Duration          // Interval between progress updates when ShowProgress is 'true'
-	FlakeShake           bool                   // Enable flake-shake mode for test stability validation
-	FlakeShakeIterations int                    // Number of times to run each test in flake-shake mode
-	Log                  log.Logger
-	ExcludeGates         []string // List of gate IDs whose tests should be excluded
+	TestDir               string
+	ValidatorConfig       string
+	TargetGate            string
+	GatelessMode          bool
+	GoBinary              string
+	RunInterval           time.Duration          // Interval between test runs
+	RunOnce               bool                   // Indicates if the service should exit after one test run
+	AllowSkips            bool                   // Allow tests to be skipped instead of failing when preconditions are not met
+	DefaultTimeout        time.Duration          // Default timeout for individual tests, can be overridden by test config
+	Timeout               time.Duration          // Timeout for gateless mode tests (if specified)
+	LogDir                string                 // Directory to store test logs
+	OutputRealtimeLogs    bool                   // If enabled, test logs will be outputted in realtime
+	StripFileLinePrefixes bool                   // If enabled, strip file:line prefixes from test output logs
+	TestLogLevel          string                 // Log level to be used for the tests
+	Orchestrator          flags.OrchestratorType // Devstack orchestrator type
+	DevnetEnvURL          string                 // URL or path to the devnet environment file
+	Serial                bool                   // Whether to run tests serially instead of in parallel
+	Concurrency           int                    // Number of concurrent test workers (0 = auto-determine)
+	ShowProgress          bool                   // Whether to show periodic progress updates during test execution
+	ProgressInterval      time.Duration          // Interval between progress updates when ShowProgress is 'true'
+	FlakeShake            bool                   // Enable flake-shake mode for test stability validation
+	FlakeShakeIterations  int                    // Number of times to run each test in flake-shake mode
+	Log                   log.Logger
+	ExcludeGates          []string // List of gate IDs whose tests should be excluded
 }
 
 // NewConfig creates a new Config from cli context
@@ -114,29 +115,30 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 	}
 
 	return &Config{
-		TestDir:              absTestDir,
-		ValidatorConfig:      absValidatorConfig,
-		TargetGate:           gate,
-		GatelessMode:         gatelessMode,
-		GoBinary:             ctx.String(flags.GoBinary.Name),
-		RunInterval:          runInterval,
-		RunOnce:              runOnce,
-		AllowSkips:           ctx.Bool(flags.AllowSkips.Name),
-		DefaultTimeout:       ctx.Duration(flags.DefaultTimeout.Name),
-		Timeout:              ctx.Duration(flags.Timeout.Name),
-		OutputRealtimeLogs:   ctx.Bool(flags.OutputRealtimeLogs.Name),
-		TestLogLevel:         ctx.String(flags.TestLogLevel.Name),
-		Orchestrator:         orchestrator,
-		DevnetEnvURL:         devnetEnvURL,
-		Serial:               ctx.Bool(flags.Serial.Name),
-		Concurrency:          ctx.Int(flags.Concurrency.Name),
-		ShowProgress:         ctx.Bool(flags.ShowProgress.Name),
-		ProgressInterval:     ctx.Duration(flags.ProgressInterval.Name),
-		FlakeShake:           ctx.Bool(flags.FlakeShake.Name),
-		FlakeShakeIterations: ctx.Int(flags.FlakeShakeIterations.Name),
-		LogDir:               logDir,
-		Log:                  log,
-		ExcludeGates:         excludeGates,
+		TestDir:               absTestDir,
+		ValidatorConfig:       absValidatorConfig,
+		TargetGate:            gate,
+		GatelessMode:          gatelessMode,
+		GoBinary:              ctx.String(flags.GoBinary.Name),
+		RunInterval:           runInterval,
+		RunOnce:               runOnce,
+		AllowSkips:            ctx.Bool(flags.AllowSkips.Name),
+		DefaultTimeout:        ctx.Duration(flags.DefaultTimeout.Name),
+		Timeout:               ctx.Duration(flags.Timeout.Name),
+		OutputRealtimeLogs:    ctx.Bool(flags.OutputRealtimeLogs.Name),
+		StripFileLinePrefixes: ctx.Bool(flags.StripFileLinePrefixes.Name),
+		TestLogLevel:          ctx.String(flags.TestLogLevel.Name),
+		Orchestrator:          orchestrator,
+		DevnetEnvURL:          devnetEnvURL,
+		Serial:                ctx.Bool(flags.Serial.Name),
+		Concurrency:           ctx.Int(flags.Concurrency.Name),
+		ShowProgress:          ctx.Bool(flags.ShowProgress.Name),
+		ProgressInterval:      ctx.Duration(flags.ProgressInterval.Name),
+		FlakeShake:            ctx.Bool(flags.FlakeShake.Name),
+		FlakeShakeIterations:  ctx.Int(flags.FlakeShakeIterations.Name),
+		LogDir:                logDir,
+		Log:                   log,
+		ExcludeGates:          excludeGates,
 	}, nil
 }
 

--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Timeout               time.Duration          // Timeout for gateless mode tests (if specified)
 	LogDir                string                 // Directory to store test logs
 	OutputRealtimeLogs    bool                   // If enabled, test logs will be outputted in realtime
+	StripCodeLinePrefixes bool                   // If enabled, file:line prefixes will be stripped from test logs
 	TestLogLevel          string                 // Log level to be used for the tests
 	Orchestrator          flags.OrchestratorType // Devstack orchestrator type
 	DevnetEnvURL          string                 // URL or path to the devnet environment file
@@ -38,7 +39,6 @@ type Config struct {
 	FlakeShakeIterations  int                    // Number of times to run each test in flake-shake mode
 	Log                   log.Logger
 	ExcludeGates          []string // List of gate IDs whose tests should be excluded
-	StripFileLinePrefixes bool     // If enabled, strip file:line prefixes from test output logs
 }
 
 // NewConfig creates a new Config from cli context
@@ -126,6 +126,7 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 		DefaultTimeout:        ctx.Duration(flags.DefaultTimeout.Name),
 		Timeout:               ctx.Duration(flags.Timeout.Name),
 		OutputRealtimeLogs:    ctx.Bool(flags.OutputRealtimeLogs.Name),
+		StripCodeLinePrefixes: ctx.Bool(flags.StripCodeLinePrefixes.Name),
 		TestLogLevel:          ctx.String(flags.TestLogLevel.Name),
 		Orchestrator:          orchestrator,
 		DevnetEnvURL:          devnetEnvURL,
@@ -138,7 +139,6 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 		LogDir:                logDir,
 		Log:                   log,
 		ExcludeGates:          excludeGates,
-		StripFileLinePrefixes: ctx.Bool(flags.StripFileLinePrefixes.Name),
 	}, nil
 }
 

--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -27,7 +27,6 @@ type Config struct {
 	Timeout               time.Duration          // Timeout for gateless mode tests (if specified)
 	LogDir                string                 // Directory to store test logs
 	OutputRealtimeLogs    bool                   // If enabled, test logs will be outputted in realtime
-	StripFileLinePrefixes bool                   // If enabled, strip file:line prefixes from test output logs
 	TestLogLevel          string                 // Log level to be used for the tests
 	Orchestrator          flags.OrchestratorType // Devstack orchestrator type
 	DevnetEnvURL          string                 // URL or path to the devnet environment file
@@ -39,6 +38,7 @@ type Config struct {
 	FlakeShakeIterations  int                    // Number of times to run each test in flake-shake mode
 	Log                   log.Logger
 	ExcludeGates          []string // List of gate IDs whose tests should be excluded
+	StripFileLinePrefixes bool     // If enabled, strip file:line prefixes from test output logs
 }
 
 // NewConfig creates a new Config from cli context
@@ -126,7 +126,6 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 		DefaultTimeout:        ctx.Duration(flags.DefaultTimeout.Name),
 		Timeout:               ctx.Duration(flags.Timeout.Name),
 		OutputRealtimeLogs:    ctx.Bool(flags.OutputRealtimeLogs.Name),
-		StripFileLinePrefixes: ctx.Bool(flags.StripFileLinePrefixes.Name),
 		TestLogLevel:          ctx.String(flags.TestLogLevel.Name),
 		Orchestrator:          orchestrator,
 		DevnetEnvURL:          devnetEnvURL,
@@ -139,6 +138,7 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 		LogDir:                logDir,
 		Log:                   log,
 		ExcludeGates:          excludeGates,
+		StripFileLinePrefixes: ctx.Bool(flags.StripFileLinePrefixes.Name),
 	}, nil
 }
 

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -121,11 +121,11 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "OUTPUT_REALTIME_LOGS"),
 		Usage:   "If enabled, test logs will be outputted to the console in realtime. Defaults to false.",
 	}
-	StripFileLinePrefixes = &cli.BoolFlag{
-		Name:    "strip-file-line-prefixes",
+	StripCodeLinePrefixes = &cli.BoolFlag{
+		Name:    "strip-code-line-prefixes",
 		Value:   true,
-		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "STRIP_FILE_LINE_PREFIXES"),
-		Usage:   "Strip file:line prefixes (e.g., 'system.go:28:') from test output logs. Defaults to true.",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "STRIP_CODE_LINE_PREFIXES"),
+		Usage:   "Strip file:line prefixes (e.g. 'test.go:123:') from test logs. Defaults to true.",
 	}
 	ShowProgress = &cli.BoolFlag{
 		Name:    "show-progress",
@@ -202,7 +202,7 @@ var optionalFlags = []cli.Flag{
 	LogDir,
 	TestLogLevel,
 	OutputRealtimeLogs,
-	StripFileLinePrefixes,
+	StripCodeLinePrefixes,
 	ShowProgress,
 	ProgressInterval,
 	Orchestrator,

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -121,6 +121,12 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "OUTPUT_REALTIME_LOGS"),
 		Usage:   "If enabled, test logs will be outputted to the console in realtime. Defaults to false.",
 	}
+	StripFileLinePrefixes = &cli.BoolFlag{
+		Name:    "strip-file-line-prefixes",
+		Value:   true,
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "STRIP_FILE_LINE_PREFIXES"),
+		Usage:   "Strip file:line prefixes (e.g., 'system.go:28:') from test output logs. Defaults to true.",
+	}
 	ShowProgress = &cli.BoolFlag{
 		Name:    "show-progress",
 		Value:   false,
@@ -196,6 +202,7 @@ var optionalFlags = []cli.Flag{
 	LogDir,
 	TestLogLevel,
 	OutputRealtimeLogs,
+	StripFileLinePrefixes,
 	ShowProgress,
 	ProgressInterval,
 	Orchestrator,

--- a/op-acceptor/logging/clean_log_output_test.go
+++ b/op-acceptor/logging/clean_log_output_test.go
@@ -1,0 +1,227 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanLogOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "simple text without special characters",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "text with leading and trailing whitespace",
+			input:    "  hello world  ",
+			expected: "hello world",
+		},
+		{
+			name:     "text with multiple spaces",
+			input:    "hello    world",
+			expected: "hello world",
+		},
+		{
+			name:     "text with tabs",
+			input:    "hello\t\tworld",
+			expected: "hello world",
+		},
+		{
+			name:     "text with newlines",
+			input:    "hello\nworld",
+			expected: "hello world",
+		},
+		{
+			name:     "text with mixed whitespace",
+			input:    "hello  \t\n  world",
+			expected: "hello world",
+		},
+		{
+			name:     "file:line prefix simple",
+			input:    "test.go:123: error message",
+			expected: "error message",
+		},
+		{
+			name:     "file:line prefix with underscore",
+			input:    "da_footprint_test.go:188: some log output",
+			expected: "some log output",
+		},
+		{
+			name:     "file:line prefix with leading whitespace",
+			input:    "  test_file.go:456: message here",
+			expected: "message here",
+		},
+		{
+			name:     "file:line prefix with hyphen",
+			input:    "my-file.go:99: content",
+			expected: "content",
+		},
+		{
+			name:     "ANSI color codes",
+			input:    "\x1b[31mred text\x1b[0m",
+			expected: "red text",
+		},
+		{
+			name:     "ANSI codes with other formatting",
+			input:    "\x1b[1;32mbold green\x1b[0m normal",
+			expected: "bold green normal",
+		},
+		{
+			name:     "combination: file prefix, ANSI codes, and whitespace",
+			input:    "  test.go:42:  \x1b[31m  error:   failed\x1b[0m  ",
+			expected: "error: failed",
+		},
+		{
+			name:     "combination: multiple whitespace types",
+			input:    "test.go:1: hello\t\t  world  \n  foo",
+			expected: "hello world foo",
+		},
+		{
+			name:     "text that looks like but isn't a file:line prefix",
+			input:    "this is not file.go:123: a prefix because text comes before",
+			expected: "this is not file.go:123: a prefix because text comes before",
+		},
+		{
+			name:     "multiple lines with different prefixes",
+			input:    "file1.go:10: first line\nfile2.go:20: second line",
+			expected: "first line file2.go:20: second line",
+		},
+		{
+			name:     "no file extension in prefix",
+			input:    "file:123: should not match",
+			expected: "file:123: should not match",
+		},
+		{
+			name:     "wrong extension in prefix",
+			input:    "file.txt:123: should not match",
+			expected: "file.txt:123: should not match",
+		},
+		{
+			name:     "real-world example with geth logger output",
+			input:    "  da_test.go:188:   \x1b[36mINFO\x1b[0m [01-01|00:00:00.000]   Transaction   submitted    hash=0x123",
+			expected: "INFO [01-01|00:00:00.000] Transaction submitted hash=0x123",
+		},
+		{
+			name:     "multiple consecutive newlines",
+			input:    "line1\n\n\nline2",
+			expected: "line1 line2",
+		},
+		{
+			name:     "only whitespace",
+			input:    "   \t\n   ",
+			expected: "",
+		},
+		{
+			name:     "unicode characters preserved",
+			input:    "hello 世界 🌍",
+			expected: "hello 世界 🌍",
+		},
+		{
+			name:     "file prefix at start preserves rest of content",
+			input:    "test.go:1: key=value another=thing",
+			expected: "key=value another=thing",
+		},
+		{
+			name:     "real log from da_footprint_test",
+			input:    "    da_footprint_test.go:188:             INFO [10-29|23:42:54.881] \"Block 0xbf9f2a47f13a639f439c3bb04070d3186019972b78d694e56e4e61647d4433a0:228357 has DA footprint (0) <= gasUsed (46218), trying next...\"",
+			expected: "INFO [10-29|23:42:54.881] \"Block 0xbf9f2a47f13a639f439c3bb04070d3186019972b78d694e56e4e61647d4433a0:228357 has DA footprint (0) <= gasUsed (46218), trying next...\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CleanLogOutput(tt.input, true, true)
+			assert.Equal(t, tt.expected, result, "CleanLogOutput(%q, true, true) = %q, want %q", tt.input, result, tt.expected)
+		})
+	}
+}
+
+func TestCleanLogOutputWithoutStrippingPrefixes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "file:line prefix preserved",
+			input:    "da_footprint_test.go:188: some log output",
+			expected: "da_footprint_test.go:188: some log output",
+		},
+		{
+			name:     "file:line prefix preserved with whitespace collapsed",
+			input:    "test.go:1: hello\t\t  world  \n  foo",
+			expected: "test.go:1: hello world foo",
+		},
+		{
+			name:     "ANSI codes still stripped",
+			input:    "test.go:42: \x1b[31mred text\x1b[0m",
+			expected: "test.go:42: red text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CleanLogOutput(tt.input, false, true)
+			assert.Equal(t, tt.expected, result, "CleanLogOutput(%q, false, true) = %q, want %q", tt.input, result, tt.expected)
+		})
+	}
+}
+
+func TestCleanLogOutputRegexPatterns(t *testing.T) {
+	t.Run("fileLinePrefixRegex matches valid patterns", func(t *testing.T) {
+		validPatterns := []string{
+			"test.go:123: ",
+			"  test.go:1: ",
+			"my_file.go:999: ",
+			"My-File.go:1: ",
+			"FILE123.go:456: ",
+		}
+		for _, pattern := range validPatterns {
+			assert.True(t, fileLinePrefixRegex.MatchString(pattern),
+				"fileLinePrefixRegex should match %q", pattern)
+		}
+	})
+
+	t.Run("fileLinePrefixRegex does not match invalid patterns", func(t *testing.T) {
+		invalidPatterns := []string{
+			"file.txt:123: ",       // not .go file
+			"prefix file.go:123: ", // not at start
+			"file.go:abc: ",        // not a number
+			"file:123: ",           // missing .go
+			".go:123: ",            // no filename
+			"file.go:",             // missing line number
+		}
+		for _, pattern := range invalidPatterns {
+			assert.False(t, fileLinePrefixRegex.MatchString(pattern),
+				"fileLinePrefixRegex should not match %q", pattern)
+		}
+	})
+
+	t.Run("multipleWhitespaceRegex collapses various whitespace", func(t *testing.T) {
+		testCases := []struct {
+			input    string
+			expected string
+		}{
+			{"a  b", "a b"},
+			{"a\tb", "a b"},
+			{"a\nb", "a b"},
+			{"a\r\nb", "a b"},
+			{"a   \t\n   b", "a b"},
+		}
+		for _, tc := range testCases {
+			result := multipleWhitespaceRegex.ReplaceAllString(tc.input, " ")
+			assert.Equal(t, tc.expected, result)
+		}
+	})
+}

--- a/op-acceptor/logging/filelogger.go
+++ b/op-acceptor/logging/filelogger.go
@@ -37,7 +37,8 @@ var (
 
 // CleanLogOutput cleans up log output by removing ANSI codes, escape sequences,
 // optionally removing file:line prefixes, optionally collapsing whitespace, and trimming.
-// When collapseWhitespace is false, formatting in structured output (like test results) is preserved.
+// When collapseWhitespace is true, multiple consecutive whitespace characters (spaces, tabs,
+// newlines) are collapsed into single spaces, which cleans up structured logging output.
 func CleanLogOutput(s string, stripCodeLinePrefixes bool, collapseWhitespace bool) string {
 	// Strip ANSI escape codes
 	cleaned := stripansi.Strip(s)
@@ -854,8 +855,8 @@ func (s *PerTestFileSink) createPlaintextFile(result *types.TestResult, filePath
 		parser := NewJSONOutputParser(result.Stdout)
 		parser.ProcessJSONOutput(func(_ map[string]interface{}, outputText string) {
 			// Clean the output (strip ANSI codes, optionally file:line prefixes)
-			// Don't collapse whitespace for test output to preserve formatting
-			cleaned := CleanLogOutput(outputText, s.logger.stripCodeLinePrefixes, false)
+			// Collapse whitespace to clean up structured logging output
+			cleaned := CleanLogOutput(outputText, s.logger.stripCodeLinePrefixes, true)
 			if cleaned != "" {
 				plaintext.WriteString(cleaned)
 				plaintext.WriteString("\n")
@@ -866,7 +867,7 @@ func (s *PerTestFileSink) createPlaintextFile(result *types.TestResult, filePath
 		// (e.g., for subtests extracted from a package run)
 		if plaintext.Len() == 0 && strings.Contains(result.Stdout, "===") {
 			// It's already plain text, clean it and use it
-			plaintext.WriteString(CleanLogOutput(result.Stdout, s.logger.stripCodeLinePrefixes, false))
+			plaintext.WriteString(CleanLogOutput(result.Stdout, s.logger.stripCodeLinePrefixes, true))
 		}
 	}
 

--- a/op-acceptor/logging/filelogger_output_test.go
+++ b/op-acceptor/logging/filelogger_output_test.go
@@ -15,7 +15,7 @@ import (
 func TestPlaintextFileCreation(t *testing.T) {
 	// Setup
 	tempDir := t.TempDir()
-	logger, err := NewFileLogger(tempDir, "test-run", "test-network", "test-gate")
+	logger, err := NewFileLogger(tempDir, "test-run", "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	sink := &PerTestFileSink{logger: logger}
@@ -116,7 +116,7 @@ func TestPlaintextFileCreation(t *testing.T) {
 func TestSubtestOutputHandling(t *testing.T) {
 	// Setup
 	tempDir := t.TempDir()
-	logger, err := NewFileLogger(tempDir, "test-run", "test-network", "test-gate")
+	logger, err := NewFileLogger(tempDir, "test-run", "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	sink := &PerTestFileSink{logger: logger}

--- a/op-acceptor/logging/filelogger_output_test.go
+++ b/op-acceptor/logging/filelogger_output_test.go
@@ -33,7 +33,7 @@ func TestPlaintextFileCreation(t *testing.T) {
 {"Time":"2025-09-23T10:00:01Z","Action":"output","Package":"test/pkg","Test":"TestExample","Output":"    test.go:10: Log message\n"}
 {"Time":"2025-09-23T10:00:02Z","Action":"output","Package":"test/pkg","Test":"TestExample","Output":"--- PASS: TestExample (1.00s)\n"}`,
 			shouldContain: []string{
-				"=== RUN   TestExample",
+				"=== RUN TestExample", // Whitespace collapsed
 				"Log message",
 				"--- PASS: TestExample",
 			},
@@ -45,7 +45,7 @@ func TestPlaintextFileCreation(t *testing.T) {
     test.go:10: Log message
 --- PASS: TestExample (1.00s)`,
 			shouldContain: []string{
-				"=== RUN   TestExample",
+				"=== RUN TestExample", // Whitespace collapsed
 				"Log message",
 				"--- PASS: TestExample",
 			},

--- a/op-acceptor/logging/filelogger_test.go
+++ b/op-acceptor/logging/filelogger_test.go
@@ -465,7 +465,7 @@ func TestPerTestFileSink_WritesTestOutput(t *testing.T) {
 	passedTxtContent, err := os.ReadFile(passedTxtPath)
 	require.NoError(t, err, "Should be able to read the passing test plaintext file")
 	passedTxtStr := string(passedTxtContent)
-	assert.Contains(t, passedTxtStr, "=== RUN   TestPass")
+	assert.Contains(t, passedTxtStr, "=== RUN TestPass") // Whitespace collapsed
 	assert.Contains(t, passedTxtStr, "--- PASS: TestPass (1.00s)")
 	// Should NOT contain headers since this is a separate file
 	assert.NotContains(t, passedTxtStr, "PLAINTEXT OUTPUT:")
@@ -497,11 +497,11 @@ func TestPerTestFileSink_WritesTestOutput(t *testing.T) {
 	failedTxtContent, err := os.ReadFile(failedTxtPath)
 	require.NoError(t, err, "Should be able to read the failing test plaintext file")
 	failedTxtStr := string(failedTxtContent)
-	assert.Contains(t, failedTxtStr, "=== RUN   TestFail")
+	assert.Contains(t, failedTxtStr, "=== RUN TestFail") // Whitespace collapsed
 	assert.Contains(t, failedTxtStr, "Error Trace:")
 	assert.Contains(t, failedTxtStr, "Error:")
 	assert.Contains(t, failedTxtStr, "expected: int(42)")
-	assert.Contains(t, failedTxtStr, "actual  : int(43)")
+	assert.Contains(t, failedTxtStr, "actual : int(43)") // Whitespace collapsed
 	assert.Contains(t, failedTxtStr, "Messages:")
 	// Should NOT contain headers since this is a separate file
 	assert.NotContains(t, failedTxtStr, "PLAINTEXT OUTPUT:")

--- a/op-acceptor/logging/filelogger_test.go
+++ b/op-acceptor/logging/filelogger_test.go
@@ -21,7 +21,7 @@ func TestFileLogger(t *testing.T) {
 
 	// Create a new FileLogger with a valid runID
 	runID := "test-run-123"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Get the directory with the testrun- prefix
@@ -153,12 +153,12 @@ func TestLoggerWithEmptyRunID(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Test that an error is returned when an empty runID is provided to NewFileLogger
-	_, err = NewFileLogger(tmpDir, "", "test-network", "test-gate")
+	_, err = NewFileLogger(tmpDir, "", "test-network", "test-gate", true)
 	assert.Error(t, err, "Expected error when creating logger with empty runID")
 	assert.Contains(t, err.Error(), "runID cannot be empty")
 
 	// Create a valid logger to test the LogTestResult with empty runID
-	logger, err := NewFileLogger(tmpDir, "valid-run-id", "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, "valid-run-id", "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Create a test result
@@ -193,7 +193,7 @@ func TestLoggingWithRunID(t *testing.T) {
 
 	// Create a new FileLogger with a valid runID
 	defaultRunID := "default-run-id"
-	logger, err := NewFileLogger(tmpDir, defaultRunID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, defaultRunID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// We'll use a different runID for this test
@@ -333,7 +333,7 @@ func TestCustomResultSink(t *testing.T) {
 
 	// Create a new FileLogger with a valid runID
 	runID := "custom-sink-test"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Create a custom sink for testing
@@ -390,7 +390,7 @@ func TestPerTestFileSink_WritesTestOutput(t *testing.T) {
 	runID := "test-pertest-sink"
 
 	// Create a file logger
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Access the PerTestFileSink directly
@@ -533,7 +533,7 @@ func TestHTMLSummarySink_GeneratesHTMLReport(t *testing.T) {
 	runID := "test-html-summary"
 
 	// Create a file logger
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Create a mix of test results
@@ -645,7 +645,7 @@ func TestHTMLSummarySink_WithSubtestsAndNetworkInfo(t *testing.T) {
 	gateRun := "isthmus"
 
 	// Create a file logger with network and gate information
-	logger, err := NewFileLogger(tmpDir, runID, networkName, gateRun)
+	logger, err := NewFileLogger(tmpDir, runID, networkName, gateRun, true)
 	require.NoError(t, err)
 
 	// Create subtests
@@ -758,7 +758,7 @@ func TestPerTestFileSink_CreatesSubtestFiles(t *testing.T) {
 	runID := "test-subtests"
 
 	// Create a file logger
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Access the PerTestFileSink directly
@@ -859,7 +859,7 @@ func TestDuplicationFix(t *testing.T) {
 	runID := "duplication-test"
 
 	// Create a file logger
-	logger, err := NewFileLogger(logDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(logDir, runID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Create a test result that would have caused duplication before
@@ -953,7 +953,7 @@ func TestHTMLSink_TestsWithSubtestsAlwaysDisplayed(t *testing.T) {
 	gateRun := "test-gate"
 
 	// Create a file logger
-	logger, err := NewFileLogger(tmpDir, runID, networkName, gateRun)
+	logger, err := NewFileLogger(tmpDir, runID, networkName, gateRun, true)
 	require.NoError(t, err)
 
 	// Simulate the fjord scenario: a test with subtests but minimal metadata

--- a/op-acceptor/logging/integration_test.go
+++ b/op-acceptor/logging/integration_test.go
@@ -16,7 +16,7 @@ func TestIntegrationSubtestOutputCapture(t *testing.T) {
 	// Setup
 	tempDir := t.TempDir()
 	runID := "test-run-" + time.Now().Format("20060102-150405")
-	logger, err := NewFileLogger(tempDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tempDir, runID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Create a main test result with subtests that have plain text output
@@ -120,7 +120,7 @@ func TestRealTestOutputCapture(t *testing.T) {
 	// Setup
 	tempDir := t.TempDir()
 	runID := "real-test-run"
-	logger, err := NewFileLogger(tempDir, runID, "optimism", "connectivity")
+	logger, err := NewFileLogger(tempDir, runID, "optimism", "connectivity", true)
 	require.NoError(t, err)
 
 	// Simulate a test result for TestRPCConnectivity with actual logger output

--- a/op-acceptor/logging/raw_json_sink_test.go
+++ b/op-acceptor/logging/raw_json_sink_test.go
@@ -25,7 +25,7 @@ func TestRawJSONSink(t *testing.T) {
 
 	// Create a new FileLogger with a valid runID
 	runID := "test-run-raw-json"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Get the RawJSONSink from the logger
@@ -227,7 +227,7 @@ func TestFail(t *testing.T) {
 
 	// Create a test result and file logger
 	runID := "real-go-test-run"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Get the RawJSONSink
@@ -404,7 +404,7 @@ func TestRawJSONSink_ComprehensiveLogging(t *testing.T) {
 
 	// Create a new FileLogger with a valid runID
 	runID := "comprehensive-test-run"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Get the RawJSONSink from the logger
@@ -663,7 +663,7 @@ func TestSkippedIntegration(t *testing.T) {
 
 	// Create a file logger to test our raw JSON sink
 	runID := "integration-test-run"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Get the RawJSONSink

--- a/op-acceptor/metrics/metrics.go
+++ b/op-acceptor/metrics/metrics.go
@@ -166,6 +166,7 @@ var (
 		Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600}, // 100ms to 10min
 	}, []string{
 		"network_name",
+		"test_name",
 		"gate",
 		"suite",
 	})
@@ -178,6 +179,7 @@ var (
 	}, []string{
 		"network_name",
 		"run_id",
+		"test_name",
 		"gate",
 		"suite",
 	})
@@ -365,13 +367,13 @@ func isValidResult(result types.TestStatus) bool {
 }
 
 // RecordTestDurationHistogram records test duration in a histogram for distribution analysis
-func RecordTestDurationHistogram(network string, gate string, suite string, duration time.Duration) {
-	testDurationHistogram.WithLabelValues(network, gate, suite).Observe(duration.Seconds())
+func RecordTestDurationHistogram(network string, testName string, gate string, suite string, duration time.Duration) {
+	testDurationHistogram.WithLabelValues(network, testName, gate, suite).Observe(duration.Seconds())
 }
 
 // RecordTestTimeout records when a test times out
-func RecordTestTimeout(network string, runID string, gate string, suite string) {
-	testTimeouts.WithLabelValues(network, runID, gate, suite).Inc()
+func RecordTestTimeout(network string, runID string, testName string, gate string, suite string) {
+	testTimeouts.WithLabelValues(network, runID, testName, gate, suite).Inc()
 }
 
 // RecordGateMetrics records aggregated metrics for a gate

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -169,7 +169,6 @@ func New(ctx context.Context, config *Config, version string, shutdownCallback f
 		GoBinary:              config.GoBinary,
 		AllowSkips:            config.AllowSkips,
 		OutputRealtimeLogs:    config.OutputRealtimeLogs,
-		StripFileLinePrefixes: config.StripFileLinePrefixes,
 		TestLogLevel:          config.TestLogLevel,
 		NetworkName:           networkName,
 		DevnetEnv:             devnetEnv,
@@ -177,6 +176,7 @@ func New(ctx context.Context, config *Config, version string, shutdownCallback f
 		Concurrency:           config.Concurrency,
 		ShowProgress:          config.ShowProgress,
 		ProgressInterval:      config.ProgressInterval,
+		StripFileLinePrefixes: config.StripFileLinePrefixes,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test runner: %w", err)

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -162,20 +162,21 @@ func New(ctx context.Context, config *Config, version string, shutdownCallback f
 	workDir := strings.TrimSuffix(config.TestDir, "/...")
 
 	testRunner, err := runner.NewTestRunner(runner.Config{
-		Registry:           reg,
-		WorkDir:            workDir,
-		Log:                config.Log,
-		TargetGate:         targetGate,
-		GoBinary:           config.GoBinary,
-		AllowSkips:         config.AllowSkips,
-		OutputRealtimeLogs: config.OutputRealtimeLogs,
-		TestLogLevel:       config.TestLogLevel,
-		NetworkName:        networkName,
-		DevnetEnv:          devnetEnv,
-		Serial:             config.Serial,
-		Concurrency:        config.Concurrency,
-		ShowProgress:       config.ShowProgress,
-		ProgressInterval:   config.ProgressInterval,
+		Registry:              reg,
+		WorkDir:               workDir,
+		Log:                   config.Log,
+		TargetGate:            targetGate,
+		GoBinary:              config.GoBinary,
+		AllowSkips:            config.AllowSkips,
+		OutputRealtimeLogs:    config.OutputRealtimeLogs,
+		StripFileLinePrefixes: config.StripFileLinePrefixes,
+		TestLogLevel:          config.TestLogLevel,
+		NetworkName:           networkName,
+		DevnetEnv:             devnetEnv,
+		Serial:                config.Serial,
+		Concurrency:           config.Concurrency,
+		ShowProgress:          config.ShowProgress,
+		ProgressInterval:      config.ProgressInterval,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test runner: %w", err)
@@ -577,10 +578,25 @@ func (n *nat) runTests(ctx context.Context) error {
 		n.result.Duration,
 	)
 
-	// Record metrics for individual tests
+	// Record metrics for individual tests and aggregated gate/suite metrics
 	for _, gate := range n.result.Gates {
+		// Calculate gate-level aggregates
+		gateTotal := 0
+		gatePassed := 0
+		gateFailed := 0
+		var gateDuration time.Duration
+
 		// Record direct gate tests
 		for testName, test := range gate.Tests {
+			gateTotal++
+			gateDuration += test.Duration
+
+			if test.Status == types.TestStatusPass {
+				gatePassed++
+			} else if test.Status == types.TestStatusFail {
+				gateFailed++
+			}
+
 			metrics.RecordIndividualTest(
 				n.networkName,
 				n.result.RunID,
@@ -590,6 +606,14 @@ func (n *nat) runTests(ctx context.Context) error {
 				test.Status,
 				test.Duration,
 			)
+
+			// Record duration histogram
+			metrics.RecordTestDurationHistogram(n.networkName, gate.ID, "", test.Duration)
+
+			// Check for timeout in error message
+			if test.Error != nil && strings.Contains(test.Error.Error(), "timeout") {
+				metrics.RecordTestTimeout(n.networkName, n.result.RunID, gate.ID, "")
+			}
 
 			// Record subtests if present
 			for subTestName, subTest := range test.SubTests {
@@ -602,12 +626,37 @@ func (n *nat) runTests(ctx context.Context) error {
 					subTest.Status,
 					subTest.Duration,
 				)
+
+				// Record subtest duration histogram
+				metrics.RecordTestDurationHistogram(n.networkName, gate.ID, "", subTest.Duration)
+
+				// Check for timeout in subtest
+				if subTest.Error != nil && strings.Contains(subTest.Error.Error(), "timeout") {
+					metrics.RecordTestTimeout(n.networkName, n.result.RunID, gate.ID, "")
+				}
 			}
 		}
 
 		// Record suite tests
 		for suiteName, suite := range gate.Suites {
+			// Calculate suite-level aggregates
+			suiteTotal := 0
+			suitePassed := 0
+			suiteFailed := 0
+
 			for testName, test := range suite.Tests {
+				gateTotal++
+				suiteTotal++
+				gateDuration += test.Duration
+
+				if test.Status == types.TestStatusPass {
+					gatePassed++
+					suitePassed++
+				} else if test.Status == types.TestStatusFail {
+					gateFailed++
+					suiteFailed++
+				}
+
 				metrics.RecordIndividualTest(
 					n.networkName,
 					n.result.RunID,
@@ -617,6 +666,14 @@ func (n *nat) runTests(ctx context.Context) error {
 					test.Status,
 					test.Duration,
 				)
+
+				// Record duration histogram
+				metrics.RecordTestDurationHistogram(n.networkName, gate.ID, suiteName, test.Duration)
+
+				// Check for timeout
+				if test.Error != nil && strings.Contains(test.Error.Error(), "timeout") {
+					metrics.RecordTestTimeout(n.networkName, n.result.RunID, gate.ID, suiteName)
+				}
 
 				// Record subtests if present
 				for subTestName, subTest := range test.SubTests {
@@ -629,8 +686,26 @@ func (n *nat) runTests(ctx context.Context) error {
 						subTest.Status,
 						subTest.Duration,
 					)
+
+					// Record subtest duration histogram
+					metrics.RecordTestDurationHistogram(n.networkName, gate.ID, suiteName, subTest.Duration)
+
+					// Check for timeout in subtest
+					if subTest.Error != nil && strings.Contains(subTest.Error.Error(), "timeout") {
+						metrics.RecordTestTimeout(n.networkName, n.result.RunID, gate.ID, suiteName)
+					}
 				}
 			}
+
+			// Record suite-level metrics
+			if suiteTotal > 0 {
+				metrics.RecordSuiteMetrics(n.networkName, gate.ID, suiteName, suiteTotal, suitePassed, suiteFailed)
+			}
+		}
+
+		// Record gate-level metrics
+		if gateTotal > 0 {
+			metrics.RecordGateMetrics(n.networkName, n.result.RunID, gate.ID, gateTotal, gatePassed, gateFailed, gateDuration)
 		}
 	}
 

--- a/op-acceptor/nat_test.go
+++ b/op-acceptor/nat_test.go
@@ -100,7 +100,7 @@ func setupTest(t *testing.T) (*trackedMockRunner, *nat, context.Context, context
 	logger := log.New()
 
 	// Set up a mock file logger
-	mockFileLogger, err := logging.NewFileLogger(t.TempDir(), "test-run-id", "test-network", "test-gate")
+	mockFileLogger, err := logging.NewFileLogger(t.TempDir(), "test-run-id", "test-network", "test-gate", true)
 	require.NoError(t, err)
 
 	// Create service with the mock
@@ -385,7 +385,7 @@ gates:
 			"name": "%s",
 			"l1": {
 				"name": "test-l1",
-				"id": "1", 
+				"id": "1",
 				"nodes": [],
 				"addresses": {},
 				"wallets": {}

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -1420,8 +1420,8 @@ func (w *logWriter) Write(p []byte) (n int, err error) {
 			// It's a valid test event JSON
 			if event.Action == ActionOutput {
 				// Only log the actual test output content
-				// Don't collapse whitespace for test output to preserve formatting
-				cleaned := logging.CleanLogOutput(event.Output, w.stripCodeLinePrefixes, false)
+				// Collapse whitespace to clean up structured logging output
+				cleaned := logging.CleanLogOutput(event.Output, w.stripCodeLinePrefixes, true)
 				if cleaned != "" {
 					w.logFn(cleaned)
 				}
@@ -1430,8 +1430,8 @@ func (w *logWriter) Write(p []byte) (n int, err error) {
 			// These are metadata used for parsing but not useful in realtime logs
 		} else {
 			// Not a valid test event JSON - it's a raw line (e.g., direct stderr)
-			// Clean up and log it - don't collapse whitespace to preserve formatting
-			cleaned := logging.CleanLogOutput(string(line), w.stripCodeLinePrefixes, false)
+			// Clean up and log it - collapse whitespace to clean up structured logging output
+			cleaned := logging.CleanLogOutput(string(line), w.stripCodeLinePrefixes, true)
 			if cleaned != "" {
 				w.logFn(cleaned)
 			}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
* More metrics and strip escape characters, and whitespaces, and optionally line-numbers from source test from go test output

**Tests**
* Unit tests have been added + running locally with output below

**Additional context**
### Logs Before
<img width="1916" height="772" alt="Screenshot 2025-10-29 at 5 02 09 PM" src="https://github.com/user-attachments/assets/6c8769a0-165d-4e3b-8f16-37ae844a4cf5" />

### Logs After
<img width="1910" height="555" alt="Screenshot 2025-10-29 at 6 11 34 PM" src="https://github.com/user-attachments/assets/1378ac83-7222-4040-bccb-b257d993223d" />

### Log File output
<img width="1430" height="511" alt="Screenshot 2025-10-29 at 11 58 44 PM" src="https://github.com/user-attachments/assets/fc180553-4911-483f-95ca-6855b68c40e6" />

**Metadata**

- Fixes #[Link to Issue]
