### PR TITLE
test: verify fork PR workflow

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -1,4 +1,5 @@
 name: branch build
+# Test fork PR flow - this comment can be removed
 
 on:
   push:


### PR DESCRIPTION
Testing the fork PR workflow to ensure builds work correctly from external forks.

This PR should trigger the 'fork' job in branches.yaml which pushes to ttl.sh instead of the GCP registry.

**This PR should be closed without merging.**