### PR TITLE
fix(mise): fix mise install error

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,15 @@
 # Shared tools for Go projects
 [tools]
 go = "1.23.12"  # Matches CI: cimg/go:1.23
+
+# Fake deps
+asterisc = "1.3.0"
+
+[alias]
+# These are disabled, but latest mise versions error if they don't have a known
+# install source even though it won't ever actually use that source.
+asterisc = "ubi:ethereum-optimism/fake-asterisc"
+
+
+[settings]
+disable_tools = ["asterisc"]


### PR DESCRIPTION
I am trying to fix an issue whereby 'mise install' fails (complaining that 'asterisc' can't be found).
Following a [pattern](https://github.com/ethereum-optimism/optimism/blob/develop/mise.toml#L71) from the optimism monorepo as a potential solution.