### PR TITLE
feat(proxyd): rate limit exempt API keys

### DIFF
--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -137,6 +137,7 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 		InteropValidationConfig{},              // interopValidatingConfig
 		NewFirstSupervisorStrategy([]string{}), // interopStrategy
 		false,                                  // enableTxHashLogging
+		nil,                                    // limExemptKeys
 	)
 	require.NoError(t, err)
 

--- a/proxyd/integration_tests/rate_limit_test.go
+++ b/proxyd/integration_tests/rate_limit_test.go
@@ -58,17 +58,17 @@ func TestFrontendMaxRPSLimit(t *testing.T) {
 	})
 
 	t.Run("exempt API keys", func(t *testing.T) {
-		// Test QUICKNODE_API_KEY in header.
 		h := make(http.Header)
 
-		// Test one of API_KEYS in header.
-		h.Set("X-Api-Key", "tuv")
+		// Test first of API_KEYS in header.
+		h.Set("X-Api-Key", "hijklmnop")
 		client2 := NewProxydClientWithHeaders("http://127.0.0.1:8545", h)
 		_, codes := spamReqs(t, client2, ethChainID, 429, 3)
 		require.Equal(t, 3, codes[200])
 
-		// Test ALCHEMY_API_KEY appended to URL.
-		client3 := NewProxydClient("http://127.0.0.1:8545/hijklmnop")
+		// Test last of API_KEYS in header.
+		h.Set("X-Api-Key", "tuv")
+		client3 := NewProxydClientWithHeaders("http://127.0.0.1:8545", h)
 		_, codes = spamReqs(t, client3, ethChainID, 429, 3)
 		require.Equal(t, 3, codes[200])
 	})

--- a/proxyd/integration_tests/rate_limit_test.go
+++ b/proxyd/integration_tests/rate_limit_test.go
@@ -26,9 +26,7 @@ func TestFrontendMaxRPSLimit(t *testing.T) {
 
 	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
 
-	t.Setenv("QUICKNODE_API_KEY", "abcdefg")
-	t.Setenv("ALCHEMY_API_KEY", "hijklmnop")
-	t.Setenv("API_KEYS", "qrs,tuv")
+	t.Setenv("API_KEYS", "abcdefg,hijklmnop,qrs,tuv")
 
 	config := ReadConfig("frontend_rate_limit")
 	_, shutdown, err := proxyd.Start(config)

--- a/proxyd/integration_tests/rate_limit_test.go
+++ b/proxyd/integration_tests/rate_limit_test.go
@@ -26,6 +26,10 @@ func TestFrontendMaxRPSLimit(t *testing.T) {
 
 	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
 
+	t.Setenv("QUICKNODE_API_KEY", "abcdefg")
+	t.Setenv("ALCHEMY_API_KEY", "hijklmnop")
+	t.Setenv("API_KEYS", "qrs,tuv")
+
 	config := ReadConfig("frontend_rate_limit")
 	_, shutdown, err := proxyd.Start(config)
 	require.NoError(t, err)
@@ -52,6 +56,26 @@ func TestFrontendMaxRPSLimit(t *testing.T) {
 		h.Set("Origin", "exempt_origin")
 		client := NewProxydClientWithHeaders("http://127.0.0.1:8545", h)
 		_, codes := spamReqs(t, client, ethChainID, 429, 3)
+		require.Equal(t, 3, codes[200])
+	})
+
+	t.Run("exempt API keys", func(t *testing.T) {
+		// Test QUICKNODE_API_KEY in header.
+		h := make(http.Header)
+		h.Set("X-Api-Key", "abcdefg")
+		client := NewProxydClientWithHeaders("http://127.0.0.1:8545", h)
+		_, codes := spamReqs(t, client, ethChainID, 429, 3)
+		require.Equal(t, 3, codes[200])
+
+		// Test one of API_KEYS in header.
+		h.Set("X-Api-Key", "tuv")
+		client2 := NewProxydClientWithHeaders("http://127.0.0.1:8545", h)
+		_, codes = spamReqs(t, client2, ethChainID, 429, 3)
+		require.Equal(t, 3, codes[200])
+
+		// Test ALCHEMY_API_KEY appended to URL.
+		client3 := NewProxydClient("http://127.0.0.1:8545/hijklmnop")
+		_, codes = spamReqs(t, client3, ethChainID, 429, 3)
 		require.Equal(t, 3, codes[200])
 	})
 

--- a/proxyd/integration_tests/rate_limit_test.go
+++ b/proxyd/integration_tests/rate_limit_test.go
@@ -26,7 +26,7 @@ func TestFrontendMaxRPSLimit(t *testing.T) {
 
 	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
 
-	t.Setenv("API_KEYS", "abcdefg,hijklmnop,qrs,tuv")
+	t.Setenv("API_KEYS", "hijklmnop,qrs,tuv")
 
 	config := ReadConfig("frontend_rate_limit")
 	_, shutdown, err := proxyd.Start(config)
@@ -60,15 +60,11 @@ func TestFrontendMaxRPSLimit(t *testing.T) {
 	t.Run("exempt API keys", func(t *testing.T) {
 		// Test QUICKNODE_API_KEY in header.
 		h := make(http.Header)
-		h.Set("X-Api-Key", "abcdefg")
-		client := NewProxydClientWithHeaders("http://127.0.0.1:8545", h)
-		_, codes := spamReqs(t, client, ethChainID, 429, 3)
-		require.Equal(t, 3, codes[200])
 
 		// Test one of API_KEYS in header.
 		h.Set("X-Api-Key", "tuv")
 		client2 := NewProxydClientWithHeaders("http://127.0.0.1:8545", h)
-		_, codes = spamReqs(t, client2, ethChainID, 429, 3)
+		_, codes := spamReqs(t, client2, ethChainID, 429, 3)
 		require.Equal(t, 3, codes[200])
 
 		// Test ALCHEMY_API_KEY appended to URL.

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -418,9 +418,9 @@ func Start(config *Config) (*Server, func(), error) {
 	}
 
 	// Allow API Keys that bypass rate-limiting.
-	apiKeys := []string{}
+	var apiKeys []string
 	if keys, err := ReadFromEnvOrConfig("$API_KEYS"); err == nil {
-		apiKeys = append(apiKeys, strings.Split(keys, ",")...)
+		apiKeys = parseCommaSeparatedList(keys)
 	}
 
 	srv, err := NewServer(
@@ -607,6 +607,17 @@ func validateReceiptsTarget(val string) (string, error) {
 
 func secondsToDuration(seconds int) time.Duration {
 	return time.Duration(seconds) * time.Second
+}
+
+func parseCommaSeparatedList(input string) []string {
+	var result []string
+	for _, item := range strings.Split(input, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			result = append(result, item)
+		}
+	}
+	return result
 }
 
 func millisecondsToDuration(ms int) time.Duration {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -419,12 +419,6 @@ func Start(config *Config) (*Server, func(), error) {
 
 	// Allow API Keys that bypass rate-limiting.
 	apiKeys := []string{}
-	if qnAPIKey, err := ReadFromEnvOrConfig("$QUICKNODE_API_KEY"); err == nil {
-		apiKeys = append(apiKeys, qnAPIKey)
-	}
-	if alchAPIKey, err := ReadFromEnvOrConfig("$ALCHEMY_API_KEY"); err == nil {
-		apiKeys = append(apiKeys, alchAPIKey)
-	}
 	if keys, err := ReadFromEnvOrConfig("$API_KEYS"); err == nil {
 		apiKeys = append(apiKeys, strings.Split(keys, ",")...)
 	}

--- a/proxyd/proxyd_test.go
+++ b/proxyd/proxyd_test.go
@@ -1,6 +1,7 @@
 package proxyd
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -65,5 +66,26 @@ func TestMillisecondsToDurationIntegration(t *testing.T) {
 	tolerance := 10 * time.Millisecond
 	if elapsed < duration-tolerance || elapsed > duration+tolerance {
 		t.Errorf("Sleep duration was %v, expected approximately %v", elapsed, duration)
+	}
+}
+
+func TestParseCommaSeparatedList(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"happy path", "key1,key2,key3", []string{"key1", "key2", "key3"}},
+		{"trims whitespace", "  key1  ,  key2  ", []string{"key1", "key2"}},
+		{"filters empty strings", "key1,,key2", []string{"key1", "key2"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseCommaSeparatedList(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("parseCommaSeparatedList(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
 	}
 }

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -809,7 +810,7 @@ func (s *Server) isUnlimitedUserAgent(origin string) bool {
 
 func (s *Server) isValidAPIKey(key string) bool {
 	for _, v := range s.limExemptKeys {
-		if key == v {
+		if subtle.ConstantTimeCompare([]byte(key), []byte(v)) == 1 {
 			return true
 		}
 	}

--- a/proxyd/server_test.go
+++ b/proxyd/server_test.go
@@ -44,3 +44,55 @@ func TestConvertSendReqToSendTx_Fusaka(t *testing.T) {
 	t.Run("blob without cell proofs", tfn(txs.OffchainTxV0, 2))
 	t.Run("blob with cell proofs", tfn(txs.OffchainTxV1, 256))
 }
+
+func TestIsValidAPIKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiKey      string
+		exemptKeys  []string
+		expected    bool
+		description string
+	}{
+		{
+			name:        "valid API key",
+			apiKey:      "valid-key-123",
+			exemptKeys:  []string{"valid-key-123"},
+			expected:    true,
+			description: "should return true for a valid API key",
+		},
+		{
+			name:        "invalid API key",
+			apiKey:      "invalid-key",
+			exemptKeys:  []string{"valid-key-123"},
+			expected:    false,
+			description: "should return false for an invalid API key",
+		},
+		{
+			name:        "empty API key",
+			apiKey:      "",
+			exemptKeys:  []string{"valid-key-123"},
+			expected:    false,
+			description: "should return false for an empty API key",
+		},
+		{
+			name:        "multiple exempt keys",
+			apiKey:      "key-2",
+			exemptKeys:  []string{"key-1", "key-2", "key-3"},
+			expected:    true,
+			description: "should return true when key is in multiple exempt keys",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{
+				limExemptKeys: tt.exemptKeys,
+			}
+
+			got := s.isValidAPIKey(tt.apiKey)
+			if got != tt.expected {
+				t.Errorf("isValidAPIKey() = %v, want %v: %s", got, tt.expected, tt.description)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Introduce `API_KEYS` env var to allow clients that specify an allow-listed API key to bypass rate limits. Can be extended to future compliance-related gates as well.

**Tests**

Integration test to bypass rate limits when matching API key is included in header by client.

**Additional context**

Needed for partners like QN/Alchemy to send transactions without hitting rate limits.
