### PR TITLE
feat(proxyd): graceful server shutdown

### DIFF
--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -574,6 +574,8 @@ func Start(config *Config) (*Server, func(), error) {
 	log.Info("started proxyd")
 
 	shutdownFunc := func() {
+		log.Info("draining proxyd")
+		srv.Drain()
 		log.Info("shutting down proxyd")
 		srv.Shutdown()
 		log.Info("goodbye")


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Graceful shutdown for proxyd on termination. Relies on external load balancer that checks `/healthz` to determine if the server is available, and not accept new requests if it's draining (503). Also, waits up to 10seconds for server to shutdown gracefully, to provide extra buffer if needed for current requests to finish.

**Tests**

Only touches shutdown functionality.

