### PR TITLE
fix(ci): use repo root context in tags workflow

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -19,8 +19,8 @@ jobs:
     uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@ae4dada9bf0951124892dbc6b63cebef44d35f91
     with:
       image_name: ${{ needs.prep.outputs.image_name }}
-      context: ${{ needs.prep.outputs.image_name }}
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: ${{ needs.prep.outputs.image_name }}/Dockerfile
       tag: ${{ needs.prep.outputs.version }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss


### PR DESCRIPTION
The tags workflow was setting context to the image subdirectory while the Dockerfile expects to run from the repo root (matching branches.yaml).

This caused builds to fail with 'not found' errors when Dockerfiles referenced paths like `COPY <image_name>/...` since the context was already inside that subdirectory.

Fixes: https://github.com/ethereum-optimism/infra/actions/runs/19926070328/job/57127949978