### PR TITLE
fix(proxyd): log tracing request ID and remote IPs

### DIFF
--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -328,7 +328,7 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 		"auth", GetAuthCtx(ctx),
 		"user_agent", userAgent,
 		"origin", origin,
-		"remote_ip", xff,
+		"remote_ip", stripXFF(GetXForwardedFor(ctx)),
 	)
 
 	body, err := io.ReadAll(LimitReader(r.Body, s.maxBodySize))
@@ -543,6 +543,7 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				"source", "rpc",
 				"req_id", GetReqID(ctx),
 				"method", parsedReq.Method,
+				"remote_ip", stripXFF(GetXForwardedFor(ctx)),
 			)
 			RecordRPCError(ctx, BackendProxyd, MethodNotAllowed, ErrMethodNotWhitelisted)
 			responses[i] = NewRPCErrorRes(parsedReq.ID, ErrMethodNotWhitelisted)
@@ -556,6 +557,7 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				"source", "rpc",
 				"req_id", GetReqID(ctx),
 				"method", parsedReq.Method,
+				"remote_ip", stripXFF(GetXForwardedFor(ctx)),
 			)
 			RecordRPCError(ctx, BackendProxyd, parsedReq.Method, ErrOverRateLimit)
 			responses[i] = NewRPCErrorRes(parsedReq.ID, ErrOverRateLimit)
@@ -569,6 +571,7 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				"source", "rpc",
 				"req_id", GetReqID(ctx),
 				"method", parsedReq.Method,
+				"remote_ip", stripXFF(GetXForwardedFor(ctx)),
 			)
 			RecordRPCError(ctx, BackendProxyd, parsedReq.Method, ErrOverRateLimit)
 			responses[i] = NewRPCErrorRes(parsedReq.ID, ErrOverRateLimit)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -328,7 +328,7 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 		"auth", GetAuthCtx(ctx),
 		"user_agent", userAgent,
 		"origin", origin,
-		"remote_ip", stripXFF(GetXForwardedFor(ctx)),
+		"remote_ip", xff,
 	)
 
 	body, err := io.ReadAll(LimitReader(r.Body, s.maxBodySize))

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -554,7 +554,7 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			log.Debug(
 				"rate limited individual RPC in a batch request",
 				"source", "rpc",
-				"req_id", parsedReq.ID,
+				"req_id", GetReqID(ctx),
 				"method", parsedReq.Method,
 			)
 			RecordRPCError(ctx, BackendProxyd, parsedReq.Method, ErrOverRateLimit)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

We should log the tracing ID here, to help correlate log entries, not the client request ID.
Also logs remote IP selectively, for clarity when reading logs.

**Tests**

None, small log changes.
