### PR TITLE
feat(proxyd): tx validation middleware

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -135,7 +135,7 @@ var (
 	ErrTransactionRejected = &RPCErr{
 		Code:          JSONRPCErrorInternal - 100,
 		Message:       "transaction rejected",
-		HTTPErrorCode: 500,
+		HTTPErrorCode: 400,
 	}
 
 	ErrBackendUnexpectedJSONRPC = errors.New("backend returned an unexpected JSON-RPC response")

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -132,6 +132,12 @@ var (
 		HTTPErrorCode: 429,
 	}
 
+	ErrTransactionRejected = &RPCErr{
+		Code:          JSONRPCErrorInternal - 100,
+		Message:       "transaction rejected",
+		HTTPErrorCode: 500,
+	}
+
 	ErrBackendUnexpectedJSONRPC = errors.New("backend returned an unexpected JSON-RPC response")
 
 	ErrConsensusGetReceiptsCantBeBatched = errors.New("consensus_getReceipts cannot be batched")

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -138,6 +138,7 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 		NewFirstSupervisorStrategy([]string{}), // interopStrategy
 		false,                                  // enableTxHashLogging
 		nil,                                    // limExemptKeys
+		TxValidationMiddlewareConfig{},         // txValidationConfig
 	)
 	require.NoError(t, err)
 

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -222,22 +222,23 @@ type SenderRateLimitConfig struct {
 }
 
 type Config struct {
-	WSBackendGroup          string                  `toml:"ws_backend_group"`
-	Server                  ServerConfig            `toml:"server"`
-	Cache                   CacheConfig             `toml:"cache"`
-	Redis                   RedisConfig             `toml:"redis"`
-	Metrics                 MetricsConfig           `toml:"metrics"`
-	RateLimit               RateLimitConfig         `toml:"rate_limit"`
-	BackendOptions          BackendOptions          `toml:"backend"`
-	Backends                BackendsConfig          `toml:"backends"`
-	BatchConfig             BatchConfig             `toml:"batch"`
-	Authentication          map[string]string       `toml:"authentication"`
-	BackendGroups           BackendGroupsConfig     `toml:"backend_groups"`
-	RPCMethodMappings       map[string]string       `toml:"rpc_method_mappings"`
-	WSMethodWhitelist       []string                `toml:"ws_method_whitelist"`
-	WhitelistErrorMessage   string                  `toml:"whitelist_error_message"`
-	SenderRateLimit         SenderRateLimitConfig   `toml:"sender_rate_limit"`
-	InteropValidationConfig InteropValidationConfig `toml:"interop_validation"`
+	WSBackendGroup               string                       `toml:"ws_backend_group"`
+	Server                       ServerConfig                 `toml:"server"`
+	Cache                        CacheConfig                  `toml:"cache"`
+	Redis                        RedisConfig                  `toml:"redis"`
+	Metrics                      MetricsConfig                `toml:"metrics"`
+	RateLimit                    RateLimitConfig              `toml:"rate_limit"`
+	BackendOptions               BackendOptions               `toml:"backend"`
+	Backends                     BackendsConfig               `toml:"backends"`
+	BatchConfig                  BatchConfig                  `toml:"batch"`
+	Authentication               map[string]string            `toml:"authentication"`
+	BackendGroups                BackendGroupsConfig          `toml:"backend_groups"`
+	RPCMethodMappings            map[string]string            `toml:"rpc_method_mappings"`
+	WSMethodWhitelist            []string                     `toml:"ws_method_whitelist"`
+	WhitelistErrorMessage        string                       `toml:"whitelist_error_message"`
+	SenderRateLimit              SenderRateLimitConfig        `toml:"sender_rate_limit"`
+	InteropValidationConfig      InteropValidationConfig      `toml:"interop_validation"`
+	TxValidationMiddlewareConfig TxValidationMiddlewareConfig `toml:"tx_validation_middleware"`
 }
 
 type InteropValidationConfig struct {

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -134,17 +134,23 @@ eth_blockNumber = "alchemy"
 
 # Transaction validation middleware configuration.
 # This middleware can validate transactions before they are forwarded to backends.
+# Note: API keys only bypass rate limits, not transaction validation.
 [tx_validation_middleware]
 # Enable or disable the validation middleware, default false
 enabled = false
 # The URL of the validation middleware service endpoint
 # endpoint = "https://your-validation-service.example.com/validate"
-# List of RPC methods to apply validation to, defaults to ["eth_sendRawTransaction", "eth_sendBundle"]
-# methods = ["eth_sendRawTransaction", "eth_sendBundle"]
+# List of RPC methods to apply validation to.
+# Defaults to ["eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle"]
+# methods = ["eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle"]
 # Timeout in seconds for validation HTTP requests, default 5
 # timeout_seconds = 5
+# Whether to allow transactions through if the validation service returns an error.
+# Defaults to true (fail-open) for safety - service disruptions won't block all transactions.
+# Set to false to reject transactions when the validation service is unavailable.
+# fail_open = true
 # Field mappings to transform the transaction object before sending to the middleware.
-# If empty (default), the full transaction object is sent.
+# If empty (default), the full transaction object is sent in go-ethereum's native JSON format.
 # Example: To send only the sender address in the format {"address": "<from_address>"}:
 # [[tx_validation_middleware.field_mappings]]
 # source_field = "from"

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -131,3 +131,22 @@ secret = "test"
 eth_call = "main"
 eth_chainId = "main"
 eth_blockNumber = "alchemy"
+
+# Transaction validation middleware configuration.
+# This middleware can validate transactions before they are forwarded to backends.
+[tx_validation_middleware]
+# Enable or disable the validation middleware, default false
+enabled = false
+# The URL of the validation middleware service endpoint
+# endpoint = "https://your-validation-service.example.com/validate"
+# List of RPC methods to apply validation to, defaults to ["eth_sendRawTransaction", "eth_sendBundle"]
+# methods = ["eth_sendRawTransaction", "eth_sendBundle"]
+# Timeout in seconds for validation HTTP requests, default 5
+# timeout_seconds = 5
+# Field mappings to transform the transaction object before sending to the middleware.
+# If empty (default), the full transaction object is sent.
+# Example: To send only the sender address in the format {"address": "<from_address>"}:
+# [[tx_validation_middleware.field_mappings]]
+# source_field = "from"
+# target_field = "address"
+# Supported source fields: from, to, value, data, nonce, gas, gasPrice, chainId, hash, type, maxFeePerGas, maxPriorityFeePerGas

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -134,7 +134,6 @@ eth_blockNumber = "alchemy"
 
 # Transaction validation middleware configuration.
 # This middleware can validate transactions before they are forwarded to backends.
-# Note: API keys only bypass rate limits, not transaction validation.
 [tx_validation_middleware]
 # Enable or disable the validation middleware, default false
 enabled = true

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -137,22 +137,15 @@ eth_blockNumber = "alchemy"
 # Note: API keys only bypass rate limits, not transaction validation.
 [tx_validation_middleware]
 # Enable or disable the validation middleware, default false
-enabled = false
+enabled = true
 # The URL of the validation middleware service endpoint
-# endpoint = "https://your-validation-service.example.com/validate"
+endpoint = "https://your-validation-service.example.com/validate"
 # List of RPC methods to apply validation to.
 # Defaults to ["eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle"]
-# methods = ["eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle"]
+methods = ["eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle"]
 # Timeout in seconds for validation HTTP requests, default 5
-# timeout_seconds = 5
+timeout_seconds = 5
 # Whether to allow transactions through if the validation service returns an error.
 # Defaults to true (fail-open) for safety - service disruptions won't block all transactions.
 # Set to false to reject transactions when the validation service is unavailable.
-# fail_open = true
-# Field mappings to transform the transaction object before sending to the middleware.
-# If empty (default), the full transaction object is sent in go-ethereum's native JSON format.
-# Example: To send only the sender address in the format {"address": "<from_address>"}:
-# [[tx_validation_middleware.field_mappings]]
-# source_field = "from"
-# target_field = "address"
-# Supported source fields: from, to, value, data, nonce, gas, gasPrice, chainId, hash, type, maxFeePerGas, maxPriorityFeePerGas
+fail_open = true

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -253,8 +253,11 @@ func Start(config *Config) (*Server, func(), error) {
 		log.Info("tx validation middleware enabled",
 			"endpoint", config.TxValidationMiddlewareConfig.Endpoint,
 			"methods", config.TxValidationMiddlewareConfig.Methods,
-			"field_mappings_count", len(config.TxValidationMiddlewareConfig.FieldMappings),
 		)
+		if len(config.TxValidationMiddlewareConfig.Methods) == 0 {
+			log.Warn("tx_validation_middleware enabled without explicit methods config, using defaults",
+				"default_methods", DefaultTxValidationMethods)
+		}
 	}
 
 	if config.InteropValidationConfig.LoadBalancingUnhealthinessTimeout == 0 && config.InteropValidationConfig.Strategy == HealthAwareLoadBalancingStrategy {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -245,6 +245,18 @@ func Start(config *Config) (*Server, func(), error) {
 		config.InteropValidationConfig.Strategy = defaultInteropValidationStrategy
 	}
 
+	if config.TxValidationMiddlewareConfig.Enabled && config.TxValidationMiddlewareConfig.Endpoint == "" {
+		return nil, nil, errors.New("tx_validation_middleware is enabled but no endpoint is configured")
+	}
+
+	if config.TxValidationMiddlewareConfig.Enabled {
+		log.Info("tx validation middleware enabled",
+			"endpoint", config.TxValidationMiddlewareConfig.Endpoint,
+			"methods", config.TxValidationMiddlewareConfig.Methods,
+			"field_mappings_count", len(config.TxValidationMiddlewareConfig.FieldMappings),
+		)
+	}
+
 	if config.InteropValidationConfig.LoadBalancingUnhealthinessTimeout == 0 && config.InteropValidationConfig.Strategy == HealthAwareLoadBalancingStrategy {
 		log.Warn("no interop validation load balancing unhealthiness timeout provided for health aware strategy, using default timeout", "timeout", defaultInteropLoadBalancingUnhealthinessTimeout)
 		config.InteropValidationConfig.LoadBalancingUnhealthinessTimeout = defaultInteropLoadBalancingUnhealthinessTimeout
@@ -446,6 +458,7 @@ func Start(config *Config) (*Server, func(), error) {
 		interopStrategy,
 		config.Server.EnableTxHashLogging,
 		apiKeys,
+		config.TxValidationMiddlewareConfig,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -645,7 +645,6 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 		}
 
 		// Apply transaction validation middleware if enabled and method is configured.
-		// Note: API keys only bypass rate limits, not transaction validation.
 		if s.enableTxValidation && s.txValidationMethods.Contains(parsedReq.Method) {
 			if err := s.applyTxValidation(ctx, parsedReq); err != nil {
 				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -91,13 +91,12 @@ type Server struct {
 	publicAccess            bool
 	enableTxHashLogging     bool
 
-	enableTxValidation        bool
-	txValidationFn            TxValidationFunc
-	txValidationEndpoint      string
-	txValidationMethods       TxValidationMethodSet
-	txValidationFieldMappings []TxFieldMapping
-	txValidationClient        *TxValidationClient
-	txValidationFailOpen      bool
+	enableTxValidation   bool
+	txValidationFn       TxValidationFunc
+	txValidationEndpoint string
+	txValidationMethods  TxValidationMethodSet
+	txValidationClient   *TxValidationClient
+	txValidationFailOpen bool
 }
 
 type limiterFunc func(method string) bool
@@ -205,7 +204,7 @@ func NewServer(
 		txValidationMethods = defaultTxValidationMethods()
 		if txValidationConfig.Enabled {
 			log.Warn("tx_validation_middleware enabled without explicit methods config, using defaults",
-				"default_methods", []string{"eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle"})
+				"default_methods", DefaultTxValidationMethods)
 		}
 	} else {
 		txValidationMethods = NewTxValidationMethodSet(txValidationConfig.Methods)
@@ -236,26 +235,25 @@ func NewServer(
 		upgrader: &websocket.Upgrader{
 			HandshakeTimeout: defaultWSHandshakeTimeout,
 		},
-		mainLim:                   mainLim,
-		overrideLims:              overrideLims,
-		globallyLimitedMethods:    globalMethodLims,
-		senderLim:                 senderLim,
-		interopSenderLim:          interopSenderLim,
-		allowedChainIds:           senderRateLimitConfig.AllowedChainIds,
-		limExemptOrigins:          limExemptOrigins,
-		limExemptUserAgents:       limExemptUserAgents,
-		limExemptKeys:             limExemptKeys,
-		rateLimitHeader:           rateLimitHeader,
-		interopValidatingConfig:   interopValidatingConfig,
-		interopStrategy:           interopStrategy,
-		enableTxHashLogging:       enableTxHashLogging,
-		enableTxValidation:        txValidationConfig.Enabled,
-		txValidationFn:            txValidationClient.Validate,
-		txValidationEndpoint:      txValidationConfig.Endpoint,
-		txValidationMethods:       txValidationMethods,
-		txValidationFieldMappings: txValidationConfig.FieldMappings,
-		txValidationClient:        txValidationClient,
-		txValidationFailOpen:      txValidationFailOpen,
+		mainLim:                 mainLim,
+		overrideLims:            overrideLims,
+		globallyLimitedMethods:  globalMethodLims,
+		senderLim:               senderLim,
+		interopSenderLim:        interopSenderLim,
+		allowedChainIds:         senderRateLimitConfig.AllowedChainIds,
+		limExemptOrigins:        limExemptOrigins,
+		limExemptUserAgents:     limExemptUserAgents,
+		limExemptKeys:           limExemptKeys,
+		rateLimitHeader:         rateLimitHeader,
+		interopValidatingConfig: interopValidatingConfig,
+		interopStrategy:         interopStrategy,
+		enableTxHashLogging:     enableTxHashLogging,
+		enableTxValidation:      txValidationConfig.Enabled,
+		txValidationFn:          txValidationClient.Validate,
+		txValidationEndpoint:    txValidationConfig.Endpoint,
+		txValidationMethods:     txValidationMethods,
+		txValidationClient:      txValidationClient,
+		txValidationFailOpen:    txValidationFailOpen,
 	}, nil
 }
 
@@ -1124,7 +1122,7 @@ func (s *Server) applyTxValidation(ctx context.Context, req *RPCReq) error {
 		return nil
 	}
 
-	return validateTransactions(ctx, txs, s.txValidationEndpoint, s.txValidationFieldMappings, s.txValidationFn, s.txValidationFailOpen)
+	return validateTransactions(ctx, txs, s.txValidationEndpoint, s.txValidationFn, s.txValidationFailOpen)
 }
 
 // SetTxValidationFn allows overriding the transaction validation function for testing.

--- a/proxyd/tx_validation_middleware.go
+++ b/proxyd/tx_validation_middleware.go
@@ -1,0 +1,385 @@
+package proxyd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	maxBundleTransactions            = 100
+	defaultValidationTimeoutSeconds  = 5
+	defaultValidationMaxIdleConns    = 10
+	defaultValidationIdleConnTimeout = 30 * time.Second
+	defaultValidationMaxConnsPerHost = 10
+)
+
+// TxValidationFunc validates a transaction and returns true if it should be rejected.
+// The endpoint is the middleware service URL, and payload is the request body to send.
+type TxValidationFunc func(ctx context.Context, endpoint string, payload []byte) (bool, error)
+
+// TxFieldMapping defines how to extract a field from a transaction and map it to the middleware request.
+type TxFieldMapping struct {
+	// SourceField is the transaction field to extract (e.g., "from", "to", "value", "data")
+	SourceField string `toml:"source_field"`
+	// TargetField is the field name in the middleware request body
+	TargetField string `toml:"target_field"`
+}
+
+// TxValidationMiddlewareConfig configures the transaction validation middleware.
+type TxValidationMiddlewareConfig struct {
+	// Enabled determines whether the middleware is active
+	Enabled bool `toml:"enabled"`
+
+	// Endpoint is the URL of the validation middleware service
+	Endpoint string `toml:"endpoint"`
+
+	// Methods is the list of RPC methods to apply validation to.
+	// Defaults to ["eth_sendRawTransaction", "eth_sendBundle"] if not specified.
+	Methods []string `toml:"methods"`
+
+	// FieldMappings defines how to transform the transaction into the middleware request format.
+	// If empty, the full transaction object is sent as-is.
+	// Example: [{ source_field = "from", target_field = "address" }] will send {"address": "<from_address>"}
+	FieldMappings []TxFieldMapping `toml:"field_mappings"`
+
+	// TimeoutSeconds is the timeout for validation HTTP requests. Defaults to 5 seconds.
+	TimeoutSeconds int `toml:"timeout_seconds"`
+}
+
+// TxValidationClient is a reusable HTTP client for validation requests.
+type TxValidationClient struct {
+	client  *http.Client
+	timeout time.Duration
+}
+
+var (
+	defaultTxValidationClient     *TxValidationClient
+	defaultTxValidationClientOnce sync.Once
+)
+
+// NewTxValidationClient creates a new validation client with the given timeout.
+func NewTxValidationClient(timeoutSeconds int) *TxValidationClient {
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = defaultValidationTimeoutSeconds
+	}
+	return &TxValidationClient{
+		client: &http.Client{
+			Transport: &http.Transport{
+				MaxIdleConns:    defaultValidationMaxIdleConns,
+				MaxConnsPerHost: defaultValidationMaxConnsPerHost,
+				IdleConnTimeout: defaultValidationIdleConnTimeout,
+			},
+		},
+		timeout: time.Duration(timeoutSeconds) * time.Second,
+	}
+}
+
+// getDefaultTxValidationClient returns the shared default validation client.
+func getDefaultTxValidationClient() *TxValidationClient {
+	defaultTxValidationClientOnce.Do(func() {
+		defaultTxValidationClient = NewTxValidationClient(defaultValidationTimeoutSeconds)
+	})
+	return defaultTxValidationClient
+}
+
+// Validate performs the HTTP request to the validation middleware service.
+func (c *TxValidationClient) Validate(ctx context.Context, endpoint string, payload []byte) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(payload))
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, err
+	}
+
+	var validationRes txValidationResponse
+	if err := json.Unmarshal(body, &validationRes); err != nil {
+		return false, err
+	}
+
+	if msg := validationRes.ErrorCode + validationRes.ErrorMessage; msg != "" {
+		return false, ErrInternal
+	}
+	return validationRes.Block, nil
+}
+
+// txValidation is the default validation function using the shared client.
+func txValidation(ctx context.Context, endpoint string, payload []byte) (bool, error) {
+	return getDefaultTxValidationClient().Validate(ctx, endpoint, payload)
+}
+
+// txValidationResponse represents the response from the validation middleware.
+type txValidationResponse struct {
+	Block        bool   `json:"block"`
+	ErrorCode    string `json:"errorCode"`
+	ErrorMessage string `json:"errorMessage"`
+}
+
+// buildValidationPayload creates the request payload for the validation middleware.
+// If fieldMappings is empty, it returns the full transaction as JSON.
+// Otherwise, it extracts the specified fields and maps them to the target field names.
+func buildValidationPayload(tx *types.Transaction, from common.Address, fieldMappings []TxFieldMapping) ([]byte, error) {
+	if len(fieldMappings) == 0 {
+		return buildFullTxPayload(tx, from)
+	}
+	return buildMappedPayload(tx, from, fieldMappings)
+}
+
+// buildFullTxPayload creates a payload containing the full transaction details.
+func buildFullTxPayload(tx *types.Transaction, from common.Address) ([]byte, error) {
+	payload := map[string]interface{}{
+		"from":     from.Hex(),
+		"nonce":    tx.Nonce(),
+		"gasPrice": tx.GasPrice().String(),
+		"gas":      tx.Gas(),
+		"value":    tx.Value().String(),
+		"data":     common.Bytes2Hex(tx.Data()),
+		"chainId":  tx.ChainId().String(),
+		"hash":     tx.Hash().Hex(),
+		"type":     tx.Type(),
+	}
+
+	if tx.To() != nil {
+		payload["to"] = tx.To().Hex()
+	}
+
+	if tx.Type() >= types.DynamicFeeTxType {
+		payload["maxFeePerGas"] = tx.GasFeeCap().String()
+		payload["maxPriorityFeePerGas"] = tx.GasTipCap().String()
+	}
+
+	return json.Marshal(payload)
+}
+
+// buildMappedPayload creates a payload with only the mapped fields.
+func buildMappedPayload(tx *types.Transaction, from common.Address, mappings []TxFieldMapping) ([]byte, error) {
+	payload := make(map[string]interface{})
+
+	for _, mapping := range mappings {
+		value := extractTxField(tx, from, mapping.SourceField)
+		if value != nil {
+			payload[mapping.TargetField] = value
+		}
+	}
+
+	return json.Marshal(payload)
+}
+
+// extractTxField extracts a field value from the transaction.
+func extractTxField(tx *types.Transaction, from common.Address, field string) interface{} {
+	switch field {
+	case "from":
+		return from.Hex()
+	case "to":
+		if tx.To() != nil {
+			return tx.To().Hex()
+		}
+		return nil
+	case "value":
+		return tx.Value().String()
+	case "data":
+		return common.Bytes2Hex(tx.Data())
+	case "nonce":
+		return tx.Nonce()
+	case "gas":
+		return tx.Gas()
+	case "gasPrice":
+		return tx.GasPrice().String()
+	case "chainId":
+		return tx.ChainId().String()
+	case "hash":
+		return tx.Hash().Hex()
+	case "type":
+		return tx.Type()
+	case "maxFeePerGas":
+		if tx.Type() >= types.DynamicFeeTxType {
+			return tx.GasFeeCap().String()
+		}
+		return nil
+	case "maxPriorityFeePerGas":
+		if tx.Type() >= types.DynamicFeeTxType {
+			return tx.GasTipCap().String()
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+// TxValidationMethodSet is a set of methods that should be validated.
+type TxValidationMethodSet map[string]struct{}
+
+// Contains checks if the given method should be validated.
+func (s TxValidationMethodSet) Contains(method string) bool {
+	_, ok := s[method]
+	return ok
+}
+
+// NewTxValidationMethodSet creates a set from a slice of methods.
+func NewTxValidationMethodSet(methods []string) TxValidationMethodSet {
+	set := make(TxValidationMethodSet, len(methods))
+	for _, m := range methods {
+		set[m] = struct{}{}
+	}
+	return set
+}
+
+// defaultTxValidationMethods returns the default set of methods to validate.
+func defaultTxValidationMethods() TxValidationMethodSet {
+	return TxValidationMethodSet{
+		"eth_sendRawTransaction": {},
+		"eth_sendBundle":         {},
+	}
+}
+
+// validateTransactions validates multiple transactions in parallel using errgroup.
+func validateTransactions(
+	ctx context.Context,
+	txs []*types.Transaction,
+	endpoint string,
+	fieldMappings []TxFieldMapping,
+	validationFn TxValidationFunc,
+) error {
+	if len(txs) > maxBundleTransactions {
+		log.Warn("bundle contains too many transactions",
+			"req_id", GetReqID(ctx),
+			"tx_count", len(txs),
+			"max_allowed", maxBundleTransactions)
+		return ErrInvalidParams(fmt.Sprintf("bundle contains %d transactions, maximum allowed is %d", len(txs), maxBundleTransactions))
+	}
+
+	var g errgroup.Group
+	for _, tx := range txs {
+		tx := tx // capture loop variable
+		g.Go(func() error {
+			return validateSingleTransaction(ctx, tx, endpoint, fieldMappings, validationFn)
+		})
+	}
+	return g.Wait()
+}
+
+// validateSingleTransaction validates a single transaction against the middleware service.
+func validateSingleTransaction(
+	ctx context.Context,
+	tx *types.Transaction,
+	endpoint string,
+	fieldMappings []TxFieldMapping,
+	validationFn TxValidationFunc,
+) error {
+	var signer types.Signer
+	if tx.ChainId().Sign() == 0 {
+		signer = new(types.HomesteadSigner)
+	} else {
+		signer = types.LatestSignerForChainID(tx.ChainId())
+	}
+
+	from, err := types.Sender(signer, tx)
+	if err != nil {
+		log.Debug("could not get sender from transaction for validation", "err", err, "req_id", GetReqID(ctx))
+		return ErrInvalidParams(err.Error())
+	}
+
+	payload, err := buildValidationPayload(tx, from, fieldMappings)
+	if err != nil {
+		log.Error("error building validation payload", "err", err, "req_id", GetReqID(ctx))
+		return ErrInternal
+	}
+
+	block, validationErr := validationFn(ctx, endpoint, payload)
+	if validationErr != nil {
+		log.Warn("tx validation service error, allowing transaction through",
+			"req_id", GetReqID(ctx),
+			"from", from.Hex(),
+			"error", validationErr,
+			"chain_id", tx.ChainId(),
+			"nonce", tx.Nonce(),
+			"value", tx.Value(),
+			"tx_hash", tx.Hash().Hex(),
+		)
+		return nil
+	}
+
+	if block {
+		log.Info("transaction rejected by validation middleware",
+			"req_id", GetReqID(ctx),
+			"from", from.Hex(),
+			"tx_hash", tx.Hash().Hex(),
+		)
+		return ErrTransactionRejected
+	}
+	return nil
+}
+
+// transactionsFromBundleReq extracts transactions from an eth_sendBundle request.
+func transactionsFromBundleReq(ctx context.Context, req *RPCReq) ([]*types.Transaction, error) {
+	var params []json.RawMessage
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		log.Debug("error unmarshalling bundle params", "err", err, "req_id", GetReqID(ctx))
+		return nil, ErrParseErr
+	}
+	if len(params) < 1 {
+		log.Debug("bundle request missing params", "req_id", GetReqID(ctx))
+		return nil, ErrInvalidParams("missing bundle params")
+	}
+	var bundle struct {
+		Txs []string `json:"txs"`
+	}
+	if err := json.Unmarshal(params[0], &bundle); err != nil {
+		log.Debug("error unmarshalling bundle object", "err", err, "req_id", GetReqID(ctx))
+		return nil, ErrInvalidParams(err.Error())
+	}
+	if len(bundle.Txs) == 0 {
+		log.Debug("bundle has no txs", "req_id", GetReqID(ctx))
+		return nil, ErrInvalidParams("bundle has no txs")
+	}
+	txs := make([]*types.Transaction, 0, len(bundle.Txs))
+	for i, txHex := range bundle.Txs {
+		tx, err := decodeSignedTx(ctx, txHex)
+		if err != nil {
+			log.Debug("failed to decode tx in bundle", "index", i, "err", err, "req_id", GetReqID(ctx))
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+	return txs, nil
+}
+
+// decodeSignedTx decodes a hex-encoded signed transaction.
+func decodeSignedTx(ctx context.Context, txHex string) (*types.Transaction, error) {
+	var data hexutil.Bytes
+	if err := data.UnmarshalText([]byte(txHex)); err != nil {
+		log.Debug("error decoding raw tx data", "err", err, "req_id", GetReqID(ctx))
+		return nil, ErrInvalidParams(err.Error())
+	}
+
+	tx := new(types.Transaction)
+	if err := tx.UnmarshalBinary(data); err != nil {
+		log.Debug("could not unmarshal transaction", "err", err, "req_id", GetReqID(ctx))
+		return nil, ErrInvalidParams(err.Error())
+	}
+	return tx, nil
+}

--- a/proxyd/tx_validation_middleware.go
+++ b/proxyd/tx_validation_middleware.go
@@ -224,7 +224,7 @@ func buildTxsWithSenders(ctx context.Context, txs []*types.Transaction) (map[str
 			return nil, ErrInvalidParams(err.Error())
 		}
 
-		// Marshal tx to JSON, then unmarshal to map to get all fields
+		// Marshal txn to JSON, then unmarshal to map to get all fields
 		txJSON, err := tx.MarshalJSON()
 		if err != nil {
 			log.Debug("could not marshal transaction for validation", "err", err, "req_id", GetReqID(ctx))

--- a/proxyd/tx_validation_middleware.go
+++ b/proxyd/tx_validation_middleware.go
@@ -111,9 +111,17 @@ type txValidationResponse struct {
 	ErrorMessage string          `json:"errorMessage"`
 }
 
-// buildValidationPayload builds a batch request payload mapping tx hashes to flattened tx objects with "from".
+// txValidationRequest is the request payload sent to the validation service.
+type txValidationRequest struct {
+	Txs map[string]map[string]interface{} `json:"txs"`
+}
+
+// buildValidationPayload builds a batch request payload with txs mapped by hash.
 func buildValidationPayload(txsWithSenders map[string]map[string]interface{}) ([]byte, error) {
-	return json.Marshal(txsWithSenders)
+	req := txValidationRequest{
+		Txs: txsWithSenders,
+	}
+	return json.Marshal(req)
 }
 
 type TxValidationMethodSet map[string]struct{}

--- a/proxyd/tx_validation_middleware.go
+++ b/proxyd/tx_validation_middleware.go
@@ -139,7 +139,7 @@ type txValidationResponse struct {
 	ErrorMessage string `json:"errorMessage"`
 }
 
-// buildValidationPayload creates the request payload for the validation middleware.
+// creates the request payload for the validation middleware.
 // If fieldMappings is empty, it returns the full transaction as JSON.
 // Otherwise, it extracts the specified fields and maps them to the target field names.
 func buildValidationPayload(tx *types.Transaction, from common.Address, fieldMappings []TxFieldMapping) ([]byte, error) {
@@ -149,33 +149,16 @@ func buildValidationPayload(tx *types.Transaction, from common.Address, fieldMap
 	return buildMappedPayload(tx, from, fieldMappings)
 }
 
-// buildFullTxPayload creates a payload containing the full transaction details.
+// creates a payload containing the full transaction details, including 'from' address
 func buildFullTxPayload(tx *types.Transaction, from common.Address) ([]byte, error) {
 	payload := map[string]interface{}{
-		"from":     from.Hex(),
-		"nonce":    tx.Nonce(),
-		"gasPrice": tx.GasPrice().String(),
-		"gas":      tx.Gas(),
-		"value":    tx.Value().String(),
-		"data":     common.Bytes2Hex(tx.Data()),
-		"chainId":  tx.ChainId().String(),
-		"hash":     tx.Hash().Hex(),
-		"type":     tx.Type(),
+		"tx":   tx,
+		"from": from.Hex(),
 	}
-
-	if tx.To() != nil {
-		payload["to"] = tx.To().Hex()
-	}
-
-	if tx.Type() >= types.DynamicFeeTxType {
-		payload["maxFeePerGas"] = tx.GasFeeCap().String()
-		payload["maxPriorityFeePerGas"] = tx.GasTipCap().String()
-	}
-
 	return json.Marshal(payload)
 }
 
-// buildMappedPayload creates a payload with only the mapped fields.
+// creates a payload with only the mapped fields.
 func buildMappedPayload(tx *types.Transaction, from common.Address, mappings []TxFieldMapping) ([]byte, error) {
 	payload := make(map[string]interface{})
 

--- a/proxyd/tx_validation_middleware_test.go
+++ b/proxyd/tx_validation_middleware_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestBuildValidationPayload_FullTx(t *testing.T) {
-	tx := createTestTransaction(t)
+	tx := createSignedTestTransaction(t) // Use signed tx with chainId
 	from := common.HexToAddress("0x1234567890123456789012345678901234567890")
 
 	payload, err := buildValidationPayload(tx, from, nil)
@@ -27,12 +27,21 @@ func TestBuildValidationPayload_FullTx(t *testing.T) {
 	err = json.Unmarshal(payload, &result)
 	require.NoError(t, err)
 
+	// Full tx payload uses go-ethereum's native Transaction JSON format
+	// with "from" added separately at the top level
 	require.Equal(t, from.Hex(), result["from"])
-	require.NotNil(t, result["nonce"])
-	require.NotNil(t, result["gas"])
-	require.NotNil(t, result["value"])
-	require.NotNil(t, result["hash"])
-	require.NotNil(t, result["chainId"])
+	require.NotNil(t, result["tx"])
+
+	txObj, ok := result["tx"].(map[string]interface{})
+	require.True(t, ok)
+
+	// Native format uses hex strings and "input" instead of "data"
+	require.NotNil(t, txObj["nonce"])
+	require.NotNil(t, txObj["gas"])
+	require.NotNil(t, txObj["value"])
+	require.NotNil(t, txObj["hash"])
+	require.NotNil(t, txObj["chainId"])
+	require.NotNil(t, txObj["type"])
 }
 
 func TestBuildValidationPayload_MappedFields(t *testing.T) {

--- a/proxyd/tx_validation_middleware_test.go
+++ b/proxyd/tx_validation_middleware_test.go
@@ -1,0 +1,422 @@
+package proxyd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildValidationPayload_FullTx(t *testing.T) {
+	tx := createTestTransaction(t)
+	from := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	payload, err := buildValidationPayload(tx, from, nil)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(payload, &result)
+	require.NoError(t, err)
+
+	require.Equal(t, from.Hex(), result["from"])
+	require.NotNil(t, result["nonce"])
+	require.NotNil(t, result["gas"])
+	require.NotNil(t, result["value"])
+	require.NotNil(t, result["hash"])
+	require.NotNil(t, result["chainId"])
+}
+
+func TestBuildValidationPayload_MappedFields(t *testing.T) {
+	tx := createTestTransaction(t)
+	from := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	mappings := []TxFieldMapping{
+		{SourceField: "from", TargetField: "address"},
+	}
+
+	payload, err := buildValidationPayload(tx, from, mappings)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(payload, &result)
+	require.NoError(t, err)
+
+	require.Equal(t, from.Hex(), result["address"])
+	require.Nil(t, result["from"])
+	require.Nil(t, result["nonce"])
+}
+
+func TestBuildValidationPayload_MultipleMappings(t *testing.T) {
+	tx := createTestTransaction(t)
+	from := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	mappings := []TxFieldMapping{
+		{SourceField: "from", TargetField: "sender"},
+		{SourceField: "value", TargetField: "amount"},
+		{SourceField: "hash", TargetField: "txHash"},
+	}
+
+	payload, err := buildValidationPayload(tx, from, mappings)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(payload, &result)
+	require.NoError(t, err)
+
+	require.Equal(t, from.Hex(), result["sender"])
+	require.NotNil(t, result["amount"])
+	require.NotNil(t, result["txHash"])
+	require.Nil(t, result["from"])
+}
+
+func TestExtractTxField(t *testing.T) {
+	tx := createTestTransaction(t)
+	from := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	tests := []struct {
+		field    string
+		expected bool
+	}{
+		{"from", true},
+		{"nonce", true},
+		{"gas", true},
+		{"value", true},
+		{"data", true},
+		{"hash", true},
+		{"chainId", true},
+		{"type", true},
+		{"invalid", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			result := extractTxField(tx, from, tt.field)
+			if tt.expected {
+				require.NotNil(t, result)
+			} else {
+				require.Nil(t, result)
+			}
+		})
+	}
+}
+
+func TestTxValidationMethodSet(t *testing.T) {
+	methods := NewTxValidationMethodSet([]string{"eth_sendRawTransaction", "eth_sendBundle"})
+
+	require.True(t, methods.Contains("eth_sendRawTransaction"))
+	require.True(t, methods.Contains("eth_sendBundle"))
+	require.False(t, methods.Contains("eth_getBalance"))
+	require.False(t, methods.Contains(""))
+}
+
+func TestDefaultTxValidationMethods(t *testing.T) {
+	methods := defaultTxValidationMethods()
+	require.True(t, methods.Contains("eth_sendRawTransaction"))
+	require.True(t, methods.Contains("eth_sendBundle"))
+}
+
+func TestTxValidation_BlockResponse(t *testing.T) {
+	alwaysBlock := func(ctx context.Context, endpoint string, payload []byte) (bool, error) {
+		return true, nil
+	}
+
+	block, err := alwaysBlock(context.Background(), "http://test", []byte(`{}`))
+	require.NoError(t, err)
+	require.True(t, block)
+}
+
+func TestTxValidation_AllowResponse(t *testing.T) {
+	neverBlock := func(ctx context.Context, endpoint string, payload []byte) (bool, error) {
+		return false, nil
+	}
+
+	block, err := neverBlock(context.Background(), "http://test", []byte(`{}`))
+	require.NoError(t, err)
+	require.False(t, block)
+}
+
+func createTestTransaction(t *testing.T) *types.Transaction {
+	to := common.HexToAddress("0x0987654321098765432109876543210987654321")
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    1,
+		GasPrice: big.NewInt(1000000000),
+		Gas:      21000,
+		To:       &to,
+		Value:    big.NewInt(1000000000000000000),
+		Data:     []byte{},
+	})
+	return tx
+}
+
+func createSignedTestTransaction(t *testing.T) *types.Transaction {
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	to := common.HexToAddress("0x0987654321098765432109876543210987654321")
+	chainID := big.NewInt(1) // Use mainnet chain ID
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     1,
+		GasFeeCap: big.NewInt(1000000000),
+		GasTipCap: big.NewInt(1000000000),
+		Gas:       21000,
+		To:        &to,
+		Value:     big.NewInt(1000000000000000000),
+		Data:      []byte{},
+	})
+
+	signer := types.LatestSignerForChainID(chainID)
+	signedTx, err := types.SignTx(tx, signer, privateKey)
+	require.NoError(t, err)
+	return signedTx
+}
+
+func TestValidateTransactions_SingleTx(t *testing.T) {
+	tx := createSignedTestTransaction(t)
+
+	validationCalled := false
+	mockValidation := func(ctx context.Context, endpoint string, payload []byte) (bool, error) {
+		validationCalled = true
+		return false, nil
+	}
+
+	err := validateTransactions(context.Background(), []*types.Transaction{tx}, "http://test", nil, mockValidation)
+	require.NoError(t, err)
+	require.True(t, validationCalled)
+}
+
+func TestValidateTransactions_MultipleTxs(t *testing.T) {
+	txs := make([]*types.Transaction, 3)
+	for i := 0; i < 3; i++ {
+		txs[i] = createSignedTestTransaction(t)
+	}
+
+	callCount := 0
+	mockValidation := func(ctx context.Context, endpoint string, payload []byte) (bool, error) {
+		callCount++
+		return false, nil
+	}
+
+	err := validateTransactions(context.Background(), txs, "http://test", nil, mockValidation)
+	require.NoError(t, err)
+	require.Equal(t, 3, callCount)
+}
+
+func TestValidateTransactions_BlocksOnFirstRejection(t *testing.T) {
+	txs := make([]*types.Transaction, 3)
+	for i := 0; i < 3; i++ {
+		txs[i] = createSignedTestTransaction(t)
+	}
+
+	mockValidation := func(ctx context.Context, endpoint string, payload []byte) (bool, error) {
+		return true, nil // block all
+	}
+
+	err := validateTransactions(context.Background(), txs, "http://test", nil, mockValidation)
+	require.Error(t, err)
+	require.Equal(t, ErrTransactionRejected, err)
+}
+
+func TestValidateTransactions_TooManyTxs(t *testing.T) {
+	txs := make([]*types.Transaction, maxBundleTransactions+1)
+	for i := 0; i <= maxBundleTransactions; i++ {
+		txs[i] = createSignedTestTransaction(t)
+	}
+
+	mockValidation := func(ctx context.Context, endpoint string, payload []byte) (bool, error) {
+		return false, nil
+	}
+
+	err := validateTransactions(context.Background(), txs, "http://test", nil, mockValidation)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "maximum allowed")
+}
+
+func TestValidateTransactions_ServiceError_AllowsThrough(t *testing.T) {
+	tx := createSignedTestTransaction(t)
+
+	mockValidation := func(ctx context.Context, endpoint string, payload []byte) (bool, error) {
+		return false, errors.New("service unavailable")
+	}
+
+	err := validateTransactions(context.Background(), []*types.Transaction{tx}, "http://test", nil, mockValidation)
+	require.NoError(t, err)
+}
+
+func TestTxValidationClient_HTTPServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "POST", r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"block": false}`))
+	}))
+	defer server.Close()
+
+	client := NewTxValidationClient(5)
+	block, err := client.Validate(context.Background(), server.URL, []byte(`{"address": "0x123"}`))
+	require.NoError(t, err)
+	require.False(t, block)
+}
+
+func TestTxValidationClient_BlockResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"block": true}`))
+	}))
+	defer server.Close()
+
+	client := NewTxValidationClient(5)
+	block, err := client.Validate(context.Background(), server.URL, []byte(`{"address": "0x123"}`))
+	require.NoError(t, err)
+	require.True(t, block)
+}
+
+func TestTxValidationClient_ErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"block": false, "errorCode": "ERR001", "errorMessage": "internal error"}`))
+	}))
+	defer server.Close()
+
+	client := NewTxValidationClient(5)
+	_, err := client.Validate(context.Background(), server.URL, []byte(`{"address": "0x123"}`))
+	require.Error(t, err)
+	require.Equal(t, ErrInternal, err)
+}
+
+func TestDecodeSignedTx(t *testing.T) {
+	tx := createSignedTestTransaction(t)
+	txBytes, err := tx.MarshalBinary()
+	require.NoError(t, err)
+
+	// Must have 0x prefix for hexutil.Bytes.UnmarshalText
+	txHex := "0x" + common.Bytes2Hex(txBytes)
+
+	decoded, err := decodeSignedTx(context.Background(), txHex)
+	require.NoError(t, err)
+	require.Equal(t, tx.Hash(), decoded.Hash())
+}
+
+func TestDecodeSignedTx_InvalidHex(t *testing.T) {
+	_, err := decodeSignedTx(context.Background(), "not-valid-hex")
+	require.Error(t, err)
+}
+
+func TestDecodeSignedTx_Missing0xPrefix(t *testing.T) {
+	tx := createSignedTestTransaction(t)
+	txBytes, err := tx.MarshalBinary()
+	require.NoError(t, err)
+
+	// Without 0x prefix, hexutil.Bytes.UnmarshalText returns error
+	txHex := common.Bytes2Hex(txBytes)
+	_, err = decodeSignedTx(context.Background(), txHex)
+	require.Error(t, err)
+}
+
+func TestTxValidationClient_CanceledContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"block": false}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	client := NewTxValidationClient(5)
+	_, err := client.Validate(ctx, server.URL, []byte(`{"address": "0x123"}`))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled))
+}
+
+func TestValidateTransactions_CanceledContext(t *testing.T) {
+	tx := createSignedTestTransaction(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	// Mock validation that returns context error - but due to fail-open behavior,
+	// the error will be logged and transaction allowed through
+	mockValidation := func(ctx context.Context, endpoint string, payload []byte) (bool, error) {
+		return false, ctx.Err()
+	}
+
+	// Due to fail-open behavior (legal requirement), validation service errors
+	// result in allowing the transaction through, not returning an error
+	err := validateTransactions(ctx, []*types.Transaction{tx}, "http://test", nil, mockValidation)
+	require.NoError(t, err) // Transaction is allowed through
+}
+
+func TestValidateSingleTransaction_CanceledContext_FailOpen(t *testing.T) {
+	tx := createSignedTestTransaction(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	// Fail-open behavior: even with canceled context, transaction is allowed through
+	mockValidation := func(ctx context.Context, endpoint string, payload []byte) (bool, error) {
+		return false, context.Canceled
+	}
+
+	err := validateSingleTransaction(ctx, tx, "http://test", nil, mockValidation)
+	require.NoError(t, err) // Allowed through due to fail-open
+}
+
+func TestTransactionsFromBundleReq(t *testing.T) {
+	tx1 := createSignedTestTransaction(t)
+	tx2 := createSignedTestTransaction(t)
+
+	tx1Bytes, _ := tx1.MarshalBinary()
+	tx2Bytes, _ := tx2.MarshalBinary()
+
+	bundleParams := []interface{}{
+		map[string]interface{}{
+			"txs": []string{
+				"0x" + common.Bytes2Hex(tx1Bytes),
+				"0x" + common.Bytes2Hex(tx2Bytes),
+			},
+		},
+	}
+	paramsJSON, _ := json.Marshal(bundleParams)
+
+	req := &RPCReq{
+		Method: "eth_sendBundle",
+		Params: paramsJSON,
+	}
+
+	txs, err := transactionsFromBundleReq(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, txs, 2)
+}
+
+func TestTransactionsFromBundleReq_EmptyBundle(t *testing.T) {
+	bundleParams := []interface{}{
+		map[string]interface{}{
+			"txs": []string{},
+		},
+	}
+	paramsJSON, _ := json.Marshal(bundleParams)
+
+	req := &RPCReq{
+		Method: "eth_sendBundle",
+		Params: paramsJSON,
+	}
+
+	_, err := transactionsFromBundleReq(context.Background(), req)
+	require.Error(t, err)
+}

--- a/proxyd/tx_validation_middleware_test.go
+++ b/proxyd/tx_validation_middleware_test.go
@@ -149,7 +149,7 @@ func TestValidateTransactions_MultipleTxs(t *testing.T) {
 		callCount++
 		// Verify the payload contains all 3 txs wrapped in "txs" field
 		var request struct {
-			Txs map[string]map[string]interface{} `json:"txs"`
+			Txs map[string]TransactionWithFrom `json:"txs"`
 		}
 		err := json.Unmarshal(payload, &request)
 		require.NoError(t, err)

--- a/proxyd/tx_validation_middleware_test.go
+++ b/proxyd/tx_validation_middleware_test.go
@@ -30,7 +30,7 @@ func TestBuildValidationPayload(t *testing.T) {
 	require.NoError(t, err)
 
 	var result struct {
-		Txs map[string]map[string]interface{} `json:"txs"`
+		Txs map[string]TransactionWithFrom `json:"txs"`
 	}
 	err = json.Unmarshal(payload, &result)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Transaction validation middleware with batching, which allows you to specify a custom URL and interface (if needed) to pass transactions to for additional checks. Either allows the group of transactions through, or blocks the entire request (for bundles).

Middleware endpoint has static request and response interfaces, which accept a map of txHash -> txObject (with 'from')

Defaults to fail open in case the middleware returns an error code, which is interpreted as server error.

Supports `eth_sendRawTransaction | eth_sendRawTransactionConditional | eth_sendBundle` currently.

**Tests**

Full unit testing for tx validation middleware file, including all utility functions.

