### PR TITLE
fix: FIx windows build

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -288,7 +288,7 @@ jobs:
           command: |
             mkdir -p /tmp/goreleaser
             cd /tmp/goreleaser
-            curl -L -o goreleaser.tgz https://github.com/goreleaser/goreleaser-pro/releases/download/v2.4.3-pro/goreleaser-pro_Linux_x86_64.tar.gz
+            curl -L -o goreleaser.tgz https://github.com/goreleaser/goreleaser-pro/releases/download/v2.13.3-pro/goreleaser-pro_Linux_x86_64.tar.gz
             tar -xzvf goreleaser.tgz
             mv goreleaser /usr/local/bin/goreleaser
       - run:

--- a/mise.toml
+++ b/mise.toml
@@ -7,12 +7,18 @@ asterisc = "1.3.0"
 kontrol = "1.0.90"
 binary_signer = "1.0.4"
 
+# Other tooling
+goreleaser-pro = "2.13.3"
+
+
 [alias]
 # These are disabled, but latest mise versions error if they don't have a known
 # install source even though it won't ever actually use that source.
 asterisc = "ubi:ethereum-optimism/fake-asterisc"
 kontrol = "ubi:ethereum-optimism/fake-kontrol"
 binary_signer = "ubi:ethereum-optimism/fake-binary_signer"
+
+goreleaser-pro = "ubi:goreleaser/goreleaser-pro[exe=goreleaser]"
 
 
 [settings]

--- a/proxyd/backend_probe.go
+++ b/proxyd/backend_probe.go
@@ -56,7 +56,7 @@ func probeDialer() *net.Dialer {
 	dialer := &net.Dialer{
 		Control: func(network, address string, c syscall.RawConn) error {
 			return c.Control(func(fd uintptr) {
-				_ = syscall.SetsockoptLinger(int(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, &syscall.Linger{Onoff: 1, Linger: 1})
+				_ = setSockOptLinger(int(fd))
 			})
 		},
 	}

--- a/proxyd/backend_probe.go
+++ b/proxyd/backend_probe.go
@@ -56,7 +56,7 @@ func probeDialer() *net.Dialer {
 	dialer := &net.Dialer{
 		Control: func(network, address string, c syscall.RawConn) error {
 			return c.Control(func(fd uintptr) {
-				_ = setSockOptLinger(int(fd))
+				_ = setSockOptLinger(int(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, &syscall.Linger{Onoff: 1, Linger: 1})
 			})
 		},
 	}

--- a/proxyd/backend_syscall.go
+++ b/proxyd/backend_syscall.go
@@ -4,7 +4,6 @@ package proxyd
 
 import "syscall"
 
-func setSockOptLinger(fd int) error {
-	// Unix only
-	return syscall.SetsockoptLinger(fd, syscall.SOL_SOCKET, syscall.SO_LINGER, &syscall.Linger{Onoff: 1, Linger: 1})
+func setSockOptLinger(fd int, level int, opt int, l *syscall.Linger) error {
+	return syscall.SetsockoptLinger(fd, level, opt, l)
 }

--- a/proxyd/backend_syscall.go
+++ b/proxyd/backend_syscall.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package proxyd
+
+import "syscall"
+
+func setSockOptLinger(fd int) error {
+	// Unix only
+	return syscall.SetsockoptLinger(fd, syscall.SOL_SOCKET, syscall.SO_LINGER, &syscall.Linger{Onoff: 1, Linger: 1})
+}

--- a/proxyd/backend_syscall_windows.go
+++ b/proxyd/backend_syscall_windows.go
@@ -1,8 +1,9 @@
-//go:build !windows
+//go:build windows
 
 package proxyd
 
-func setSockOptLinger(fd int) error {
-	// setSockOptLinger is not supported on Windows
-	return nil
+import "syscall"
+
+func setSockOptLinger(fd int, level int, opt int, l *syscall.Linger) error {
+	return syscall.SetsockoptLinger(syscall.Handle(fd), level, opt, l)
 }

--- a/proxyd/backend_syscall_windows.go
+++ b/proxyd/backend_syscall_windows.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package proxyd
+
+func setSockOptLinger(fd int) error {
+	// setSockOptLinger is not supported on Windows
+	return nil
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- Fixes OS-dependent `syscall` call by providing OS-dependent implementations
- Updates `goreleaser` and adds it to `mise.toml` - this opens up a pathway to use the `mise`-based CI tooling install



[Failing workflow here](https://app.circleci.com/pipelines/github/ethereum-optimism/infra/1764/workflows/c3e0747f-63c5-4cee-bd90-f6a770013de2/jobs/11084)

Related to https://github.com/ethereum-optimism/optimism/issues/19133
Related to https://github.com/ethereum-optimism/infra/issues/546