### PR TITLE
fix(replica-healthcheck): use repo root as docker build context

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -671,7 +671,7 @@ workflows:
           docker_file: replica-healthcheck/Dockerfile
           docker_name: replica-healthcheck
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: replica-healthcheck
+          docker_context: .
   release:
     jobs:
       - log-config-results:

--- a/.github/workflows/replica-healthcheck.yml
+++ b/.github/workflows/replica-healthcheck.yml
@@ -11,8 +11,8 @@ jobs:
     uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@8a71ef009f8cc2b5284da3ed7642e1fffb59b01e
     with:
       image_name: replica-healthcheck
-      context: replica-healthcheck
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: replica-healthcheck/Dockerfile
       platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss

--- a/replica-healthcheck/Dockerfile
+++ b/replica-healthcheck/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:23-alpine3.20
 
 WORKDIR /opt/optimism/replica-healthcheck
-COPY . .
+COPY ./replica-healthcheck .
 
 RUN yarn install --frozen-lockfile && yarn cache clean
 RUN yarn build


### PR DESCRIPTION
Align replica-healthcheck with all other images by using repo root as the docker build context instead of the subdirectory.

This change updates both the Dockerfile COPY path and the CircleCI config to use consistent context across all images.