### PR TITLE
ci: add GitHub Actions workflows to build and attest infra Docker images

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 * @ethereum-optimism/infra-reviewers
 
 /op-txproxy @ethereum-optimism/devxpod
+.github/workflows/ @ethereum-optimism/plaftorm-security

--- a/.github/workflows/cci-stats.yml
+++ b/.github/workflows/cci-stats.yml
@@ -20,4 +20,3 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-

--- a/.github/workflows/cci-stats.yml
+++ b/.github/workflows/cci-stats.yml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'cci-stats/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/cci-stats.yml'
   pull_request:
     paths:
       - 'cci-stats/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/cci-stats.yml'
 
 jobs:
   build:

--- a/.github/workflows/cci-stats.yml
+++ b/.github/workflows/cci-stats.yml
@@ -1,0 +1,26 @@
+name: cci-stats
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@8a71ef009f8cc2b5284da3ed7642e1fffb59b01e
+    with:
+      image_name: cci-stats
+      context: .
+      dockerfile: cci-stats/Dockerfile
+      platforms: linux/amd64
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      extraTags: type=raw,value=latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+

--- a/.github/workflows/cci-stats.yml
+++ b/.github/workflows/cci-stats.yml
@@ -2,11 +2,15 @@ name: cci-stats
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'cci-stats/**'
+      - '.circleci/**'
+      - '.github/**'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'cci-stats/**'
+      - '.circleci/**'
+      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/cci-stats.yml
+++ b/.github/workflows/cci-stats.yml
@@ -18,7 +18,6 @@ jobs:
       platforms: linux/amd64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
-      extraTags: type=raw,value=latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/cci-stats.yml
+++ b/.github/workflows/cci-stats.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'cci-stats/**'
       - '.github/workflows/cci-stats.yml'
-  pull_request:
-    paths:
-      - 'cci-stats/**'
-      - '.github/workflows/cci-stats.yml'
 
 jobs:
   build:

--- a/.github/workflows/cci-stats.yml
+++ b/.github/workflows/cci-stats.yml
@@ -13,7 +13,7 @@ jobs:
       image_name: cci-stats
       context: .
       dockerfile: cci-stats/Dockerfile
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
     permissions:

--- a/.github/workflows/op-acceptor.yml
+++ b/.github/workflows/op-acceptor.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'op-acceptor/**'
       - '.github/workflows/op-acceptor.yml'
-  pull_request:
-    paths:
-      - 'op-acceptor/**'
-      - '.github/workflows/op-acceptor.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-acceptor.yml
+++ b/.github/workflows/op-acceptor.yml
@@ -20,4 +20,3 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-

--- a/.github/workflows/op-acceptor.yml
+++ b/.github/workflows/op-acceptor.yml
@@ -18,7 +18,6 @@ jobs:
       platforms: linux/amd64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
-      extraTags: type=raw,value=latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/op-acceptor.yml
+++ b/.github/workflows/op-acceptor.yml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'op-acceptor/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-acceptor.yml'
   pull_request:
     paths:
       - 'op-acceptor/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-acceptor.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-acceptor.yml
+++ b/.github/workflows/op-acceptor.yml
@@ -2,11 +2,15 @@ name: op-acceptor
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'op-acceptor/**'
+      - '.circleci/**'
+      - '.github/**'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'op-acceptor/**'
+      - '.circleci/**'
+      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/op-acceptor.yml
+++ b/.github/workflows/op-acceptor.yml
@@ -1,0 +1,26 @@
+name: op-acceptor
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@8a71ef009f8cc2b5284da3ed7642e1fffb59b01e
+    with:
+      image_name: op-acceptor
+      context: .
+      dockerfile: op-acceptor/Dockerfile
+      platforms: linux/amd64
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      extraTags: type=raw,value=latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+

--- a/.github/workflows/op-acceptor.yml
+++ b/.github/workflows/op-acceptor.yml
@@ -13,7 +13,7 @@ jobs:
       image_name: op-acceptor
       context: .
       dockerfile: op-acceptor/Dockerfile
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
     permissions:

--- a/.github/workflows/op-conductor-mon.yml
+++ b/.github/workflows/op-conductor-mon.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'op-conductor-mon/**'
       - '.github/workflows/op-conductor-mon.yml'
-  pull_request:
-    paths:
-      - 'op-conductor-mon/**'
-      - '.github/workflows/op-conductor-mon.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-conductor-mon.yml
+++ b/.github/workflows/op-conductor-mon.yml
@@ -1,0 +1,26 @@
+name: op-conductor-mon
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@8a71ef009f8cc2b5284da3ed7642e1fffb59b01e
+    with:
+      image_name: op-conductor-mon
+      context: .
+      dockerfile: op-conductor-mon/Dockerfile
+      platforms: linux/amd64
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      extraTags: type=raw,value=latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+

--- a/.github/workflows/op-conductor-mon.yml
+++ b/.github/workflows/op-conductor-mon.yml
@@ -20,4 +20,3 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-

--- a/.github/workflows/op-conductor-mon.yml
+++ b/.github/workflows/op-conductor-mon.yml
@@ -2,11 +2,15 @@ name: op-conductor-mon
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'op-conductor-mon/**'
+      - '.circleci/**'
+      - '.github/**'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'op-conductor-mon/**'
+      - '.circleci/**'
+      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/op-conductor-mon.yml
+++ b/.github/workflows/op-conductor-mon.yml
@@ -18,7 +18,6 @@ jobs:
       platforms: linux/amd64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
-      extraTags: type=raw,value=latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/op-conductor-mon.yml
+++ b/.github/workflows/op-conductor-mon.yml
@@ -13,7 +13,7 @@ jobs:
       image_name: op-conductor-mon
       context: .
       dockerfile: op-conductor-mon/Dockerfile
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
     permissions:

--- a/.github/workflows/op-conductor-mon.yml
+++ b/.github/workflows/op-conductor-mon.yml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'op-conductor-mon/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-conductor-mon.yml'
   pull_request:
     paths:
       - 'op-conductor-mon/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-conductor-mon.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-conductor-ops.yml
+++ b/.github/workflows/op-conductor-ops.yml
@@ -20,4 +20,3 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-

--- a/.github/workflows/op-conductor-ops.yml
+++ b/.github/workflows/op-conductor-ops.yml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'op-conductor-ops/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-conductor-ops.yml'
   pull_request:
     paths:
       - 'op-conductor-ops/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-conductor-ops.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-conductor-ops.yml
+++ b/.github/workflows/op-conductor-ops.yml
@@ -18,7 +18,6 @@ jobs:
       platforms: linux/amd64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
-      extraTags: type=raw,value=latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/op-conductor-ops.yml
+++ b/.github/workflows/op-conductor-ops.yml
@@ -2,11 +2,15 @@ name: op-conductor-ops
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'op-conductor-ops/**'
+      - '.circleci/**'
+      - '.github/**'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'op-conductor-ops/**'
+      - '.circleci/**'
+      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/op-conductor-ops.yml
+++ b/.github/workflows/op-conductor-ops.yml
@@ -13,7 +13,7 @@ jobs:
       image_name: op-conductor-ops
       context: .
       dockerfile: op-conductor-ops/Dockerfile
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
     permissions:

--- a/.github/workflows/op-conductor-ops.yml
+++ b/.github/workflows/op-conductor-ops.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'op-conductor-ops/**'
       - '.github/workflows/op-conductor-ops.yml'
-  pull_request:
-    paths:
-      - 'op-conductor-ops/**'
-      - '.github/workflows/op-conductor-ops.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-conductor-ops.yml
+++ b/.github/workflows/op-conductor-ops.yml
@@ -1,0 +1,26 @@
+name: op-conductor-ops
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@8a71ef009f8cc2b5284da3ed7642e1fffb59b01e
+    with:
+      image_name: op-conductor-ops
+      context: .
+      dockerfile: op-conductor-ops/Dockerfile
+      platforms: linux/amd64
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      extraTags: type=raw,value=latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+

--- a/.github/workflows/op-signer.yml
+++ b/.github/workflows/op-signer.yml
@@ -1,0 +1,26 @@
+name: op-signer
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@8a71ef009f8cc2b5284da3ed7642e1fffb59b01e
+    with:
+      image_name: op-signer
+      context: .
+      dockerfile: op-signer/Dockerfile
+      platforms: linux/amd64
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      extraTags: type=raw,value=latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+

--- a/.github/workflows/op-signer.yml
+++ b/.github/workflows/op-signer.yml
@@ -20,4 +20,3 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-

--- a/.github/workflows/op-signer.yml
+++ b/.github/workflows/op-signer.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'op-signer/**'
       - '.github/workflows/op-signer.yml'
-  pull_request:
-    paths:
-      - 'op-signer/**'
-      - '.github/workflows/op-signer.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-signer.yml
+++ b/.github/workflows/op-signer.yml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'op-signer/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-signer.yml'
   pull_request:
     paths:
       - 'op-signer/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-signer.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-signer.yml
+++ b/.github/workflows/op-signer.yml
@@ -18,7 +18,6 @@ jobs:
       platforms: linux/amd64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
-      extraTags: type=raw,value=latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/op-signer.yml
+++ b/.github/workflows/op-signer.yml
@@ -2,11 +2,15 @@ name: op-signer
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'op-signer/**'
+      - '.circleci/**'
+      - '.github/**'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'op-signer/**'
+      - '.circleci/**'
+      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/op-signer.yml
+++ b/.github/workflows/op-signer.yml
@@ -13,7 +13,7 @@ jobs:
       image_name: op-signer
       context: .
       dockerfile: op-signer/Dockerfile
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
     permissions:

--- a/.github/workflows/op-txproxy.yml
+++ b/.github/workflows/op-txproxy.yml
@@ -20,4 +20,3 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-

--- a/.github/workflows/op-txproxy.yml
+++ b/.github/workflows/op-txproxy.yml
@@ -1,0 +1,26 @@
+name: op-txproxy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@8a71ef009f8cc2b5284da3ed7642e1fffb59b01e
+    with:
+      image_name: op-txproxy
+      context: .
+      dockerfile: op-txproxy/Dockerfile
+      platforms: linux/amd64
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      extraTags: type=raw,value=latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+

--- a/.github/workflows/op-txproxy.yml
+++ b/.github/workflows/op-txproxy.yml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'op-txproxy/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-txproxy.yml'
   pull_request:
     paths:
       - 'op-txproxy/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-txproxy.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-txproxy.yml
+++ b/.github/workflows/op-txproxy.yml
@@ -18,7 +18,6 @@ jobs:
       platforms: linux/amd64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
-      extraTags: type=raw,value=latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/op-txproxy.yml
+++ b/.github/workflows/op-txproxy.yml
@@ -13,7 +13,7 @@ jobs:
       image_name: op-txproxy
       context: .
       dockerfile: op-txproxy/Dockerfile
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
     permissions:

--- a/.github/workflows/op-txproxy.yml
+++ b/.github/workflows/op-txproxy.yml
@@ -2,11 +2,15 @@ name: op-txproxy
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'op-txproxy/**'
+      - '.circleci/**'
+      - '.github/**'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'op-txproxy/**'
+      - '.circleci/**'
+      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/op-txproxy.yml
+++ b/.github/workflows/op-txproxy.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'op-txproxy/**'
       - '.github/workflows/op-txproxy.yml'
-  pull_request:
-    paths:
-      - 'op-txproxy/**'
-      - '.github/workflows/op-txproxy.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-ufm.yml
+++ b/.github/workflows/op-ufm.yml
@@ -20,4 +20,3 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-

--- a/.github/workflows/op-ufm.yml
+++ b/.github/workflows/op-ufm.yml
@@ -1,0 +1,26 @@
+name: op-ufm
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@8a71ef009f8cc2b5284da3ed7642e1fffb59b01e
+    with:
+      image_name: op-ufm
+      context: .
+      dockerfile: op-ufm/Dockerfile
+      platforms: linux/amd64
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      extraTags: type=raw,value=latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+

--- a/.github/workflows/op-ufm.yml
+++ b/.github/workflows/op-ufm.yml
@@ -2,11 +2,15 @@ name: op-ufm
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'op-ufm/**'
+      - '.circleci/**'
+      - '.github/**'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'op-ufm/**'
+      - '.circleci/**'
+      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/op-ufm.yml
+++ b/.github/workflows/op-ufm.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'op-ufm/**'
       - '.github/workflows/op-ufm.yml'
-  pull_request:
-    paths:
-      - 'op-ufm/**'
-      - '.github/workflows/op-ufm.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-ufm.yml
+++ b/.github/workflows/op-ufm.yml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'op-ufm/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-ufm.yml'
   pull_request:
     paths:
       - 'op-ufm/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/op-ufm.yml'
 
 jobs:
   build:

--- a/.github/workflows/op-ufm.yml
+++ b/.github/workflows/op-ufm.yml
@@ -18,7 +18,6 @@ jobs:
       platforms: linux/amd64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
-      extraTags: type=raw,value=latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/op-ufm.yml
+++ b/.github/workflows/op-ufm.yml
@@ -13,7 +13,7 @@ jobs:
       image_name: op-ufm
       context: .
       dockerfile: op-ufm/Dockerfile
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
     permissions:

--- a/.github/workflows/peer-mgmt-service.yml
+++ b/.github/workflows/peer-mgmt-service.yml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'peer-mgmt-service/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/peer-mgmt-service.yml'
   pull_request:
     paths:
       - 'peer-mgmt-service/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/peer-mgmt-service.yml'
 
 jobs:
   build:

--- a/.github/workflows/peer-mgmt-service.yml
+++ b/.github/workflows/peer-mgmt-service.yml
@@ -20,4 +20,3 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-

--- a/.github/workflows/peer-mgmt-service.yml
+++ b/.github/workflows/peer-mgmt-service.yml
@@ -1,0 +1,26 @@
+name: peer-mgmt-service
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@8a71ef009f8cc2b5284da3ed7642e1fffb59b01e
+    with:
+      image_name: peer-mgmt-service
+      context: .
+      dockerfile: peer-mgmt-service/Dockerfile
+      platforms: linux/amd64
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      extraTags: type=raw,value=latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+

--- a/.github/workflows/peer-mgmt-service.yml
+++ b/.github/workflows/peer-mgmt-service.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'peer-mgmt-service/**'
       - '.github/workflows/peer-mgmt-service.yml'
-  pull_request:
-    paths:
-      - 'peer-mgmt-service/**'
-      - '.github/workflows/peer-mgmt-service.yml'
 
 jobs:
   build:

--- a/.github/workflows/peer-mgmt-service.yml
+++ b/.github/workflows/peer-mgmt-service.yml
@@ -18,7 +18,6 @@ jobs:
       platforms: linux/amd64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
-      extraTags: type=raw,value=latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/peer-mgmt-service.yml
+++ b/.github/workflows/peer-mgmt-service.yml
@@ -2,11 +2,15 @@ name: peer-mgmt-service
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'peer-mgmt-service/**'
+      - '.circleci/**'
+      - '.github/**'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'peer-mgmt-service/**'
+      - '.circleci/**'
+      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/peer-mgmt-service.yml
+++ b/.github/workflows/peer-mgmt-service.yml
@@ -13,7 +13,7 @@ jobs:
       image_name: peer-mgmt-service
       context: .
       dockerfile: peer-mgmt-service/Dockerfile
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
     permissions:

--- a/.github/workflows/proxyd.yml
+++ b/.github/workflows/proxyd.yml
@@ -13,7 +13,7 @@ jobs:
       image_name: proxyd
       context: .
       dockerfile: proxyd/Dockerfile
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
     permissions:

--- a/.github/workflows/proxyd.yml
+++ b/.github/workflows/proxyd.yml
@@ -20,4 +20,3 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-

--- a/.github/workflows/proxyd.yml
+++ b/.github/workflows/proxyd.yml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'proxyd/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/proxyd.yml'
   pull_request:
     paths:
       - 'proxyd/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/proxyd.yml'
 
 jobs:
   build:

--- a/.github/workflows/proxyd.yml
+++ b/.github/workflows/proxyd.yml
@@ -18,7 +18,6 @@ jobs:
       platforms: linux/amd64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
-      extraTags: type=raw,value=latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/proxyd.yml
+++ b/.github/workflows/proxyd.yml
@@ -1,0 +1,26 @@
+name: proxyd
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@8a71ef009f8cc2b5284da3ed7642e1fffb59b01e
+    with:
+      image_name: proxyd
+      context: .
+      dockerfile: proxyd/Dockerfile
+      platforms: linux/amd64
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      extraTags: type=raw,value=latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+

--- a/.github/workflows/proxyd.yml
+++ b/.github/workflows/proxyd.yml
@@ -2,11 +2,15 @@ name: proxyd
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'proxyd/**'
+      - '.circleci/**'
+      - '.github/**'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'proxyd/**'
+      - '.circleci/**'
+      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/proxyd.yml
+++ b/.github/workflows/proxyd.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'proxyd/**'
       - '.github/workflows/proxyd.yml'
-  pull_request:
-    paths:
-      - 'proxyd/**'
-      - '.github/workflows/proxyd.yml'
 
 jobs:
   build:

--- a/.github/workflows/replica-healthcheck.yml
+++ b/.github/workflows/replica-healthcheck.yml
@@ -20,4 +20,3 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-

--- a/.github/workflows/replica-healthcheck.yml
+++ b/.github/workflows/replica-healthcheck.yml
@@ -13,7 +13,7 @@ jobs:
       image_name: replica-healthcheck
       context: replica-healthcheck
       dockerfile: Dockerfile
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
     permissions:

--- a/.github/workflows/replica-healthcheck.yml
+++ b/.github/workflows/replica-healthcheck.yml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'replica-healthcheck/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/replica-healthcheck.yml'
   pull_request:
     paths:
       - 'replica-healthcheck/**'
-      - '.circleci/**'
-      - '.github/**'
+      - '.github/workflows/replica-healthcheck.yml'
 
 jobs:
   build:

--- a/.github/workflows/replica-healthcheck.yml
+++ b/.github/workflows/replica-healthcheck.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'replica-healthcheck/**'
       - '.github/workflows/replica-healthcheck.yml'
-  pull_request:
-    paths:
-      - 'replica-healthcheck/**'
-      - '.github/workflows/replica-healthcheck.yml'
 
 jobs:
   build:

--- a/.github/workflows/replica-healthcheck.yml
+++ b/.github/workflows/replica-healthcheck.yml
@@ -18,7 +18,6 @@ jobs:
       platforms: linux/amd64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
-      extraTags: type=raw,value=latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/replica-healthcheck.yml
+++ b/.github/workflows/replica-healthcheck.yml
@@ -2,11 +2,15 @@ name: replica-healthcheck
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'replica-healthcheck/**'
+      - '.circleci/**'
+      - '.github/**'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'replica-healthcheck/**'
+      - '.circleci/**'
+      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/replica-healthcheck.yml
+++ b/.github/workflows/replica-healthcheck.yml
@@ -1,0 +1,26 @@
+name: replica-healthcheck
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@8a71ef009f8cc2b5284da3ed7642e1fffb59b01e
+    with:
+      image_name: replica-healthcheck
+      context: replica-healthcheck
+      dockerfile: replica-healthcheck/Dockerfile
+      platforms: linux/amd64
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      extraTags: type=raw,value=latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+

--- a/.github/workflows/replica-healthcheck.yml
+++ b/.github/workflows/replica-healthcheck.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       image_name: replica-healthcheck
       context: replica-healthcheck
-      dockerfile: replica-healthcheck/Dockerfile
+      dockerfile: Dockerfile
       platforms: linux/amd64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss


### PR DESCRIPTION
This pull request adds GitHub Actions workflows to build attest and sign Docker images for all infra components.

### Changes

* Added ten workflow files for all infra components:
  * `.github/workflows/op-conductor-mon.yml`
  * `.github/workflows/op-conductor-ops.yml`
  * `.github/workflows/op-signer.yml`
  * `.github/workflows/op-txproxy.yml`
  * `.github/workflows/peer-mgmt-service.yml`
  * `.github/workflows/op-ufm.yml`
  * `.github/workflows/proxyd.yml`
  * `.github/workflows/cci-stats.yml`
  * `.github/workflows/op-acceptor.yml`
  * `.github/workflows/replica-healthcheck.yml`
* Each workflow uses the reusable workflow from `ethereum-optimism/factory`
* Adds GitHub Actions Docker image builds alongside existing CircleCI builds

### Security Benefits

* SLSA Build Level 3 in-toto provenance attestation attached to images
* Attestations signed with Sigstore (provides same benefit as image signatures)
* Users can verify that images were built from this repository, from a specific branch/tag, and that they were not tampered
* Attestations will appear in the repository [attestations page](https://github.com/ethereum-optimism/infra/attestations)

<img width="1392" height="1521" alt="Screenshot 2025-11-13 at 15 18 35" src="https://github.com/user-attachments/assets/9ff45316-49a4-45ac-b023-246fab4a3f5c" />
