### PR TITLE
fix(ci): goreleaser; make latest release.

### DIFF
--- a/cci-stats/.goreleaser.yaml
+++ b/cci-stats/.goreleaser.yaml
@@ -49,7 +49,7 @@ release:
   github:
     owner: ethereum-optimism
     name: infra
-  make_latest: false
+  make_latest: auto
 
 monorepo:
   tag_prefix: cci-stats/

--- a/op-acceptor/.goreleaser.yaml
+++ b/op-acceptor/.goreleaser.yaml
@@ -50,7 +50,7 @@ release:
   github:
     owner: ethereum-optimism
     name: infra
-  make_latest: false
+  make_latest: auto
 
 monorepo:
   tag_prefix: op-acceptor/

--- a/op-conductor-mon/.goreleaser.yaml
+++ b/op-conductor-mon/.goreleaser.yaml
@@ -49,7 +49,7 @@ release:
   github:
     owner: ethereum-optimism
     name: infra
-  make_latest: false
+  make_latest: auto
 
 monorepo:
   tag_prefix: op-conductor-mon/

--- a/op-signer/.goreleaser.yaml
+++ b/op-signer/.goreleaser.yaml
@@ -49,7 +49,7 @@ release:
   github:
     owner: ethereum-optimism
     name: infra
-  make_latest: false
+  make_latest: auto
 
 monorepo:
   tag_prefix: op-signer/

--- a/op-ufm/.goreleaser.yaml
+++ b/op-ufm/.goreleaser.yaml
@@ -49,7 +49,7 @@ release:
   github:
     owner: ethereum-optimism
     name: infra
-  make_latest: false
+  make_latest: auto
 
 monorepo:
   tag_prefix: op-ufm/

--- a/peer-mgmt-service/.goreleaser.yaml
+++ b/peer-mgmt-service/.goreleaser.yaml
@@ -49,7 +49,7 @@ release:
   github:
     owner: ethereum-optimism
     name: infra
-  make_latest: false
+  make_latest: auto
 
 monorepo:
   tag_prefix: peer-mgmt-service/

--- a/proxyd/.goreleaser.yaml
+++ b/proxyd/.goreleaser.yaml
@@ -49,7 +49,7 @@ release:
   github:
     owner: ethereum-optimism
     name: infra
-  make_latest: false
+  make_latest: auto
 
 monorepo:
   tag_prefix: proxyd/


### PR DESCRIPTION
We had 'latest_release' disabled by default for most services. This changes that, so the github repo shows the actual latest release.

The currently listed latest release is op-ufm/v0.2.6 from July 25, which is clearly not correct.
<img width="262" height="164" alt="Screenshot 2025-12-10 at 11 01 19" src="https://github.com/user-attachments/assets/e2cf23f5-e61b-4581-b421-f856e035e4d7" />

### Metadata
Resolves https://github.com/ethereum-optimism/platforms-team/issues/1548