### PR TITLE
clean(op-acceptor): subtest timeouts refactor

### DIFF
--- a/op-acceptor/types/test.go
+++ b/op-acceptor/types/test.go
@@ -20,7 +20,7 @@ const (
 type TestResult struct {
 	Metadata ValidatorMetadata
 	Status   TestStatus
-	Error    error                  // Changed from string to error
+	Error    error                  // Error message for the test
 	Duration time.Duration          // Track test execution time
 	SubTests map[string]*TestResult // Store individual test results when running a package
 	Stdout   string                 // Capture stdout for failing tests


### PR DESCRIPTION
Refactored this code a bit as there was a divergent timeout handling.

* Changed timeout handling so completed sub-tests retain their real status, and only sub-tests that started but didn’t finish are marked as timed out; when start time is unknown, we now set the sub-test duration to the full timeout.
* The runner’s timeout path now delegates to the parser’s timeout logic and appends the actual duration to the error for clarity.
* Added tests to cover the preserved-completed-subtests behavior and verified the full test suite and linter pass.