### PR TITLE
fix(op-acceptor): Stream stdout to disk and refactor raw JSON logging

### DIFF
--- a/op-acceptor/logging/filelogger.go
+++ b/op-acceptor/logging/filelogger.go
@@ -54,6 +54,17 @@ type AsyncFile struct {
 	stopped bool
 }
 
+type asyncFileWriterAdapter struct {
+	writer *AsyncFile
+}
+
+func (a asyncFileWriterAdapter) Write(p []byte) (int, error) {
+	if err := a.writer.Write(p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
 // NewAsyncFile creates a new AsyncFile for non-blocking writes
 func NewAsyncFile(filepath string) (*AsyncFile, error) {
 	file, err := os.Create(filepath)

--- a/op-acceptor/logging/raw_json_sink.go
+++ b/op-acceptor/logging/raw_json_sink.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -18,9 +19,9 @@ const rawGoEventsLog = "raw_go_events.log"
 type RawJSONSink struct {
 	logger *FileLogger
 
-	// Store the original raw JSON output from go test -json
+	// Store the original raw JSON output from go test -json on disk to avoid keeping it in memory.
 	mu            sync.Mutex
-	rawJSONEvents map[string][]byte // Map of [test-id] -> []raw JSON events
+	rawJSONEvents map[string]string // Map of [test-id] -> temp file path with raw JSON events
 }
 
 // GoTestEvent represents an event in the go test JSON output
@@ -51,18 +52,16 @@ func (s *RawJSONSink) Consume(result *types.TestResult, runID string) error {
 		return err
 	}
 
-	// Initialize if needed
-	s.mu.Lock()
-	if s.rawJSONEvents == nil {
-		s.rawJSONEvents = make(map[string][]byte)
-	}
-	// Get the raw JSON events for this test
-	rawJSON, exists := s.rawJSONEvents[result.Metadata.ID]
-	s.mu.Unlock()
+	// Retrieve the stored path for this test without removing it yet so other consumers can access it.
+	path := s.getPath(result.Metadata.ID)
+	if path != "" {
+		file, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("failed to open raw JSON file %s: %w", path, err)
+		}
+		defer file.Close()
 
-	if exists && len(rawJSON) > 0 {
-		// Write the raw JSON events directly to the file
-		if err := writer.Write(rawJSON); err != nil {
+		if _, err := io.Copy(asyncFileWriterAdapter{writer: writer}, file); err != nil {
 			return fmt.Errorf("failed to write raw JSON events: %w", err)
 		}
 	}
@@ -81,35 +80,91 @@ func (s *RawJSONSink) GetRawEventsFileForRunID(runID string) (string, error) {
 
 // StoreRawJSON stores the raw JSON output for a test
 // This must be called by the test runner to provide the original JSON data
-func (s *RawJSONSink) StoreRawJSON(testID string, rawJSON []byte) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.rawJSONEvents == nil {
-		s.rawJSONEvents = make(map[string][]byte)
+func (s *RawJSONSink) StoreRawJSON(testID string, rawJSON []byte) error {
+	if len(rawJSON) == 0 {
+		return nil
 	}
-	s.rawJSONEvents[testID] = rawJSON
+
+	tmpFile, err := s.createTempRawFile(testID)
+	if err != nil {
+		return err
+	}
+
+	if _, err := tmpFile.Write(rawJSON); err != nil {
+		tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		return fmt.Errorf("failed to write raw JSON: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpFile.Name())
+		return fmt.Errorf("failed to close raw JSON file: %w", err)
+	}
+
+	s.storePath(testID, tmpFile.Name())
+	return nil
+}
+
+// StoreRawJSONFromFile copies an existing file into the sink-managed storage.
+func (s *RawJSONSink) StoreRawJSONFromFile(testID, sourcePath string) error {
+	src, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("failed to open raw JSON source %s: %w", sourcePath, err)
+	}
+	defer src.Close()
+
+	tmpFile, err := s.createTempRawFile(testID)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(tmpFile, src); err != nil {
+		tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		return fmt.Errorf("failed to copy raw JSON: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpFile.Name())
+		return fmt.Errorf("failed to close raw JSON file: %w", err)
+	}
+
+	s.storePath(testID, tmpFile.Name())
+	return nil
 }
 
 // GetRawJSON retrieves the raw JSON output for a test ID
 // Returns the raw JSON bytes and a boolean indicating if the test ID was found
 func (s *RawJSONSink) GetRawJSON(testID string) ([]byte, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.rawJSONEvents == nil {
+	path := s.getPath(testID)
+	if path == "" {
 		return nil, false
 	}
 
-	rawJSON, exists := s.rawJSONEvents[testID]
-	if !exists {
+	data, err := os.ReadFile(path)
+	if err != nil {
 		return nil, false
 	}
+	return data, true
+}
 
-	// Return a copy to avoid race conditions
-	result := make([]byte, len(rawJSON))
-	copy(result, rawJSON)
-	return result, true
+// WriteRawJSONTo streams the stored raw JSON into the provided writer.
+func (s *RawJSONSink) WriteRawJSONTo(testID string, w io.Writer) (bool, error) {
+	path := s.getPath(testID)
+	if path == "" {
+		return false, nil
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return false, fmt.Errorf("failed to open raw JSON file %s: %w", path, err)
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(w, file); err != nil {
+		return false, fmt.Errorf("failed to copy raw JSON: %w", err)
+	}
+	return true, nil
 }
 
 // Complete creates the results directory
@@ -125,5 +180,68 @@ func (s *RawJSONSink) Complete(runID string) error {
 		return fmt.Errorf("failed to create results directory: %w", err)
 	}
 
+	s.cleanupStoredFiles()
 	return nil
+}
+
+func (s *RawJSONSink) createTempRawFile(testID string) (*os.File, error) {
+	prefix := fmt.Sprintf("raw-json-%s-", safeFilename(testID))
+	tmpFile, err := os.CreateTemp("", prefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp raw JSON file: %w", err)
+	}
+	return tmpFile, nil
+}
+
+func (s *RawJSONSink) storePath(testID, path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.rawJSONEvents == nil {
+		s.rawJSONEvents = make(map[string]string)
+	}
+	s.rawJSONEvents[testID] = path
+}
+
+func (s *RawJSONSink) getPath(testID string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.rawJSONEvents == nil {
+		return ""
+	}
+	return s.rawJSONEvents[testID]
+}
+
+func (s *RawJSONSink) deletePath(testID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.rawJSONEvents == nil {
+		return
+	}
+
+	if path, ok := s.rawJSONEvents[testID]; ok {
+		_ = os.Remove(path)
+		delete(s.rawJSONEvents, testID)
+	}
+}
+
+// DeleteRawJSON removes the stored raw JSON for a test once all consumers are done with it.
+func (s *RawJSONSink) DeleteRawJSON(testID string) {
+	s.deletePath(testID)
+}
+
+func (s *RawJSONSink) cleanupStoredFiles() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.rawJSONEvents == nil {
+		return
+	}
+
+	for testID, path := range s.rawJSONEvents {
+		_ = os.Remove(path)
+		delete(s.rawJSONEvents, testID)
+	}
 }

--- a/op-acceptor/logging/raw_json_sink.go
+++ b/op-acceptor/logging/raw_json_sink.go
@@ -59,7 +59,9 @@ func (s *RawJSONSink) Consume(result *types.TestResult, runID string) error {
 		if err != nil {
 			return fmt.Errorf("failed to open raw JSON file %s: %w", path, err)
 		}
-		defer file.Close()
+		defer func() {
+			_ = file.Close()
+		}()
 
 		if _, err := io.Copy(asyncFileWriterAdapter{writer: writer}, file); err != nil {
 			return fmt.Errorf("failed to write raw JSON events: %w", err)
@@ -91,7 +93,7 @@ func (s *RawJSONSink) StoreRawJSON(testID string, rawJSON []byte) error {
 	}
 
 	if _, err := tmpFile.Write(rawJSON); err != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close()
 		_ = os.Remove(tmpFile.Name())
 		return fmt.Errorf("failed to write raw JSON: %w", err)
 	}
@@ -111,7 +113,9 @@ func (s *RawJSONSink) StoreRawJSONFromFile(testID, sourcePath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open raw JSON source %s: %w", sourcePath, err)
 	}
-	defer src.Close()
+	defer func() {
+		_ = src.Close()
+	}()
 
 	tmpFile, err := s.createTempRawFile(testID)
 	if err != nil {
@@ -119,7 +123,7 @@ func (s *RawJSONSink) StoreRawJSONFromFile(testID, sourcePath string) error {
 	}
 
 	if _, err := io.Copy(tmpFile, src); err != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close()
 		_ = os.Remove(tmpFile.Name())
 		return fmt.Errorf("failed to copy raw JSON: %w", err)
 	}
@@ -159,7 +163,9 @@ func (s *RawJSONSink) WriteRawJSONTo(testID string, w io.Writer) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to open raw JSON file %s: %w", path, err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	if _, err := io.Copy(w, file); err != nil {
 		return false, fmt.Errorf("failed to copy raw JSON: %w", err)

--- a/op-acceptor/logging/raw_json_sink_test.go
+++ b/op-acceptor/logging/raw_json_sink_test.go
@@ -103,8 +103,8 @@ func TestRawJSONSink(t *testing.T) {
 	}
 
 	// Store the raw JSON for each test
-	rawSink.StoreRawJSON(testResults[0].Metadata.ID, rawJSON)
-	rawSink.StoreRawJSON(testResults[1].Metadata.ID, rawJSON)
+	require.NoError(t, rawSink.StoreRawJSON(testResults[0].Metadata.ID, rawJSON))
+	require.NoError(t, rawSink.StoreRawJSON(testResults[1].Metadata.ID, rawJSON))
 
 	// Log the test results
 	for _, result := range testResults {
@@ -299,8 +299,8 @@ func TestFail(t *testing.T) {
 	}
 
 	// Store the raw JSON for each test
-	rawSink.StoreRawJSON(passResult.Metadata.ID, passJSON)
-	rawSink.StoreRawJSON(failResult.Metadata.ID, failJSON)
+	require.NoError(t, rawSink.StoreRawJSON(passResult.Metadata.ID, passJSON))
+	require.NoError(t, rawSink.StoreRawJSON(failResult.Metadata.ID, failJSON))
 
 	// Log the test results
 	err = logger.LogTestResult(passResult, runID)
@@ -491,9 +491,9 @@ func TestRawJSONSink_ComprehensiveLogging(t *testing.T) {
 	}
 
 	// Store the raw JSON for each test
-	rawSink.StoreRawJSON(testResults[0].Metadata.ID, passingTestJSON)
-	rawSink.StoreRawJSON(testResults[1].Metadata.ID, failingTestJSON)
-	rawSink.StoreRawJSON(testResults[2].Metadata.ID, packageTestJSON)
+	require.NoError(t, rawSink.StoreRawJSON(testResults[0].Metadata.ID, passingTestJSON))
+	require.NoError(t, rawSink.StoreRawJSON(testResults[1].Metadata.ID, failingTestJSON))
+	require.NoError(t, rawSink.StoreRawJSON(testResults[2].Metadata.ID, packageTestJSON))
 
 	// Log all test results
 	for _, result := range testResults {
@@ -734,7 +734,7 @@ func TestSkippedIntegration(t *testing.T) {
 
 		// Store raw JSON for this test
 		rawJSON := []byte(strings.Join(lines, "\n") + "\n")
-		rawSink.StoreRawJSON(result.Metadata.ID, rawJSON)
+		require.NoError(t, rawSink.StoreRawJSON(result.Metadata.ID, rawJSON))
 	}
 
 	// Log all test results

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -611,9 +611,10 @@ func (n *nat) runTests(ctx context.Context) error {
 			gateTotal++
 			gateDuration += test.Duration
 
-			if test.Status == types.TestStatusPass {
+			switch test.Status {
+			case types.TestStatusPass:
 				gatePassed++
-			} else if test.Status == types.TestStatusFail {
+			case types.TestStatusFail:
 				gateFailed++
 			}
 
@@ -669,10 +670,11 @@ func (n *nat) runTests(ctx context.Context) error {
 				suiteTotal++
 				gateDuration += test.Duration
 
-				if test.Status == types.TestStatusPass {
+				switch test.Status {
+				case types.TestStatusPass:
 					gatePassed++
 					suitePassed++
-				} else if test.Status == types.TestStatusFail {
+				case types.TestStatusFail:
 					gateFailed++
 					suiteFailed++
 				}

--- a/op-acceptor/runner/executor.go
+++ b/op-acceptor/runner/executor.go
@@ -162,7 +162,7 @@ func (e *testExecutor) runSingleTest(ctx context.Context, metadata types.Validat
 	} else {
 		result = e.outputParser.Parse(stdoutReader, metadata)
 	}
-	stdoutReader.Close()
+	_ = stdoutReader.Close()
 
 	if result == nil {
 		result = &types.TestResult{

--- a/op-acceptor/runner/executor.go
+++ b/op-acceptor/runner/executor.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 	"time"
 
@@ -37,16 +39,16 @@ type testExecutor struct {
 	jsonStore    JSONStore
 }
 
-// JSONStore handles storing and retrieving raw JSON output
+// JSONStore handles storing raw JSON output
 type JSONStore interface {
-	Store(testID string, rawJSON []byte)
-	Get(testID string) ([]byte, bool)
+	Store(testID string, rawJSON []byte) error
+	StoreFromFile(testID, path string) error
 }
 
 // OutputParser handles parsing test output
 type OutputParser interface {
-	Parse(output []byte, metadata types.ValidatorMetadata) *types.TestResult
-	ParseWithTimeout(output []byte, metadata types.ValidatorMetadata, timeout time.Duration) *types.TestResult
+	Parse(output io.Reader, metadata types.ValidatorMetadata) *types.TestResult
+	ParseWithTimeout(output io.Reader, metadata types.ValidatorMetadata, timeout time.Duration) *types.TestResult
 }
 
 // NewTestExecutor creates a new test executor
@@ -121,23 +123,46 @@ func (e *testExecutor) runSingleTest(ctx context.Context, metadata types.Validat
 	cmd, cleanup := e.cmdBuilder(ctx, e.goBinary, args...)
 	defer cleanup()
 
-	var stdoutBuf, stderrBuf bytes.Buffer
-	cmd.Stdout = &stdoutBuf
+	stdoutFile, err := os.CreateTemp("", "op-acceptor-exec-stdout-*.log")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdout temp file: %w", err)
+	}
+	stdoutPath := stdoutFile.Name()
+	defer func() {
+		_ = stdoutFile.Close()
+		_ = os.Remove(stdoutPath)
+	}()
+
+	stdoutTail := newTailBuffer(defaultStdoutTailBytes)
+	var stderrBuf bytes.Buffer
+
+	cmd.Stdout = io.MultiWriter(stdoutFile, stdoutTail)
 	cmd.Stderr = &stderrBuf
 
 	startTime := time.Now()
-	err := cmd.Run()
+	runErr := cmd.Run()
 	duration := time.Since(startTime)
 
-	stdout := stdoutBuf.Bytes()
-	stderr := stderrBuf.Bytes()
+	_ = stdoutFile.Sync()
+	_ = stdoutFile.Close()
+
+	timeoutOccurred := e.timeout > 0 && duration >= e.timeout
+
+	openStdout := func() (*os.File, error) {
+		return os.Open(stdoutPath)
+	}
 
 	var result *types.TestResult
-	if e.timeout > 0 && duration >= e.timeout {
-		result = e.outputParser.ParseWithTimeout(stdout, metadata, e.timeout)
-	} else {
-		result = e.outputParser.Parse(stdout, metadata)
+	stdoutReader, readerErr := openStdout()
+	if readerErr != nil {
+		return nil, fmt.Errorf("failed to read stdout: %w", readerErr)
 	}
+	if timeoutOccurred {
+		result = e.outputParser.ParseWithTimeout(stdoutReader, metadata, e.timeout)
+	} else {
+		result = e.outputParser.Parse(stdoutReader, metadata)
+	}
+	stdoutReader.Close()
 
 	if result == nil {
 		result = &types.TestResult{
@@ -147,34 +172,50 @@ func (e *testExecutor) runSingleTest(ctx context.Context, metadata types.Validat
 			Duration: duration,
 		}
 	}
+	result.Duration = duration
 
-	// Store raw JSON if available
+	stdoutSnippet := buildStdoutSnippet(stdoutTail)
+	if stdoutSnippet != "" {
+		result.Stdout = stdoutSnippet
+	}
+
+	// Store raw JSON without keeping it in memory
 	if e.jsonStore != nil {
-		e.jsonStore.Store(e.getTestKey(metadata), stdout)
+		if stdoutTail.TotalBytes() > 0 {
+			if err := e.jsonStore.StoreFromFile(e.getTestKey(metadata), stdoutPath); err != nil {
+				return nil, fmt.Errorf("failed to store raw JSON: %w", err)
+			}
+		} else if timeoutOccurred {
+			timeoutMarker := fmt.Sprintf(`{"Time":"%s","Action":"timeout","Package":"%s","Test":"%s","Output":"TEST TIMED OUT after %v - no JSON output captured\n"}`,
+				time.Now().Format(time.RFC3339), metadata.Package, metadata.FuncName, e.timeout)
+			if err := e.jsonStore.Store(e.getTestKey(metadata), []byte(timeoutMarker)); err != nil {
+				return nil, fmt.Errorf("failed to store timeout marker: %w", err)
+			}
+		}
 	}
 
 	// Handle execution errors
-	if err != nil {
+	if runErr != nil {
 		exitErr := &exec.ExitError{}
-		if errors.As(err, &exitErr) {
+		if errors.As(runErr, &exitErr) {
 			if exitErr.ExitCode() == 1 && result.Status != types.TestStatusPass {
-				// Test failed, which is expected
+				// Expected test failure
 			} else if exitErr.ExitCode() == 2 {
 				result.Status = types.TestStatusFail
-				result.Error = fmt.Errorf("test compilation failed: %s", string(stderr))
+				result.Error = fmt.Errorf("test compilation failed: %s", stderrBuf.String())
 			} else {
 				result.Status = types.TestStatusFail
-				result.Error = fmt.Errorf("test execution failed with exit code %d: %s", exitErr.ExitCode(), string(stderr))
+				result.Error = fmt.Errorf("test execution failed with exit code %d: %s", exitErr.ExitCode(), stderrBuf.String())
 			}
 		} else {
 			result.Status = types.TestStatusFail
-			result.Error = fmt.Errorf("failed to run test: %w", err)
+			result.Error = fmt.Errorf("failed to run test: %w", runErr)
 		}
 	}
 
 	// Add stderr to error if present
-	if len(stderr) > 0 && result.Error != nil {
-		result.Error = fmt.Errorf("%w\nstderr: %s", result.Error, string(stderr))
+	if stderrBuf.Len() > 0 && result.Error != nil {
+		result.Error = fmt.Errorf("%w\nstderr: %s", result.Error, stderrBuf.String())
 	}
 
 	return result, nil

--- a/op-acceptor/runner/executor_test.go
+++ b/op-acceptor/runner/executor_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"io"
 	"os/exec"
 	"testing"
 	"time"
@@ -270,18 +271,15 @@ func TestNewTestExecutor_DefaultGoBinaryBehavior(t *testing.T) {
 // Mock implementations for testing
 type mockOutputParser struct{}
 
-func (m *mockOutputParser) Parse(output []byte, metadata types.ValidatorMetadata) *types.TestResult {
+func (m *mockOutputParser) Parse(output io.Reader, metadata types.ValidatorMetadata) *types.TestResult {
 	return &types.TestResult{Metadata: metadata, Status: types.TestStatusPass}
 }
 
-func (m *mockOutputParser) ParseWithTimeout(output []byte, metadata types.ValidatorMetadata, timeout time.Duration) *types.TestResult {
+func (m *mockOutputParser) ParseWithTimeout(output io.Reader, metadata types.ValidatorMetadata, timeout time.Duration) *types.TestResult {
 	return &types.TestResult{Metadata: metadata, Status: types.TestStatusPass}
 }
 
 type mockJSONStore struct{}
 
-func (m *mockJSONStore) Store(testID string, rawJSON []byte) {}
-
-func (m *mockJSONStore) Get(testID string) ([]byte, bool) {
-	return nil, false
-}
+func (m *mockJSONStore) Store(testID string, rawJSON []byte) error { return nil }
+func (m *mockJSONStore) StoreFromFile(testID, path string) error   { return nil }

--- a/op-acceptor/runner/jsonstore.go
+++ b/op-acceptor/runner/jsonstore.go
@@ -1,25 +1,17 @@
 package runner
 
-import (
-	"sync"
-
-	"github.com/ethereum-optimism/infra/op-acceptor/logging"
-)
+import "github.com/ethereum-optimism/infra/op-acceptor/logging"
 
 var _ JSONStore = (*jsonStore)(nil)
 
 // jsonStore implements JSONStore interface using FileLogger's RawJSONSink
 type jsonStore struct {
 	rawJSONSink *logging.RawJSONSink
-	storage     map[string][]byte
-	mu          sync.RWMutex
 }
 
 // NewJSONStore creates a new JSON store
 func NewJSONStore(fileLogger *logging.FileLogger) JSONStore {
-	store := &jsonStore{
-		storage: make(map[string][]byte),
-	}
+	store := &jsonStore{}
 
 	if fileLogger != nil {
 		// Try to get the RawJSONSink from the fileLogger
@@ -34,33 +26,17 @@ func NewJSONStore(fileLogger *logging.FileLogger) JSONStore {
 }
 
 // Store stores raw JSON output for a test
-func (s *jsonStore) Store(testID string, rawJSON []byte) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// Store in local map for retrieval
-	s.storage[testID] = rawJSON
-
-	// Also store in the RawJSONSink if available
-	if s.rawJSONSink != nil {
-		s.rawJSONSink.StoreRawJSON(testID, rawJSON)
+func (s *jsonStore) Store(testID string, rawJSON []byte) error {
+	if len(rawJSON) == 0 || s.rawJSONSink == nil {
+		return nil
 	}
+	return s.rawJSONSink.StoreRawJSON(testID, rawJSON)
 }
 
-// Get retrieves raw JSON output for a test
-func (s *jsonStore) Get(testID string) ([]byte, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	// First try local storage
-	if data, exists := s.storage[testID]; exists {
-		return data, true
+// StoreFromFile copies raw JSON from an existing file path
+func (s *jsonStore) StoreFromFile(testID, path string) error {
+	if s.rawJSONSink == nil {
+		return nil
 	}
-
-	// Fallback to RawJSONSink if available
-	if s.rawJSONSink != nil {
-		return s.rawJSONSink.GetRawJSON(testID)
-	}
-
-	return nil, false
+	return s.rawJSONSink.StoreRawJSONFromFile(testID, path)
 }

--- a/op-acceptor/runner/parser_subtest_output_test.go
+++ b/op-acceptor/runner/parser_subtest_output_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/ethereum-optimism/infra/op-acceptor/types"
@@ -36,7 +37,7 @@ func TestParserCapturesSubtestOutput(t *testing.T) {
 	}
 
 	parser := NewOutputParser()
-	result := parser.Parse(jsonOutput, metadata)
+	result := parser.Parse(bytes.NewReader(jsonOutput), metadata)
 
 	require.NotNil(t, result)
 	assert.Equal(t, types.TestStatusPass, result.Status)
@@ -87,7 +88,7 @@ func TestRealWorldTestOutput(t *testing.T) {
 	}
 
 	parser := NewOutputParser()
-	result := parser.Parse(jsonOutput, metadata)
+	result := parser.Parse(bytes.NewReader(jsonOutput), metadata)
 
 	require.NotNil(t, result)
 	assert.Equal(t, types.TestStatusPass, result.Status)

--- a/op-acceptor/runner/parser_test.go
+++ b/op-acceptor/runner/parser_test.go
@@ -82,7 +82,7 @@ func TestOutputParser_Parse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := parser.Parse([]byte(tt.output), tt.metadata)
+			result := parser.Parse(strings.NewReader(tt.output), tt.metadata)
 
 			require.NotNil(t, result, "Parse should return non-nil result")
 			assert.Equal(t, tt.wantStatus, result.Status, "Status should match expected")
@@ -108,7 +108,7 @@ func TestOutputParser_ParseWithTimeout(t *testing.T) {
 		Package:  "example/pkg",
 	}
 
-	result := parser.ParseWithTimeout([]byte(output), metadata, timeout)
+	result := parser.ParseWithTimeout(strings.NewReader(output), metadata, timeout)
 
 	require.NotNil(t, result, "ParseWithTimeout should return non-nil result")
 
@@ -134,7 +134,7 @@ func TestOutputParser_ParseWithTimeout_PreservesCompletedSubtests(t *testing.T) 
 		Package:  "example/pkg",
 	}
 
-	result := parser.ParseWithTimeout([]byte(output), metadata, timeout)
+	result := parser.ParseWithTimeout(strings.NewReader(output), metadata, timeout)
 	require.NotNil(t, result)
 	assert.True(t, result.TimedOut)
 
@@ -260,7 +260,7 @@ func TestOutputParser_ParsePackageMode(t *testing.T) {
 		Package:  "example/pkg",
 	}
 
-	result := parser.Parse([]byte(output), metadata)
+	result := parser.Parse(strings.NewReader(output), metadata)
 
 	require.NotNil(t, result, "Parse should return non-nil result")
 	assert.Equal(t, types.TestStatusPass, result.Status, "Package should pass")
@@ -298,7 +298,7 @@ func TestOutputParser_ParsePackageModeWithElapsedFallback(t *testing.T) {
 		Package:  "example/pkg",
 	}
 
-	result := parser.Parse([]byte(output), metadata)
+	result := parser.Parse(strings.NewReader(output), metadata)
 
 	require.NotNil(t, result, "Parse should return non-nil result")
 	require.Len(t, result.SubTests, 2, "Should have 2 subtests")
@@ -332,7 +332,7 @@ func TestOutputParser_ParseSingleTestModeWithPackageLevelEvents(t *testing.T) {
 		Package:  "example/pkg",
 	}
 
-	result := parser.Parse([]byte(output), metadata)
+	result := parser.Parse(strings.NewReader(output), metadata)
 
 	require.NotNil(t, result, "Parse should return non-nil result")
 	assert.Equal(t, types.TestStatusPass, result.Status, "Test should pass")
@@ -368,7 +368,7 @@ func TestOutputParser_ParseSingleTestModeWithFailure(t *testing.T) {
 		Package:  "example/pkg",
 	}
 
-	result := parser.Parse([]byte(output), metadata)
+	result := parser.Parse(strings.NewReader(output), metadata)
 
 	require.NotNil(t, result, "Parse should return non-nil result")
 	assert.Equal(t, types.TestStatusFail, result.Status, "Test should fail")

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -672,7 +672,9 @@ func (r *runner) runTestList(ctx context.Context, metadata types.ValidatorMetada
 	var totalDuration time.Duration
 	testResults := make(map[string]*types.TestResult)
 	var failedTestsStdout strings.Builder
-	var aggregatedRawJSON []byte          // Store aggregated raw JSON for the test list
+	var aggregatedRawFile *os.File // Store aggregated raw JSON on disk
+	var aggregatedRawPath string
+	var aggregatedRawUsed bool
 	var timeoutCount int                  // Track how many tests timed out
 	var timedOutTests = make([]string, 0) // Track which tests timed out
 
@@ -707,10 +709,23 @@ func (r *runner) runTestList(ctx context.Context, metadata types.ValidatorMetada
 				"error", testResult.Error.Error())
 		}
 
-		// Aggregate raw JSON from individual tests for the aggregated result
-		if individualRawJSON, exists := r.getRawJSON(testMetadata.ID); exists {
-			// Append this test's raw JSON to the aggregated JSON
-			aggregatedRawJSON = append(aggregatedRawJSON, individualRawJSON...)
+		// Aggregate raw JSON from individual tests for the aggregated result without duplicating in memory
+		if rawSink, ok := r.getRawJSONSink(); ok {
+			if aggregatedRawFile == nil {
+				tempFile, err := os.CreateTemp("", "op-acceptor-aggregated-raw-*.log")
+				if err != nil {
+					r.log.Error("Failed to create aggregated raw JSON file", "error", err)
+					return nil, fmt.Errorf("creating aggregated raw JSON file: %w", err)
+				}
+				aggregatedRawFile = tempFile
+				aggregatedRawPath = tempFile.Name()
+			}
+			if wrote, err := rawSink.WriteRawJSONTo(testMetadata.ID, aggregatedRawFile); err != nil {
+				return nil, fmt.Errorf("copying raw JSON for %s: %w", testName, err)
+			} else if wrote {
+				aggregatedRawUsed = true
+				rawSink.DeleteRawJSON(testMetadata.ID)
+			}
 		}
 
 		// Update overall status based on individual test result
@@ -734,8 +749,19 @@ func (r *runner) runTestList(ctx context.Context, metadata types.ValidatorMetada
 	}
 
 	// Store the aggregated raw JSON for the package-level test result
-	if len(aggregatedRawJSON) > 0 {
-		r.storeRawJSON(metadata.ID, aggregatedRawJSON)
+	if aggregatedRawFile != nil {
+		if _, err := aggregatedRawFile.Seek(0, io.SeekStart); err != nil {
+			aggregatedRawFile.Close()
+			_ = os.Remove(aggregatedRawPath)
+			return nil, fmt.Errorf("failed to rewind aggregated raw JSON file: %w", err)
+		}
+		if aggregatedRawUsed {
+			if err := r.storeRawJSONFromFile(metadata.ID, aggregatedRawPath); err != nil {
+				r.log.Error("Failed to store aggregated raw JSON", "package", metadata.Package, "error", err)
+			}
+		}
+		aggregatedRawFile.Close()
+		_ = os.Remove(aggregatedRawPath)
 	}
 
 	// Create an appropriate error message that includes timeout information
@@ -826,9 +852,23 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 	cmd, cleanup := r.testCommandContext(ctx, r.goBinary, args...)
 	defer cleanup()
 
-	var stdout, stderr bytes.Buffer
+	stdoutFile, err := os.CreateTemp("", "op-acceptor-stdout-*.log")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdout temp file: %w", err)
+	}
+	stdoutFilePath := stdoutFile.Name()
+	defer func() {
+		_ = stdoutFile.Close()
+		_ = os.Remove(stdoutFilePath)
+	}()
+
+	stdoutTail := newTailBuffer(defaultStdoutTailBytes)
+	var stderr bytes.Buffer
 	var timeoutOccurred bool
 	var testStartTime = time.Now()
+
+	var stdoutWriters []io.Writer
+	stdoutWriters = append(stdoutWriters, stdoutFile, stdoutTail)
 
 	if r.outputRealtimeLogs {
 		stdoutLogger := &logWriter{logFn: func(msg string) {
@@ -838,12 +878,12 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 			r.log.Error("Test error output", "test", metadata.FuncName, "error", msg)
 		}}
 
-		cmd.Stdout = io.MultiWriter(&stdout, stdoutLogger)
+		stdoutWriters = append(stdoutWriters, stdoutLogger)
 		cmd.Stderr = io.MultiWriter(&stderr, stderrLogger)
 	} else {
-		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 	}
+	cmd.Stdout = io.MultiWriter(stdoutWriters...)
 
 	// If there's no function name use package name
 	testLabel := metadata.FuncName
@@ -861,8 +901,10 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 		"allowSkips", r.allowSkips)
 
 	// Run the command
-	err := cmd.Run()
+	err = cmd.Run()
 	testDuration := time.Since(testStartTime)
+	_ = stdoutFile.Sync()
+	_ = stdoutFile.Close()
 
 	// Check for timeout first and set flag
 	if ctx.Err() == context.DeadlineExceeded {
@@ -871,15 +913,19 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 			"test", metadata.FuncName,
 			"timeout", timeoutDuration,
 			"duration", testDuration,
-			"partialStdout", len(stdout.Bytes()),
+			"partialStdout", stdoutTail.TotalBytes(),
 			"partialStderr", len(stderr.Bytes()))
 	}
 
 	// ALWAYS store the raw JSON output for the RawJSONSink if we have a file logger
 	// This ensures partial output is captured even on timeout
-	if stdout.Len() > 0 {
-		r.storeRawJSON(metadata.ID, stdout.Bytes())
-		r.log.Debug("Stored partial output", "test", metadata.FuncName, "bytes", stdout.Len())
+	if stdoutTail.TotalBytes() > 0 {
+		if err := r.storeRawJSONFromFile(metadata.ID, stdoutFilePath); err != nil {
+			r.log.Error("Failed to persist raw JSON output",
+				"test", metadata.FuncName, "error", err)
+		} else {
+			r.log.Debug("Stored partial output", "test", metadata.FuncName, "bytes", stdoutTail.TotalBytes())
+		}
 	} else if timeoutOccurred {
 		// Even if no stdout, store a timeout marker in raw JSON for debugging
 		timeoutInfo := fmt.Sprintf(`{"Time":"%s","Action":"timeout","Package":"%s","Test":"%s","Output":"TEST TIMED OUT after %v - no JSON output captured\n"}`,
@@ -888,10 +934,21 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 		r.log.Debug("Stored timeout marker", "test", metadata.FuncName)
 	}
 
+	stdoutSnippet := buildStdoutSnippet(stdoutTail)
+
+	openStdout := func() (*os.File, error) {
+		return os.Open(stdoutFilePath)
+	}
+
 	// Handle timeout case with enhanced error messaging
 	if timeoutOccurred {
 		// Delegate parsing of partial output
-		parsed := r.outputParser.ParseWithTimeout(stdout.Bytes(), metadata, timeoutDuration)
+		stdoutReader, readerErr := openStdout()
+		if readerErr != nil {
+			return nil, fmt.Errorf("failed to read stdout for timeout parsing: %w", readerErr)
+		}
+		parsed := r.outputParser.ParseWithTimeout(stdoutReader, metadata, timeoutDuration)
+		stdoutReader.Close()
 		if parsed == nil {
 			parsed = &types.TestResult{
 				Metadata: metadata,
@@ -906,8 +963,8 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 		if parsed.Error != nil && testDuration > 0 {
 			parsed.Error = fmt.Errorf("%w (actual duration: %v)", parsed.Error, testDuration)
 		}
-		if stdout.Len() > 0 {
-			parsed.Stdout = stdout.String()
+		if stdoutTail.TotalBytes() > 0 {
+			parsed.Stdout = stdoutSnippet
 		}
 		// Include stderr in the result if present
 		if stderr.Len() > 0 {
@@ -935,7 +992,12 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 	}
 
 	// Parse the JSON output for non-timeout cases
-	parsedResult := r.parseTestOutput(stdout.Bytes(), metadata)
+	stdoutReader, readerErr := openStdout()
+	if readerErr != nil {
+		return nil, fmt.Errorf("failed to read stdout for parsing: %w", readerErr)
+	}
+	parsedResult := r.parseTestOutput(stdoutReader, metadata)
+	stdoutReader.Close()
 
 	// If we couldn't parse the output for some reason, create a minimal failing result
 	if parsedResult == nil {
@@ -944,14 +1006,14 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 			Metadata: metadata,
 			Status:   types.TestStatusFail,
 			Error:    fmt.Errorf("failed to parse test output"),
-			Stdout:   stdout.String(),
+			Stdout:   stdoutSnippet,
 			SubTests: make(map[string]*types.TestResult),
 		}
 	}
 
 	// Capture stdout in the test result for all tests
-	if stdout.Len() > 0 {
-		parsedResult.Stdout = stdout.String()
+	if stdoutTail.TotalBytes() > 0 {
+		parsedResult.Stdout = stdoutSnippet
 	}
 
 	// Add any stderr output to the error
@@ -974,8 +1036,21 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 }
 
 // parseTestOutput parses the JSON test output and extracts test result information
-func (r *runner) parseTestOutput(output []byte, metadata types.ValidatorMetadata) *types.TestResult {
+func (r *runner) parseTestOutput(output io.Reader, metadata types.ValidatorMetadata) *types.TestResult {
 	return r.outputParser.Parse(output, metadata)
+}
+
+func buildStdoutSnippet(buf *tailBuffer) string {
+	if buf == nil || buf.TotalBytes() == 0 {
+		return ""
+	}
+
+	snippet := string(buf.Bytes())
+	if buf.Truncated() {
+		return fmt.Sprintf("[showing last %d of %d bytes]\n%s",
+			len(snippet), buf.TotalBytes(), snippet)
+	}
+	return snippet
 }
 
 // buildTestArgs constructs the command line arguments for running a test
@@ -1328,11 +1403,28 @@ func (r *runner) getRawJSONSink() (*logging.RawJSONSink, bool) {
 
 // storeRawJSON is a helper method to store raw JSON for a test
 func (r *runner) storeRawJSON(testID string, rawJSON []byte) {
+	if len(rawJSON) == 0 {
+		return
+	}
 	if rawSink, ok := r.getRawJSONSink(); ok {
-		rawSink.StoreRawJSON(testID, rawJSON)
+		if err := rawSink.StoreRawJSON(testID, rawJSON); err != nil {
+			r.log.Error("Failed to store raw JSON", "test", testID, "error", err)
+		}
 	} else {
 		r.log.Debug("No raw JSON sink available, not storing raw JSON output")
 	}
+}
+
+func (r *runner) storeRawJSONFromFile(testID, path string) error {
+	rawSink, ok := r.getRawJSONSink()
+	if !ok {
+		r.log.Debug("No raw JSON sink available, not storing raw JSON output")
+		return nil
+	}
+	if err := rawSink.StoreRawJSONFromFile(testID, path); err != nil {
+		return err
+	}
+	return nil
 }
 
 // getRawJSON is a helper method to retrieve raw JSON for a test

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -751,7 +751,7 @@ func (r *runner) runTestList(ctx context.Context, metadata types.ValidatorMetada
 	// Store the aggregated raw JSON for the package-level test result
 	if aggregatedRawFile != nil {
 		if _, err := aggregatedRawFile.Seek(0, io.SeekStart); err != nil {
-			aggregatedRawFile.Close()
+			_ = aggregatedRawFile.Close()
 			_ = os.Remove(aggregatedRawPath)
 			return nil, fmt.Errorf("failed to rewind aggregated raw JSON file: %w", err)
 		}
@@ -760,7 +760,7 @@ func (r *runner) runTestList(ctx context.Context, metadata types.ValidatorMetada
 				r.log.Error("Failed to store aggregated raw JSON", "package", metadata.Package, "error", err)
 			}
 		}
-		aggregatedRawFile.Close()
+		_ = aggregatedRawFile.Close()
 		_ = os.Remove(aggregatedRawPath)
 	}
 
@@ -948,7 +948,7 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 			return nil, fmt.Errorf("failed to read stdout for timeout parsing: %w", readerErr)
 		}
 		parsed := r.outputParser.ParseWithTimeout(stdoutReader, metadata, timeoutDuration)
-		stdoutReader.Close()
+		_ = stdoutReader.Close()
 		if parsed == nil {
 			parsed = &types.TestResult{
 				Metadata: metadata,
@@ -997,7 +997,7 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 		return nil, fmt.Errorf("failed to read stdout for parsing: %w", readerErr)
 	}
 	parsedResult := r.parseTestOutput(stdoutReader, metadata)
-	stdoutReader.Close()
+	_ = stdoutReader.Close()
 
 	// If we couldn't parse the output for some reason, create a minimal failing result
 	if parsedResult == nil {
@@ -1425,14 +1425,6 @@ func (r *runner) storeRawJSONFromFile(testID, path string) error {
 		return err
 	}
 	return nil
-}
-
-// getRawJSON is a helper method to retrieve raw JSON for a test
-func (r *runner) getRawJSON(testID string) ([]byte, bool) {
-	if rawSink, ok := r.getRawJSONSink(); ok {
-		return rawSink.GetRawJSON(testID)
-	}
-	return nil, false
 }
 
 func (r *runner) testCommandContext(ctx context.Context, name string, arg ...string) (*exec.Cmd, func()) {

--- a/op-acceptor/runner/runner_test.go
+++ b/op-acceptor/runner/runner_test.go
@@ -1476,7 +1476,7 @@ func TestParseTestOutput(t *testing.T) {
 			// Convert events to JSON string
 			jsonOutput := eventToJSON(tt.events)
 
-			result := r.parseTestOutput([]byte(jsonOutput), tt.metadata)
+			result := r.parseTestOutput(strings.NewReader(jsonOutput), tt.metadata)
 
 			assert.NotNil(t, result, "result should not be nil")
 			assert.Equal(t, tt.wantStatus, result.Status, "unexpected status")
@@ -1571,7 +1571,7 @@ func TestSubTestDurationCalculation(t *testing.T) {
 	}
 
 	jsonOutput := eventToJSON(events)
-	result := r.parseTestOutput([]byte(jsonOutput), metadata)
+	result := r.parseTestOutput(strings.NewReader(jsonOutput), metadata)
 
 	// Verify subtests were created
 	require.Equal(t, 2, len(result.SubTests), "Expected 2 subtests")

--- a/op-acceptor/runner/stdout_buffer.go
+++ b/op-acceptor/runner/stdout_buffer.go
@@ -1,0 +1,69 @@
+package runner
+
+import (
+	"sync"
+)
+
+const defaultStdoutTailBytes = 5 * 1024 * 1024 // 5MB kept in memory per test
+
+// tailBuffer keeps only the last N bytes written to it so we can attach a
+// representative snippet of stdout to the TestResult without retaining the
+// entire log in memory.
+type tailBuffer struct {
+	maxBytes int
+
+	mu       sync.Mutex
+	total    int64
+	contents []byte
+	overflow bool
+}
+
+func newTailBuffer(maxBytes int) *tailBuffer {
+	if maxBytes <= 0 {
+		maxBytes = defaultStdoutTailBytes
+	}
+	return &tailBuffer{
+		maxBytes: maxBytes,
+		contents: make([]byte, 0, maxBytes),
+	}
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.total += int64(len(p))
+	if len(b.contents)+len(p) <= b.maxBytes {
+		b.contents = append(b.contents, p...)
+		return len(p), nil
+	}
+
+	// Append then trim front to keep the most recent bytes
+	b.contents = append(b.contents, p...)
+	if len(b.contents) > b.maxBytes {
+		b.contents = b.contents[len(b.contents)-b.maxBytes:]
+		b.overflow = true
+	}
+	return len(p), nil
+}
+
+func (b *tailBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	cp := make([]byte, len(b.contents))
+	copy(cp, b.contents)
+	return cp
+}
+
+func (b *tailBuffer) TotalBytes() int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.total
+}
+
+func (b *tailBuffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.overflow || int64(len(b.contents)) < b.total
+}


### PR DESCRIPTION
Streams the logs straight to disk so we don't use up lots of RAM.
Also implements a signal handler, so we can _try_ to exit gracefully if, say, CircleCI kills our host.
