### PR TITLE
fix(op-acceptor): ensure logs are written to disk for timeout cases

### DIFF
--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -784,6 +784,13 @@ func (n *nat) writeRunArtifacts(runID string) error {
 func (n *nat) Stop(ctx context.Context) error {
 	n.config.Log.Info("Stopping op-acceptor")
 
+	// Flush logs before shutdown to ensure all buffered writes are persisted
+	if n.fileLogger != nil {
+		if err := n.fileLogger.FlushAll(); err != nil {
+			n.config.Log.Error("Error flushing logs during shutdown", "error", err)
+		}
+	}
+
 	// Check if we're already stopped
 	if !n.running.Load() {
 		n.config.Log.Debug("Service already stopped, nothing to do")

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -976,8 +976,9 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 		}
 
 		// Force logging of timeout result to ensure it's captured
+		// Use synchronous logging to ensure writes are flushed to disk before potential process termination
 		if r.fileLogger != nil {
-			if logErr := r.fileLogger.LogTestResult(parsed, r.runID); logErr != nil {
+			if logErr := r.fileLogger.LogTestResultSync(parsed, r.runID); logErr != nil {
 				r.log.Error("Failed to log timeout result", "error", logErr, "test", metadata.FuncName)
 			}
 		}


### PR DESCRIPTION
When tests timeout and CI kills the process (SIGKILL, exit code 137),
buffered writes in AsyncFile were being lost because the background
goroutine never had a chance to flush them.

This adds:
- AsyncFile.Flush() to block until queued writes are synced to disk
- FileLogger.FlushAll() to flush all async writers
- FileLogger.LogTestResultSync() for synchronous logging of timeout results
- Graceful shutdown flush in nat.Stop() to persist logs before exit

This ensures per-test log files exist in logs/testrun-*/failed/ even
when tests are terminated due to timeout.
