### PR TITLE
feat(op-acceptor): add multigate and dry-run

### DIFF
--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -133,6 +133,12 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "PROGRESS_INTERVAL"),
 		Usage:   "Interval between progress updates when --show-progress is enabled. Defaults to 30s.",
 	}
+	DryRun = &cli.BoolFlag{
+		Name:    "dry-run",
+		Value:   false,
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "DRY_RUN"),
+		Usage:   "Show what tests would be run without actually executing them. Defaults to false.",
+	}
 	Orchestrator = &cli.StringFlag{
 		Name:    "orchestrator",
 		Value:   OrchestratorSysext.String(),
@@ -205,6 +211,7 @@ var optionalFlags = []cli.Flag{
 	FlakeShake,
 	FlakeShakeIterations,
 	ExcludeGates,
+	DryRun,
 }
 var Flags []cli.Flag
 

--- a/op-acceptor/logging/filelogger.go
+++ b/op-acceptor/logging/filelogger.go
@@ -119,7 +119,7 @@ func (af *AsyncFile) Close() error {
 }
 
 // NewFileLogger creates a new FileLogger with given configuration
-func NewFileLogger(baseDir string, runID string, networkName, gateRun string) (*FileLogger, error) {
+func NewFileLogger(baseDir string, runID string, networkName string, gateRuns []string) (*FileLogger, error) {
 	if runID == "" {
 		return nil, fmt.Errorf("runID cannot be empty")
 	}
@@ -127,6 +127,8 @@ func NewFileLogger(baseDir string, runID string, networkName, gateRun string) (*
 	if baseDir == "" {
 		return nil, fmt.Errorf("baseDir cannot be empty")
 	}
+
+	gateRun := strings.Join(gateRuns, "_")
 
 	// Use the standardized prefix for the run directory
 	logDir := filepath.Join(baseDir, RunDirectoryPrefix+runID)

--- a/op-acceptor/logging/filelogger_output_test.go
+++ b/op-acceptor/logging/filelogger_output_test.go
@@ -15,7 +15,7 @@ import (
 func TestPlaintextFileCreation(t *testing.T) {
 	// Setup
 	tempDir := t.TempDir()
-	logger, err := NewFileLogger(tempDir, "test-run", "test-network", "test-gate")
+	logger, err := NewFileLogger(tempDir, "test-run", "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	sink := &PerTestFileSink{logger: logger}
@@ -116,7 +116,7 @@ func TestPlaintextFileCreation(t *testing.T) {
 func TestSubtestOutputHandling(t *testing.T) {
 	// Setup
 	tempDir := t.TempDir()
-	logger, err := NewFileLogger(tempDir, "test-run", "test-network", "test-gate")
+	logger, err := NewFileLogger(tempDir, "test-run", "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	sink := &PerTestFileSink{logger: logger}

--- a/op-acceptor/logging/filelogger_test.go
+++ b/op-acceptor/logging/filelogger_test.go
@@ -21,7 +21,7 @@ func TestFileLogger(t *testing.T) {
 
 	// Create a new FileLogger with a valid runID
 	runID := "test-run-123"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Get the directory with the testrun- prefix
@@ -153,12 +153,12 @@ func TestLoggerWithEmptyRunID(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Test that an error is returned when an empty runID is provided to NewFileLogger
-	_, err = NewFileLogger(tmpDir, "", "test-network", "test-gate")
+	_, err = NewFileLogger(tmpDir, "", "test-network", []string{"test-gate"})
 	assert.Error(t, err, "Expected error when creating logger with empty runID")
 	assert.Contains(t, err.Error(), "runID cannot be empty")
 
 	// Create a valid logger to test the LogTestResult with empty runID
-	logger, err := NewFileLogger(tmpDir, "valid-run-id", "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, "valid-run-id", "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Create a test result
@@ -193,7 +193,7 @@ func TestLoggingWithRunID(t *testing.T) {
 
 	// Create a new FileLogger with a valid runID
 	defaultRunID := "default-run-id"
-	logger, err := NewFileLogger(tmpDir, defaultRunID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, defaultRunID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// We'll use a different runID for this test
@@ -333,7 +333,7 @@ func TestCustomResultSink(t *testing.T) {
 
 	// Create a new FileLogger with a valid runID
 	runID := "custom-sink-test"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Create a custom sink for testing
@@ -390,7 +390,7 @@ func TestPerTestFileSink_WritesTestOutput(t *testing.T) {
 	runID := "test-pertest-sink"
 
 	// Create a file logger
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Access the PerTestFileSink directly
@@ -533,7 +533,7 @@ func TestHTMLSummarySink_GeneratesHTMLReport(t *testing.T) {
 	runID := "test-html-summary"
 
 	// Create a file logger
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Create a mix of test results
@@ -645,7 +645,7 @@ func TestHTMLSummarySink_WithSubtestsAndNetworkInfo(t *testing.T) {
 	gateRun := "isthmus"
 
 	// Create a file logger with network and gate information
-	logger, err := NewFileLogger(tmpDir, runID, networkName, gateRun)
+	logger, err := NewFileLogger(tmpDir, runID, networkName, []string{gateRun})
 	require.NoError(t, err)
 
 	// Create subtests
@@ -758,7 +758,7 @@ func TestPerTestFileSink_CreatesSubtestFiles(t *testing.T) {
 	runID := "test-subtests"
 
 	// Create a file logger
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Access the PerTestFileSink directly
@@ -859,7 +859,7 @@ func TestDuplicationFix(t *testing.T) {
 	runID := "duplication-test"
 
 	// Create a file logger
-	logger, err := NewFileLogger(logDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(logDir, runID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Create a test result that would have caused duplication before
@@ -953,7 +953,7 @@ func TestHTMLSink_TestsWithSubtestsAlwaysDisplayed(t *testing.T) {
 	gateRun := "test-gate"
 
 	// Create a file logger
-	logger, err := NewFileLogger(tmpDir, runID, networkName, gateRun)
+	logger, err := NewFileLogger(tmpDir, runID, networkName, []string{gateRun})
 	require.NoError(t, err)
 
 	// Simulate the fjord scenario: a test with subtests but minimal metadata

--- a/op-acceptor/logging/integration_test.go
+++ b/op-acceptor/logging/integration_test.go
@@ -16,7 +16,7 @@ func TestIntegrationSubtestOutputCapture(t *testing.T) {
 	// Setup
 	tempDir := t.TempDir()
 	runID := "test-run-" + time.Now().Format("20060102-150405")
-	logger, err := NewFileLogger(tempDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tempDir, runID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Create a main test result with subtests that have plain text output
@@ -120,7 +120,7 @@ func TestRealTestOutputCapture(t *testing.T) {
 	// Setup
 	tempDir := t.TempDir()
 	runID := "real-test-run"
-	logger, err := NewFileLogger(tempDir, runID, "optimism", "connectivity")
+	logger, err := NewFileLogger(tempDir, runID, "optimism", []string{"connectivity"})
 	require.NoError(t, err)
 
 	// Simulate a test result for TestRPCConnectivity with actual logger output

--- a/op-acceptor/logging/raw_json_sink_test.go
+++ b/op-acceptor/logging/raw_json_sink_test.go
@@ -25,7 +25,7 @@ func TestRawJSONSink(t *testing.T) {
 
 	// Create a new FileLogger with a valid runID
 	runID := "test-run-raw-json"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Get the RawJSONSink from the logger
@@ -227,7 +227,7 @@ func TestFail(t *testing.T) {
 
 	// Create a test result and file logger
 	runID := "real-go-test-run"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Get the RawJSONSink
@@ -404,7 +404,7 @@ func TestRawJSONSink_ComprehensiveLogging(t *testing.T) {
 
 	// Create a new FileLogger with a valid runID
 	runID := "comprehensive-test-run"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Get the RawJSONSink from the logger
@@ -663,7 +663,7 @@ func TestSkippedIntegration(t *testing.T) {
 
 	// Create a file logger to test our raw JSON sink
 	runID := "integration-test-run"
-	logger, err := NewFileLogger(tmpDir, runID, "test-network", "test-gate")
+	logger, err := NewFileLogger(tmpDir, runID, "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Get the RawJSONSink

--- a/op-acceptor/logging/templates/results.tmpl.html
+++ b/op-acceptor/logging/templates/results.tmpl.html
@@ -438,7 +438,7 @@
         <ul>
             <li><strong>Orchestrator:</strong> {{.Config.Orchestration.Orchestrator}}</li>
             {{if .Config.Orchestration.DevnetEnvURL}}<li><strong>Devnet Env URL:</strong> {{.Config.Orchestration.DevnetEnvURL}}</li>{{end}}
-            <li><strong>Target Gate:</strong> {{.Config.Execution.TargetGate}}</li>
+            <li><strong>Target Gate:</strong> {{join ", " .Config.Execution.TargetGate}}</li>
             <li><strong>Gateless Mode:</strong> {{.Config.Execution.Gateless}}</li>
             <li><strong>Run Once:</strong> {{.Config.Execution.RunOnce}}</li>
             {{if not .Config.Execution.RunOnce}}<li><strong>Run Interval:</strong> {{formatDuration .Config.Execution.RunInterval}}</li>{{end}}

--- a/op-acceptor/nat_test.go
+++ b/op-acceptor/nat_test.go
@@ -100,7 +100,7 @@ func setupTest(t *testing.T) (*trackedMockRunner, *nat, context.Context, context
 	logger := log.New()
 
 	// Set up a mock file logger
-	mockFileLogger, err := logging.NewFileLogger(t.TempDir(), "test-run-id", "test-network", "test-gate")
+	mockFileLogger, err := logging.NewFileLogger(t.TempDir(), "test-run-id", "test-network", []string{"test-gate"})
 	require.NoError(t, err)
 
 	// Create service with the mock
@@ -404,7 +404,8 @@ gates:
 			Log:             logger,
 			ValidatorConfig: validatorConfigFile,
 			TestDir:         t.TempDir(),
-			TargetGate:      "test-gate",
+			TargetGate:      []string{"test-gate"},
+			GatelessMode:    false,
 			Orchestrator:    orchestrator,
 			DevnetEnvURL:    devnetURL,
 		}

--- a/op-acceptor/reporting/html_sink_test.go
+++ b/op-acceptor/reporting/html_sink_test.go
@@ -26,7 +26,7 @@ func TestReportingHTMLSink(t *testing.T) {
 {{if .Config}}
 <div id="config">
   <div>Orchestrator: {{.Config.Orchestration.Orchestrator}}</div>
-  <div>TargetGate: {{.Config.Execution.TargetGate}}</div>
+  <div>TargetGate: {{join ", " .Config.Execution.TargetGate}}</div>
   <div>Concurrency: {{.Config.Runner.Concurrency}}</div>
   <div>TestLogLevel: {{.Config.Logging.TestLogLevel}}</div>
   <div>TestDir: {{.Config.Paths.TestDir}}</div>
@@ -83,7 +83,7 @@ func TestReportingHTMLSink(t *testing.T) {
 	// Provide a config snapshot and consume results
 	sink.SetConfigSnapshot(runID, &types.EffectiveConfigSnapshot{
 		Orchestration: types.OrchestrationConfigSnapshot{Orchestrator: "sysext", DevnetEnvURL: "file:///devnet.json"},
-		Execution:     types.ExecutionConfigSnapshot{TargetGate: "test-gate"},
+		Execution:     types.ExecutionConfigSnapshot{TargetGate: []string{"test-gate"}},
 		Runner:        types.RunnerConfigSnapshot{Concurrency: 2, ShowProgress: true, ProgressInterval: time.Second},
 		Logging:       types.LoggingConfigSnapshot{TestLogLevel: "info"},
 		Paths:         types.PathsConfigSnapshot{TestDir: "/tmp/tests"},

--- a/op-acceptor/reporting/text_sink.go
+++ b/op-acceptor/reporting/text_sink.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/infra/op-acceptor/types"
@@ -110,7 +111,8 @@ func NewTableReporter(title string, showIndividualTests bool) *TableReporter {
 }
 
 // PrintTableFromTestResultsWithTiming generates and prints a table report to stdout with enhanced timing
-func (tr *TableReporter) PrintTableFromTestResultsWithTiming(testResults []*types.TestResult, runID, networkName, gateName string, wallClockTime time.Duration) error {
+func (tr *TableReporter) PrintTableFromTestResultsWithTiming(testResults []*types.TestResult, runID, networkName string, gateNames []string, wallClockTime time.Duration) error {
+	gateName := strings.Join(gateNames, ",")
 	content, err := tr.GenerateTableFromTestResultsWithTiming(testResults, runID, networkName, gateName, wallClockTime)
 	if err != nil {
 		return err

--- a/op-acceptor/runner/parallel.go
+++ b/op-acceptor/runner/parallel.go
@@ -256,6 +256,9 @@ func (r *runner) collectTestWork() []TestWork {
 	// Group validators by gate
 	gateValidators := r.groupValidatorsByGate()
 
+	// Process all gates (including inherited gates like "base")
+	// This allows inherited tests to appear under both the inheriting gate
+	// and the original gate in the results
 	for gateName, validators := range gateValidators {
 		// Split validators into suites and direct tests
 		suiteValidators, directTests := r.categorizeValidators(validators)

--- a/op-acceptor/runner/progress.go
+++ b/op-acceptor/runner/progress.go
@@ -168,9 +168,13 @@ func (c *consoleProgressIndicator) reportProgress() {
 	}
 
 	// Create structured log with JSON fields
+	suiteDisplay := c.currentSuite
+	if suiteDisplay == "" {
+		suiteDisplay = "-" // Show "-" when there's no suite instead of empty string
+	}
 	logFields := []interface{}{
 		"gate", c.currentGate,
-		"suite", c.currentSuite,
+		"suite", suiteDisplay,
 		"completed", c.completedTests,
 		"total", c.totalTests,
 		"percent", fmt.Sprintf("%.1f%%", percentComplete),

--- a/op-acceptor/templates/functions.go
+++ b/op-acceptor/templates/functions.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"fmt"
 	"html/template"
+	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/infra/op-acceptor/types"
@@ -40,6 +41,9 @@ func GetTemplateFunc() template.FuncMap {
 				return types.TestStatusSkip
 			}
 			return types.TestStatusError
+		},
+		"join": func(sep string, elems []string) string {
+			return strings.Join(elems, sep)
 		},
 	}
 }

--- a/op-acceptor/types/config_snapshot.go
+++ b/op-acceptor/types/config_snapshot.go
@@ -39,7 +39,7 @@ type ExecutionConfigSnapshot struct {
 	RunInterval time.Duration `json:"runInterval"`
 	RunOnce     bool          `json:"runOnce"`
 	GoBinary    string        `json:"goBinary"`
-	TargetGate  string        `json:"targetGate"`
+	TargetGate  []string      `json:"targetGate"`
 	Gateless    bool          `json:"gatelessMode"`
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds the following convenience functionalities into op-acceptor:

- Multi-gate input (pass multiple gates such as `--gate cgt,flashblocks,jovian`). Deduplicates tests ensuring they're only ran once.
- Dry run mode to see which tests are about to be run.
