### PR TITLE
ci: complete migration of docker builds from CircleCI to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ workflows:
             op-acceptor/.* run-build-op-acceptor true
             replica-healthcheck/.* run-build-rhc true
             .circleci/.* run-all true
-            .github/.* run-all true
           filters:
             tags:
               only: /.*/

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -170,154 +170,6 @@ jobs:
               echo "replica-healthcheck tag regex match: false"
             fi
 
-  docker-build:
-    environment:
-      DOCKER_BUILDKIT: 1
-    parameters:
-      docker_name:
-        description: Docker image name
-        type: string
-      docker_tags:
-        description: Docker image tags as csv
-        type: string
-      docker_file:
-        description: Path to Dockerfile
-        type: string
-      docker_context:
-        description: Docker build context
-        type: string
-      registry:
-        description: Docker registry
-        type: string
-        default: "us-docker.pkg.dev"
-      repo:
-        description: Docker repo
-        type: string
-        default: "oplabs-tools-artifacts/images"
-    machine:
-      image: <<pipeline.parameters.vm-image>>
-    steps:
-      - checkout:
-          method: blobless
-      - run:
-          command: mkdir -p /tmp/docker_images
-      - run:
-          name: Build
-          command: |
-            # Check to see if DOCKER_HUB_READ_ONLY_TOKEN is set (i.e. we are in repo) before attempting to use secrets.
-            # Building should work without this read only login, but may get rate limited.
-            if [[ -v DOCKER_HUB_READ_ONLY_TOKEN ]]; then
-              echo "$DOCKER_HUB_READ_ONLY_TOKEN" | docker login -u "$DOCKER_HUB_READ_ONLY_USER" --password-stdin
-            fi
-            IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
-            DOCKER_TAGS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g" | sed -e "s|^|-t ${IMAGE_BASE}:|")
-            docker build \
-            $(echo -ne $DOCKER_TAGS | tr '\n' ' ') \
-            -f <<parameters.docker_file>> \
-            <<parameters.docker_context>>
-      - run:
-          name: Save
-          command: |
-            IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
-            DOCKER_LABELS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g")
-            echo -ne $DOCKER_LABELS | tr ' ' '\n' | xargs -I {} docker save -o /tmp/docker_images/<<parameters.docker_name>>_{}.tar $IMAGE_BASE:{}
-      - persist_to_workspace:
-          root: /tmp/docker_images
-          paths:
-            - "."
-
-  docker-publish:
-    parameters:
-      docker_name:
-        description: Docker image name
-        type: string
-      docker_tags:
-        description: Docker image tags as csv
-        type: string
-      registry:
-        description: Docker registry
-        type: string
-        default: "us-docker.pkg.dev"
-      repo:
-        description: Docker repo
-        type: string
-        default: "oplabs-tools-artifacts/images"
-    machine:
-      image: <<pipeline.parameters.vm-image>>
-    steps:
-      - attach_workspace:
-          at: /tmp/docker_images
-      - run:
-          name: Docker load
-          command: |
-            DOCKER_LABELS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g")
-            echo -ne $DOCKER_LABELS | tr ' ' '\n' | xargs -I {} docker load -i /tmp/docker_images/<<parameters.docker_name>>_{}.tar
-      - gcp-oidc-authenticate
-      # Below is CircleCI recommended way of specifying nameservers on an Ubuntu box:
-      # https://support.circleci.com/hc/en-us/articles/7323511028251-How-to-set-custom-DNS-on-Ubuntu-based-images-using-netplan
-      - run: sudo sed -i '13 i \ \ \ \ \ \ \ \ \ \ \ \ nameservers:' /etc/netplan/50-cloud-init.yaml
-      - run: sudo sed -i '14 i \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ addresses:' /etc/netplan/50-cloud-init.yaml
-      - run: sudo sed -i "s/addresses:/ addresses":" [8.8.8.8, 8.8.4.4] /g" /etc/netplan/50-cloud-init.yaml
-      - run: sudo cat /etc/netplan/50-cloud-init.yaml
-      - run: sudo netplan apply
-      - run:
-          name: Publish
-          command: |
-            gcloud auth configure-docker <<parameters.registry>>
-            IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
-            DOCKER_TAGS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g" | sed -e "s|^|${IMAGE_BASE}:|")
-            echo -ne $DOCKER_TAGS | tr ' ' '\n' | xargs -L1 docker push
-
-      - when:
-          condition:
-            equal: ['main', <<pipeline.git.branch>>]
-          steps:
-            - gcp-oidc-authenticate:
-                service_account_email: GCP_SERVICE_ATTESTOR_ACCOUNT_EMAIL
-            - run:
-                name: Sign
-                command: |
-                  git clone --branch v1.0.3 --depth 1 https://github.com/ethereum-optimism/binary_signer
-                  cd binary_signer/signer
-
-                  IMAGE_PATH="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>:<<pipeline.git.revision>>"
-                  echo $IMAGE_PATH
-                  pip3 install -r requirements.txt
-
-                  python3 ./sign_image.py --command="sign"\
-                      --attestor-project-name="$ATTESTOR_PROJECT_NAME"\
-                      --attestor-name="$ATTESTOR_NAME"\
-                      --image-path="$IMAGE_PATH"\
-                      --signer-logging-level="INFO"\
-                      --attestor-key-id="//cloudkms.googleapis.com/v1/projects/$ATTESTOR_PROJECT_NAME/locations/global/keyRings/$ATTESTOR_NAME-key-ring/cryptoKeys/$ATTESTOR_NAME-key/cryptoKeyVersions/1"
-
-  docker-tag-op-stack-release:
-    parameters:
-      docker_name:
-        description: Docker image name
-        type: string
-      registry:
-        description: Docker registry
-        type: string
-        default: "us-docker.pkg.dev"
-      repo:
-        description: Docker repo
-        type: string
-        default: "oplabs-tools-artifacts/images"
-    docker:
-      - image: cimg/python:3.7
-    resource_class: small
-    steps:
-      - gcp-cli/install
-      - gcp-oidc-authenticate
-      - checkout:
-          method: blobless
-      - run:
-          name: Tag
-          command: |
-            gcloud auth configure-docker <<parameters.registry>>
-            ./ops/ci-tag-docker-release/ci-docker-tag-op-stack-release.sh <<parameters.registry>>/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
-
   go-lint:
     parameters:
       module:
@@ -531,23 +383,11 @@ workflows:
       - go-test:
           name: op-conductor-mon-tests
           module: op-conductor-mon
-      - docker-build:
-          name: op-conductor-mon-docker-build
-          docker_file: op-conductor-mon/Dockerfile
-          docker_name: op-conductor-mon
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: .
   op-conductor-ops:
     when:
       or: [<< pipeline.parameters.run-build-op-conductor-ops >>, << pipeline.parameters.run-all >>]
     jobs:
       - op-conductor-ops-lint
-      - docker-build:
-          name: op-conductor-ops-docker-build
-          docker_file: op-conductor-ops/Dockerfile
-          docker_name: op-conductor-ops
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: .
   op-signer:
     when:
       or: [<< pipeline.parameters.run-build-op-signer >>, << pipeline.parameters.run-all >>]
@@ -558,12 +398,6 @@ workflows:
       - go-test:
           name: op-signer-tests
           module: op-signer
-      - docker-build:
-          name: op-signer-docker-build
-          docker_file: op-signer/Dockerfile
-          docker_name: op-signer
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: .
   peer-mgmt-service:
     when:
       or: [<< pipeline.parameters.run-build-pms >>, << pipeline.parameters.run-all >>]
@@ -574,12 +408,6 @@ workflows:
       - go-test:
           name: pms-tests
           module: peer-mgmt-service
-      - docker-build:
-          name: pms-docker-build
-          docker_file: peer-mgmt-service/Dockerfile
-          docker_name: peer-mgmt-service
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: .
   op-txproxy:
     when:
       or: [<< pipeline.parameters.run-build-op-txproxy >>, << pipeline.parameters.run-all >>]
@@ -590,12 +418,6 @@ workflows:
       - go-test:
           name: op-txproxy-tests
           module: op-txproxy
-      - docker-build:
-          name: op-txproxy-docker-build
-          docker_file: op-txproxy/Dockerfile
-          docker_name: op-txproxy
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: .
   op-ufm:
     when:
       or: [<< pipeline.parameters.run-build-op-ufm >>, << pipeline.parameters.run-all >>]
@@ -606,12 +428,6 @@ workflows:
       - go-test:
           name: op-ufm-tests
           module: op-ufm
-      - docker-build:
-          name: op-ufm-docker-build
-          docker_file: op-ufm/Dockerfile
-          docker_name: op-ufm
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: .
   op-proxyd:
     when:
       or: [<< pipeline.parameters.run-build-proxyd >>, << pipeline.parameters.run-all >>]
@@ -622,12 +438,6 @@ workflows:
       - go-test:
           name: proxyd-tests
           module: proxyd
-      - docker-build:
-          name: proxyd-docker-build
-          docker_file: proxyd/Dockerfile
-          docker_name: proxyd
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: .
   cci-stats:
     when:
       or: [ << pipeline.parameters.run-build-cci-stats >>, << pipeline.parameters.run-all >> ]
@@ -638,12 +448,6 @@ workflows:
       - go-test:
           name: cci-stats-tests
           module: cci-stats
-      - docker-build:
-          name: cci-stats-docker-build
-          docker_file: cci-stats/Dockerfile
-          docker_name: cci-stats
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: .
   op-acceptor:
     when:
       or: [<< pipeline.parameters.run-build-op-acceptor >>, << pipeline.parameters.run-all >>]
@@ -655,23 +459,7 @@ workflows:
           name: op-acceptor-tests
           module: op-acceptor
       - op-acceptor-test-all
-      - docker-build:
-          name: op-acceptor-docker-build
-          docker_file: op-acceptor/Dockerfile
-          docker_name: op-acceptor
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: .
 
-  replica-healthcheck:
-    when:
-      or: [<< pipeline.parameters.run-build-rhc >>, << pipeline.parameters.run-all >>]
-    jobs:
-      - docker-build:
-          name: replica-healthcheck-docker-build
-          docker_file: replica-healthcheck/Dockerfile
-          docker_name: replica-healthcheck
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          docker_context: .
   release:
     jobs:
       - log-config-results:
@@ -687,78 +475,6 @@ workflows:
               only: /^(replica-healthcheck|cci-stats|peer-mgmt-service|proxyd|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
             branches:
               ignore: /.*/
-      - docker-build:
-          matrix:
-            parameters:
-              docker_name:
-                - op-signer
-                - op-txproxy
-                - op-ufm
-                - proxyd
-                - op-conductor-mon
-                - op-conductor-ops
-                - peer-mgmt-service
-                - cci-stats
-                - op-acceptor
-                - replica-healthcheck
-          name: <<matrix.docker_name>>-docker-build
-          filters:
-            tags:
-              only: /^<<matrix.docker_name>>\/v.*/
-          docker_tags: <<pipeline.git.revision>>
-          docker_context: .
-          docker_file: <<matrix.docker_name>>/Dockerfile
-          context:
-            - oplabs-gcr-release
-          requires:
-            - hold
-      - docker-publish:
-          matrix:
-            parameters:
-              docker_name:
-                - op-signer
-                - op-txproxy
-                - op-ufm
-                - proxyd
-                - op-conductor-mon
-                - op-conductor-ops
-                - peer-mgmt-service
-                - cci-stats
-                - op-acceptor
-                - replica-healthcheck
-          name: <<matrix.docker_name>>-docker-publish
-          filters:
-            tags:
-              only: /^<<matrix.docker_name>>\/v.*/
-          docker_tags: <<pipeline.git.revision>>
-          context:
-            - oplabs-gcr-release
-          requires:
-            - <<matrix.docker_name>>-docker-build
-      - docker-tag-op-stack-release:
-          matrix:
-            parameters:
-              docker_name:
-                - op-signer
-                - op-txproxy
-                - op-ufm
-                - proxyd
-                - op-conductor-mon
-                - op-conductor-ops
-                - peer-mgmt-service
-                - cci-stats
-                - op-acceptor
-                - replica-healthcheck
-          name: <<matrix.docker_name>>-docker-tag
-          filters:
-            tags:
-              only: /^<<matrix.docker_name>>\/v.*/
-            branches:
-              ignore: /.*/
-          context:
-            - oplabs-gcr-release
-          requires:
-            - <<matrix.docker_name>>-docker-publish
       - go-release:
           matrix:
             parameters:

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -12,7 +12,7 @@ jobs:
   local:
     # only build if the push is to a local branch, or if the PR is to main from a local branch
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@ae4dada9bf0951124892dbc6b63cebef44d35f91
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +32,7 @@ jobs:
       context: .
       dockerfile: ${{ matrix.image_name }}/Dockerfile
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
-      registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
     permissions:
       contents: read
       id-token: write
@@ -41,7 +41,7 @@ jobs:
   fork:
     # only build if the PR is from a fork
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@ae4dada9bf0951124892dbc6b63cebef44d35f91
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
     strategy:
       fail-fast: false
       matrix:
@@ -63,4 +63,3 @@ jobs:
       registry: ttl.sh/${{ github.sha }}
     permissions:
       contents: read
-    

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -12,18 +12,18 @@ jobs:
       image_name: ${{ steps.parse-tag.outputs.image_name }}
       version: ${{ steps.parse-tag.outputs.version }}
     steps:
-      - uses: ethereum-optimism/factory/actions/parse-tag@240b16167a5f5aa789270fa9c0efbfa9f010b7e7
+      - uses: ethereum-optimism/factory/actions/parse-tag@f8f3cb4800e538003134fb5f50cc734c2c98d762
         id: parse-tag
   tag:
     needs: prep
-    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@ae4dada9bf0951124892dbc6b63cebef44d35f91
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
     with:
       image_name: ${{ needs.prep.outputs.image_name }}
       context: .
       dockerfile: ${{ needs.prep.outputs.image_name }}/Dockerfile
       tag: ${{ needs.prep.outputs.version }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
-      registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Migrating docker builds from CircleCI to GitHub Actions.

- GHA now pushes to `images` registry instead of `oss`
- Removed CCI docker-build, docker-publish, and docker-tag jobs
- Kept all test/lint jobs and goreleaser for binary releases