### PR TITLE
fix(mise): fix mise install error

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,12 +4,16 @@ go = "1.23.12"  # Matches CI: cimg/go:1.23
 
 # Fake deps
 asterisc = "1.3.0"
+kontrol = "1.0.90"
+binary_signer = "1.0.4"
 
 [alias]
 # These are disabled, but latest mise versions error if they don't have a known
 # install source even though it won't ever actually use that source.
 asterisc = "ubi:ethereum-optimism/fake-asterisc"
+kontrol = "ubi:ethereum-optimism/fake-kontrol"
+binary_signer = "ubi:ethereum-optimism/fake-binary_signer"
 
 
 [settings]
-disable_tools = ["asterisc"]
+disable_tools = ["asterisc", "kontrol", "binary_signer"]


### PR DESCRIPTION
My last PR managed to fix this error for 'asterisc'. So this should hopefully address the remaining tools.

example error:
https://app.circleci.com/pipelines/github/ethereum-optimism/infra/1626/workflows/2ae7428a-aeeb-4ed3-95f7-536dc21b9ed0/jobs/9475

Please feel free to merge if/when this is approved.