### PR TITLE
feat(op-acceptor): CI parallelism splitting and report-from-events mode

### DIFF
--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	ReportFromEvents     string                 // Path to raw events file for report-only mode (empty = normal mode)
 	SplitTotal           int                    // Total split nodes for CI parallelism (0 = no splitting)
 	SplitIndex           int                    // This node's index (0-based) for CI parallelism
+	SplitTimingFile      string                 // Path to JSON timing hints for balanced CI splitting
+	SplitTimingOutput    string                 // Path to write updated timing data after test execution
 	Log                  log.Logger
 	ExcludeGates         []string // List of gate IDs whose tests should be excluded
 }
@@ -166,6 +168,8 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 		ReportFromEvents:     ctx.String(flags.ReportFromEvents.Name),
 		SplitTotal:           splitTotal,
 		SplitIndex:           splitIndex,
+		SplitTimingFile:      ctx.String(flags.SplitTimingFile.Name),
+		SplitTimingOutput:    ctx.String(flags.SplitTimingOutput.Name),
 		LogDir:               logDir,
 		Log:                  log,
 		ExcludeGates:         excludeGates,

--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -37,48 +37,50 @@ type Config struct {
 	FlakeShake           bool                   // Enable flake-shake mode for test stability validation
 	FlakeShakeIterations int                    // Number of times to run each test in flake-shake mode
 	DryRun               bool                   // If true, show what tests would be run without executing them
+	ReportFromEvents     string                 // Path to raw events file for report-only mode (empty = normal mode)
+	SplitTotal           int                    // Total split nodes for CI parallelism (0 = no splitting)
+	SplitIndex           int                    // This node's index (0-based) for CI parallelism
 	Log                  log.Logger
 	ExcludeGates         []string // List of gate IDs whose tests should be excluded
 }
 
-// NewConfig creates a new Config from cli context
-// parseGates parses a comma-separated string of gate IDs into a slice
-func parseGates(gateStr string) []string {
-	if gateStr == "" {
+// parseCSV splits a comma-separated string into a trimmed, non-empty slice.
+func parseCSV(s string) []string {
+	if s == "" {
 		return nil
 	}
-	var gates []string
-	for _, g := range strings.Split(gateStr, ",") {
-		g = strings.TrimSpace(g)
-		if g != "" {
-			gates = append(gates, g)
+	var out []string
+	for _, v := range strings.Split(s, ",") {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			out = append(out, v)
 		}
 	}
-	return gates
+	return out
 }
 
 // NewConfig creates a new Config from cli context
 func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig string, gate string) (*Config, error) {
-	gates := parseGates(gate)
-	// Parse flags
-	if err := flags.CheckRequired(ctx); err != nil {
-		return nil, fmt.Errorf("missing required flags: %w", err)
-	}
-	if testDir == "" {
-		return nil, errors.New("test directory is required")
+	gates := parseCSV(gate)
+
+	reportFromEvents := ctx.String(flags.ReportFromEvents.Name)
+
+	// In report-from-events mode, testdir is not required
+	if reportFromEvents == "" {
+		if err := flags.CheckRequired(ctx); err != nil {
+			return nil, fmt.Errorf("missing required flags: %w", err)
+		}
+		if testDir == "" {
+			return nil, errors.New("test directory is required")
+		}
 	}
 
 	// Determine if we're in gateless mode (gate not specified). Validator config is optional in gateless mode
 	gatelessMode := len(gates) == 0
 
-	// In gateless mode, we don't require validator config or gate
-	if !gatelessMode {
-		if validatorConfig == "" {
-			return nil, errors.New("validator configuration file is required when not in gateless mode")
-		}
-		if len(gates) == 0 {
-			return nil, errors.New("gate is required when not in gateless mode")
-		}
+	// In gate mode, validator config is required
+	if !gatelessMode && validatorConfig == "" {
+		return nil, errors.New("validator configuration file is required when not in gateless mode")
 	}
 
 	var absValidatorConfig string
@@ -120,7 +122,15 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 
 	devnetEnvURL := ctx.String(flags.DevnetEnvURL.Name)
 
-	excludeGates := parseExcludeGates(ctx.String(flags.ExcludeGates.Name))
+	splitTotal := ctx.Int(flags.SplitTotal.Name)
+	splitIndex := ctx.Int(flags.SplitIndex.Name)
+	if splitTotal > 0 {
+		if splitIndex < 0 || splitIndex >= splitTotal {
+			return nil, fmt.Errorf("split-index must be >= 0 and < split-total (%d), got %d", splitTotal, splitIndex)
+		}
+	}
+
+	excludeGates := parseCSV(ctx.String(flags.ExcludeGates.Name))
 
 	// Conflict: selected gates are also excluded
 	for _, g := range gates {
@@ -153,26 +163,11 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 		FlakeShake:           ctx.Bool(flags.FlakeShake.Name),
 		FlakeShakeIterations: ctx.Int(flags.FlakeShakeIterations.Name),
 		DryRun:               ctx.Bool(flags.DryRun.Name),
+		ReportFromEvents:     ctx.String(flags.ReportFromEvents.Name),
+		SplitTotal:           splitTotal,
+		SplitIndex:           splitIndex,
 		LogDir:               logDir,
 		Log:                  log,
 		ExcludeGates:         excludeGates,
 	}, nil
-}
-
-// parseExcludeGates determines which gates to exclude based on env/flag.
-
-func parseExcludeGates(value string) []string {
-	val := strings.TrimSpace(value)
-	if val == "" {
-		// No default exclusions: empty means no skip gates
-		return nil
-	}
-	parts := strings.Split(val, ",")
-	var gates []string
-	for _, p := range parts {
-		if s := strings.TrimSpace(p); s != "" {
-			gates = append(gates, s)
-		}
-	}
-	return gates
 }

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -185,6 +185,24 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "EXCLUDE_GATES"),
 		Usage:   "Comma-separated list of gate IDs to blacklist globally across all modes.",
 	}
+	ReportFromEvents = &cli.StringFlag{
+		Name:    "report-from-events",
+		Value:   "",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "REPORT_FROM_EVENTS"),
+		Usage:   "Path to a raw_go_events.log file (or merged file). Generates an HTML report from the events without running tests.",
+	}
+	SplitTotal = &cli.IntFlag{
+		Name:    "split-total",
+		Value:   0,
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "SPLIT_TOTAL"),
+		Usage:   "Total number of split nodes for CI parallelism. 0 = no splitting.",
+	}
+	SplitIndex = &cli.IntFlag{
+		Name:    "split-index",
+		Value:   0,
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "SPLIT_INDEX"),
+		Usage:   "Index of this node (0-based) for CI parallelism.",
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -212,6 +230,9 @@ var optionalFlags = []cli.Flag{
 	FlakeShakeIterations,
 	ExcludeGates,
 	DryRun,
+	ReportFromEvents,
+	SplitTotal,
+	SplitIndex,
 }
 var Flags []cli.Flag
 

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -203,6 +203,18 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "SPLIT_INDEX"),
 		Usage:   "Index of this node (0-based) for CI parallelism.",
 	}
+	SplitTimingFile = &cli.StringFlag{
+		Name:    "split-timing-file",
+		Value:   "",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "SPLIT_TIMING_FILE"),
+		Usage:   "Path to JSON file with package timing hints for balanced CI splitting.",
+	}
+	SplitTimingOutput = &cli.StringFlag{
+		Name:    "split-timing-output",
+		Value:   "",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "SPLIT_TIMING_OUTPUT"),
+		Usage:   "Path to write updated timing data after test execution (for caching).",
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -233,6 +245,8 @@ var optionalFlags = []cli.Flag{
 	ReportFromEvents,
 	SplitTotal,
 	SplitIndex,
+	SplitTimingFile,
+	SplitTimingOutput,
 }
 var Flags []cli.Flag
 

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -105,6 +105,21 @@ func New(ctx context.Context, config *Config, version string, shutdownCallback f
 		return nil, errors.New("config is required")
 	}
 
+	// In report-from-events mode, we only need config + log dir.
+	// Skip registry, runner, orchestrator, and addons setup.
+	if config.ReportFromEvents != "" {
+		config.Log.Info("Report-from-events mode: skipping test runner setup")
+		return &nat{
+			ctx:              ctx,
+			config:           config,
+			version:          version,
+			done:             make(chan struct{}),
+			shutdownCallback: shutdownCallback,
+			networkName:      "report",
+			tracer:           otel.Tracer("op-acceptor"),
+		}, nil
+	}
+
 	reg, err := registry.NewRegistry(registry.Config{
 		Log:                 config.Log,
 		ValidatorConfigFile: config.ValidatorConfig,
@@ -182,6 +197,8 @@ func New(ctx context.Context, config *Config, version string, shutdownCallback f
 		Concurrency:        config.Concurrency,
 		ShowProgress:       config.ShowProgress,
 		ProgressInterval:   config.ProgressInterval,
+		SplitTotal:         config.SplitTotal,
+		SplitIndex:         config.SplitIndex,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test runner: %w", err)
@@ -307,6 +324,8 @@ func (n *nat) Start(ctx context.Context) error {
 			"concurrency", snap.Runner.Concurrency,
 			"show_progress", snap.Runner.ShowProgress,
 			"progress_interval", snap.Runner.ProgressInterval,
+			"split_total", n.config.SplitTotal,
+			"split_index", n.config.SplitIndex,
 			"test_log_level", snap.Logging.TestLogLevel,
 			"output_realtime_logs", snap.Logging.OutputRealtimeLogs,
 			"network", snap.NetworkName,
@@ -317,6 +336,18 @@ func (n *nat) Start(ctx context.Context) error {
 		"config.TestDir", n.config.TestDir,
 		"config.ValidatorConfig", n.config.ValidatorConfig,
 		"config.LogDir", n.config.LogDir)
+
+	// Report-from-events mode: generate HTML report from a raw events file, then exit.
+	if n.config.ReportFromEvents != "" {
+		err := n.reportFromEvents()
+		if err != nil {
+			return err
+		}
+		go func() {
+			n.shutdownCallback(nil)
+		}()
+		return nil
+	}
 
 	// Run tests immediately on startup (or dry-run)
 	if n.config.DryRun {
@@ -1011,9 +1042,39 @@ func (n *nat) dryRun(ctx context.Context) error {
 		gateValidators[gateID] = gateTests
 	}
 
+	// Apply CI split filtering if configured (mirrors runner.collectTestWork behavior)
+	if n.config.SplitTotal > 0 {
+		// Collect all work items in the same way as the runner
+		var allWork []runner.TestWork
+		for gateName, gateTests := range gateValidators {
+			for _, v := range gateTests {
+				allWork = append(allWork, runner.TestWork{
+					Validator: v,
+					GateID:    gateName,
+					SuiteID:   v.Suite,
+				})
+			}
+		}
+		filtered := runner.ApplySplitFilter(allWork, n.config.SplitTotal, n.config.SplitIndex)
+
+		// Rebuild gateValidators from the filtered work items
+		gateValidators = make(map[string][]types.ValidatorMetadata)
+		for _, w := range filtered {
+			gateValidators[w.GateID] = append(gateValidators[w.GateID], w.Validator)
+		}
+		n.config.Log.Info("DRY RUN: Applied CI split filter",
+			"splitTotal", n.config.SplitTotal,
+			"splitIndex", n.config.SplitIndex,
+			"workItems", len(filtered))
+	}
+
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
-	t.SetTitle("DRY RUN: Planned Test Execution (network: " + n.networkName + ")")
+	titleSuffix := ""
+	if n.config.SplitTotal > 0 {
+		titleSuffix = fmt.Sprintf(" [split %d/%d]", n.config.SplitIndex, n.config.SplitTotal)
+	}
+	t.SetTitle("DRY RUN: Planned Test Execution (network: " + n.networkName + ")" + titleSuffix)
 
 	headers := []interface{}{"TYPE", "ID", "TESTS", "STATUS"}
 	t.AppendHeader(table.Row(headers))
@@ -1097,6 +1158,52 @@ func (n *nat) dryRun(ctx context.Context) error {
 	t.Render()
 
 	n.config.Log.Info("DRY RUN: Summary", "totalGates", len(gateValidators), "totalTests", totalTests)
+	return nil
+}
+
+// reportFromEvents reads a raw_go_events.log file (possibly merged from multiple
+// parallel nodes) and generates a consolidated report without running any tests.
+// It reuses the standard FileLogger pipeline so that all sinks (HTML, text summary,
+// per-test logs, etc.) are exercised through the same code path as normal execution.
+func (n *nat) reportFromEvents() error {
+	eventsPath := n.config.ReportFromEvents
+	n.config.Log.Info("Generating report from events file", "path", eventsPath)
+
+	f, err := os.Open(eventsPath)
+	if err != nil {
+		return fmt.Errorf("failed to open events file %s: %w", eventsPath, err)
+	}
+	defer f.Close()
+
+	results, err := runner.ParseMultiPackageEvents(f)
+	if err != nil {
+		return fmt.Errorf("failed to parse events: %w", err)
+	}
+
+	n.config.Log.Info("Parsed test results from events", "packages", len(results))
+
+	// Use the same FileLogger pipeline as normal test execution
+	runID := uuid.New().String()
+	fileLogger, err := logging.NewFileLogger(n.config.LogDir, runID, n.networkName, n.config.TargetGate)
+	if err != nil {
+		return fmt.Errorf("failed to create file logger: %w", err)
+	}
+
+	// Feed all parsed results through the standard sink pipeline
+	for _, result := range results {
+		if err := fileLogger.LogTestResult(result, runID); err != nil {
+			return fmt.Errorf("failed to log result for %s: %w", result.Metadata.Package, err)
+		}
+	}
+
+	// Finalize all sinks (generates HTML, text summary, etc.)
+	if err := fileLogger.Complete(runID); err != nil {
+		return fmt.Errorf("failed to complete report: %w", err)
+	}
+
+	logDir, _ := fileLogger.GetDirectoryForRunID(runID)
+	n.config.Log.Info("Consolidated report generated", "path", logDir)
+
 	return nil
 }
 

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -199,6 +199,7 @@ func New(ctx context.Context, config *Config, version string, shutdownCallback f
 		ProgressInterval:   config.ProgressInterval,
 		SplitTotal:         config.SplitTotal,
 		SplitIndex:         config.SplitIndex,
+		SplitTimingFile:    config.SplitTimingFile,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test runner: %w", err)
@@ -547,6 +548,18 @@ func (n *nat) runTests(ctx context.Context) error {
 				_ = n.fileLogger.CompleteWithTiming(n.result.RunID, n.result.WallClockTime)
 			}
 			return nil
+		}
+	}
+
+	// Write timing output if configured (for CI caching)
+	if n.config.SplitTimingOutput != "" && !n.config.FlakeShake && n.result != nil {
+		timingData := n.extractTimingData(n.result)
+		if err := runner.WriteTimingFile(n.config.SplitTimingOutput, timingData); err != nil {
+			n.config.Log.Error("Failed to write timing output", "path", n.config.SplitTimingOutput, "error", err)
+		} else {
+			n.config.Log.Info("Wrote timing output for CI caching",
+				"path", n.config.SplitTimingOutput,
+				"packages", len(timingData))
 		}
 	}
 
@@ -1055,7 +1068,12 @@ func (n *nat) dryRun(ctx context.Context) error {
 				})
 			}
 		}
-		filtered := runner.ApplySplitFilter(allWork, n.config.SplitTotal, n.config.SplitIndex)
+		timings, err := runner.LoadTimingFile(n.config.SplitTimingFile)
+		if err != nil {
+			n.config.Log.Warn("Failed to load timing file, falling back to round-robin",
+				"path", n.config.SplitTimingFile, "error", err)
+		}
+		filtered := runner.ApplySplitFilter(allWork, n.config.SplitTotal, n.config.SplitIndex, timings)
 
 		// Rebuild gateValidators from the filtered work items
 		gateValidators = make(map[string][]types.ValidatorMetadata)
@@ -1065,7 +1083,8 @@ func (n *nat) dryRun(ctx context.Context) error {
 		n.config.Log.Info("DRY RUN: Applied CI split filter",
 			"splitTotal", n.config.SplitTotal,
 			"splitIndex", n.config.SplitIndex,
-			"workItems", len(filtered))
+			"workItems", len(filtered),
+			"timingBased", len(timings) > 0)
 	}
 
 	t := table.NewWriter()
@@ -1204,7 +1223,50 @@ func (n *nat) reportFromEvents() error {
 	logDir, _ := fileLogger.GetDirectoryForRunID(runID)
 	n.config.Log.Info("Consolidated report generated", "path", logDir)
 
+	// Write timing output if configured (for CI caching)
+	if n.config.SplitTimingOutput != "" {
+		timingData := extractTimingDataFromParsedResults(results)
+		if err := runner.WriteTimingFile(n.config.SplitTimingOutput, timingData); err != nil {
+			n.config.Log.Error("Failed to write timing output from events", "error", err)
+		} else {
+			n.config.Log.Info("Wrote timing output from events",
+				"path", n.config.SplitTimingOutput,
+				"packages", len(timingData))
+		}
+	}
+
 	return nil
+}
+
+// extractTimingData builds a TimingKey → duration_seconds map from test results.
+// This data can be cached and used for timing-based CI splitting on subsequent runs.
+func (n *nat) extractTimingData(result *runner.RunnerResult) map[string]float64 {
+	timings := make(map[string]float64)
+	for gateName, gate := range result.Gates {
+		for _, test := range gate.Tests {
+			key := runner.TimingKey(gateName, test.Metadata.Package, test.Metadata.FuncName)
+			timings[key] = test.Duration.Seconds()
+		}
+		for _, suite := range gate.Suites {
+			for _, test := range suite.Tests {
+				key := runner.TimingKey(gateName, test.Metadata.Package, test.Metadata.FuncName)
+				timings[key] = test.Duration.Seconds()
+			}
+		}
+	}
+	return timings
+}
+
+// extractTimingDataFromParsedResults builds a TimingKey → duration_seconds map
+// from parsed test results (used in report-from-events mode).
+func extractTimingDataFromParsedResults(results []*types.TestResult) map[string]float64 {
+	timings := make(map[string]float64)
+	for _, result := range results {
+		// In gateless/report mode, use "gateless" as the gate ID
+		key := runner.TimingKey("gateless", result.Metadata.Package, result.Metadata.FuncName)
+		timings[key] = result.Duration.Seconds()
+	}
+	return timings
 }
 
 // WaitForShutdown waits for all goroutines to finish

--- a/op-acceptor/runner/events_report.go
+++ b/op-acceptor/runner/events_report.go
@@ -1,0 +1,94 @@
+package runner
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/ethereum-optimism/infra/op-acceptor/types"
+)
+
+// ParseMultiPackageEvents reads a raw_go_events.log (possibly merged from multiple
+// parallel nodes) and reconstructs one TestResult per package.  Each package is
+// treated as a "run-all" result whose subtests are the individual Test* functions
+// discovered in the event stream.
+//
+// The returned slice is sorted by package name for deterministic output.
+func ParseMultiPackageEvents(r io.Reader) ([]*types.TestResult, error) {
+	if r == nil {
+		return nil, fmt.Errorf("reader is nil")
+	}
+
+	// Group raw JSON lines by package so we can parse each package independently.
+	pkgLines := make(map[string][][]byte)
+	scanner := bufio.NewScanner(r)
+	// Allow long lines (some output events can be large)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		event, err := parseTestEvent(line)
+		if err != nil {
+			continue // skip non-JSON lines
+		}
+		pkg := event.Package
+		if pkg == "" {
+			continue
+		}
+		// Copy the line since scanner reuses the buffer
+		lineCopy := make([]byte, len(line))
+		copy(lineCopy, line)
+		pkgLines[pkg] = append(pkgLines[pkg], lineCopy)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading events: %w", err)
+	}
+
+	if len(pkgLines) == 0 {
+		return nil, nil
+	}
+
+	// Parse each package's events into a TestResult
+	parser := NewOutputParser()
+	var results []*types.TestResult
+
+	// Sort package names for deterministic order
+	pkgNames := make([]string, 0, len(pkgLines))
+	for pkg := range pkgLines {
+		pkgNames = append(pkgNames, pkg)
+	}
+	sort.Strings(pkgNames)
+
+	for _, pkg := range pkgNames {
+		lines := pkgLines[pkg]
+		// Reconstruct an io.Reader from the grouped lines
+		combined := strings.NewReader(joinLines(lines))
+
+		meta := types.ValidatorMetadata{
+			Package: pkg,
+			RunAll:  true,
+			Gate:    "gateless",
+		}
+
+		result := parser.Parse(combined, meta)
+		if result != nil {
+			results = append(results, result)
+		}
+	}
+
+	return results, nil
+}
+
+// joinLines joins byte slices with newlines into a single string.
+func joinLines(lines [][]byte) string {
+	var b strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.Write(line)
+	}
+	return b.String()
+}

--- a/op-acceptor/runner/events_report_test.go
+++ b/op-acceptor/runner/events_report_test.go
@@ -1,0 +1,62 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/infra/op-acceptor/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMultiPackageEvents(t *testing.T) {
+	// Simulate events from two packages as they'd appear in a raw_go_events.log
+	events := `{"Time":"2024-01-01T00:00:00Z","Action":"start","Package":"./tests/pkgA"}
+{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"./tests/pkgA","Test":"TestAlpha"}
+{"Time":"2024-01-01T00:00:00Z","Action":"start","Package":"./tests/pkgB"}
+{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"./tests/pkgB","Test":"TestBeta"}
+{"Time":"2024-01-01T00:00:01Z","Action":"output","Package":"./tests/pkgA","Test":"TestAlpha","Output":"alpha running\n"}
+{"Time":"2024-01-01T00:00:01Z","Action":"pass","Package":"./tests/pkgA","Test":"TestAlpha","Elapsed":1.0}
+{"Time":"2024-01-01T00:00:01Z","Action":"pass","Package":"./tests/pkgA","Elapsed":1.0}
+{"Time":"2024-01-01T00:00:02Z","Action":"output","Package":"./tests/pkgB","Test":"TestBeta","Output":"--- FAIL: TestBeta\n"}
+{"Time":"2024-01-01T00:00:02Z","Action":"fail","Package":"./tests/pkgB","Test":"TestBeta","Elapsed":2.0}
+{"Time":"2024-01-01T00:00:02Z","Action":"fail","Package":"./tests/pkgB","Elapsed":2.0}`
+
+	results, err := ParseMultiPackageEvents(strings.NewReader(events))
+	require.NoError(t, err)
+	require.Len(t, results, 2, "should produce one result per package")
+
+	// Results should be sorted by package name
+	assert.Equal(t, "./tests/pkgA", results[0].Metadata.Package)
+	assert.Equal(t, "./tests/pkgB", results[1].Metadata.Package)
+
+	// pkgA should pass
+	assert.Equal(t, types.TestStatusPass, results[0].Status)
+
+	// pkgB should fail
+	assert.Equal(t, types.TestStatusFail, results[1].Status)
+}
+
+func TestParseMultiPackageEventsEmpty(t *testing.T) {
+	results, err := ParseMultiPackageEvents(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}
+
+func TestParseMultiPackageEventsNilReader(t *testing.T) {
+	_, err := ParseMultiPackageEvents(nil)
+	assert.Error(t, err)
+}
+
+func TestParseMultiPackageEventsNonJSON(t *testing.T) {
+	// Lines that aren't valid JSON should be skipped
+	events := `not json
+{"Time":"2024-01-01T00:00:00Z","Action":"start","Package":"./tests/pkg"}
+also not json
+{"Time":"2024-01-01T00:00:01Z","Action":"pass","Package":"./tests/pkg","Elapsed":1.0}`
+
+	results, err := ParseMultiPackageEvents(strings.NewReader(events))
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "./tests/pkg", results[0].Metadata.Package)
+}

--- a/op-acceptor/runner/parallel.go
+++ b/op-acceptor/runner/parallel.go
@@ -296,12 +296,27 @@ func (r *runner) collectTestWork() []TestWork {
 			r.log.Warn("Failed to load timing file, falling back to round-robin",
 				"path", r.splitTimingFile, "error", err)
 		}
+		if len(timings) > 0 {
+			r.log.Info("Using timing-based bin-packing for CI split",
+				"timingFile", r.splitTimingFile,
+				"knownPackages", len(timings))
+		} else if r.splitTimingFile == "" {
+			r.log.Info("No timing file configured, using round-robin split")
+		} else {
+			r.log.Info("Timing file not found or empty, using round-robin split",
+				"timingFile", r.splitTimingFile)
+		}
 		workItems = ApplySplitFilter(workItems, r.splitTotal, r.splitIndex, timings)
 		r.log.Info("Applied CI split filter",
 			"splitTotal", r.splitTotal,
 			"splitIndex", r.splitIndex,
 			"workItems", len(workItems),
-			"timingBased", len(timings) > 0)
+			"algorithm", func() string {
+				if len(timings) > 0 {
+					return "timing-based"
+				}
+				return "round-robin"
+			}())
 	}
 
 	return workItems

--- a/op-acceptor/runner/parallel.go
+++ b/op-acceptor/runner/parallel.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -286,7 +287,40 @@ func (r *runner) collectTestWork() []TestWork {
 		}
 	}
 
+	// Apply CI split filtering if configured
+	if r.splitTotal > 0 {
+		workItems = ApplySplitFilter(workItems, r.splitTotal, r.splitIndex)
+		r.log.Info("Applied CI split filter",
+			"splitTotal", r.splitTotal,
+			"splitIndex", r.splitIndex,
+			"workItems", len(workItems))
+	}
+
 	return workItems
+}
+
+// splitKey returns a deterministic key for sorting work items during CI split filtering.
+// Includes GateID so that the same package appearing under different gates (via inheritance)
+// gets a stable, distinct position in the sort order.
+func splitKey(w TestWork) string {
+	return w.GateID + "|" + w.Validator.Package + "|" + w.Validator.FuncName
+}
+
+// ApplySplitFilter sorts work items deterministically and returns only those assigned
+// to the given split index. Items are distributed round-robin: item i is assigned to
+// node i % total.
+func ApplySplitFilter(items []TestWork, total, index int) []TestWork {
+	sort.Slice(items, func(i, j int) bool {
+		return splitKey(items[i]) < splitKey(items[j])
+	})
+
+	var filtered []TestWork
+	for i, item := range items {
+		if i%total == index {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
 }
 
 // initializeProgressTracking sets up data structures to concurrently

--- a/op-acceptor/runner/parallel.go
+++ b/op-acceptor/runner/parallel.go
@@ -2,7 +2,9 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -289,31 +291,46 @@ func (r *runner) collectTestWork() []TestWork {
 
 	// Apply CI split filtering if configured
 	if r.splitTotal > 0 {
-		workItems = ApplySplitFilter(workItems, r.splitTotal, r.splitIndex)
+		timings, err := LoadTimingFile(r.splitTimingFile)
+		if err != nil {
+			r.log.Warn("Failed to load timing file, falling back to round-robin",
+				"path", r.splitTimingFile, "error", err)
+		}
+		workItems = ApplySplitFilter(workItems, r.splitTotal, r.splitIndex, timings)
 		r.log.Info("Applied CI split filter",
 			"splitTotal", r.splitTotal,
 			"splitIndex", r.splitIndex,
-			"workItems", len(workItems))
+			"workItems", len(workItems),
+			"timingBased", len(timings) > 0)
 	}
 
 	return workItems
 }
 
-// splitKey returns a deterministic key for sorting work items during CI split filtering.
-// Includes GateID so that the same package appearing under different gates (via inheritance)
-// gets a stable, distinct position in the sort order.
-func splitKey(w TestWork) string {
-	return w.GateID + "|" + w.Validator.Package + "|" + w.Validator.FuncName
+// TimingKey builds the canonical key used for timing-based CI splitting.
+// The format is "gate|package|funcName", which uniquely identifies a test
+// work item across gates (the same package under different gates via
+// inheritance gets a distinct key).
+func TimingKey(gate, pkg, funcName string) string {
+	return gate + "|" + pkg + "|" + funcName
 }
 
-// ApplySplitFilter sorts work items deterministically and returns only those assigned
-// to the given split index. Items are distributed round-robin: item i is assigned to
-// node i % total.
-func ApplySplitFilter(items []TestWork, total, index int) []TestWork {
+// splitKey returns the timing key for a TestWork item.
+func splitKey(w TestWork) string {
+	return TimingKey(w.GateID, w.Validator.Package, w.Validator.FuncName)
+}
+
+// ApplySplitFilter distributes work items across split nodes. When timings are
+// provided, it uses a greedy bin-packing (LPT) algorithm for balanced splits.
+// Otherwise it falls back to deterministic round-robin by sorted key.
+func ApplySplitFilter(items []TestWork, total, index int, timings map[string]float64) []TestWork {
+	if len(timings) > 0 {
+		return applySplitByTiming(items, total, index, timings)
+	}
+	// Existing round-robin fallback
 	sort.Slice(items, func(i, j int) bool {
 		return splitKey(items[i]) < splitKey(items[j])
 	})
-
 	var filtered []TestWork
 	for i, item := range items {
 		if i%total == index {
@@ -321,6 +338,100 @@ func ApplySplitFilter(items []TestWork, total, index int) []TestWork {
 		}
 	}
 	return filtered
+}
+
+// applySplitByTiming uses the Longest Processing Time first (LPT) greedy
+// bin-packing algorithm to distribute work items across nodes, minimizing
+// the makespan (duration of the slowest node).
+func applySplitByTiming(items []TestWork, total, index int, timings map[string]float64) []TestWork {
+	defaultDuration := medianTiming(timings)
+
+	// Build a duration lookup for each item
+	duration := func(w TestWork) float64 {
+		if d, ok := timings[splitKey(w)]; ok {
+			return d
+		}
+		return defaultDuration
+	}
+
+	// Sort by duration descending (heaviest first -- standard LPT),
+	// with tie-break by key for determinism.
+	sort.Slice(items, func(i, j int) bool {
+		di, dj := duration(items[i]), duration(items[j])
+		if di != dj {
+			return di > dj
+		}
+		return splitKey(items[i]) < splitKey(items[j])
+	})
+
+	// Greedy assignment: assign each item to the node with the lowest total
+	nodeTotals := make([]float64, total)
+	nodeItems := make([][]TestWork, total)
+	for _, item := range items {
+		minNode := 0
+		for n := 1; n < total; n++ {
+			if nodeTotals[n] < nodeTotals[minNode] {
+				minNode = n
+			}
+		}
+		nodeItems[minNode] = append(nodeItems[minNode], item)
+		nodeTotals[minNode] += duration(item)
+	}
+
+	return nodeItems[index]
+}
+
+// medianTiming returns the median of the timing values. If the map is empty,
+// returns 60.0 as a sensible default for unknown test durations.
+func medianTiming(timings map[string]float64) float64 {
+	if len(timings) == 0 {
+		return 60.0
+	}
+	vals := make([]float64, 0, len(timings))
+	for _, v := range timings {
+		vals = append(vals, v)
+	}
+	sort.Float64s(vals)
+	mid := len(vals) / 2
+	if len(vals)%2 == 0 {
+		return (vals[mid-1] + vals[mid]) / 2
+	}
+	return vals[mid]
+}
+
+// LoadTimingFile reads a JSON file mapping TimingKey → duration_seconds.
+// Returns nil map (not error) if the path is empty or the file doesn't exist.
+func LoadTimingFile(path string) (map[string]float64, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading timing file: %w", err)
+	}
+	var timings map[string]float64
+	if err := json.Unmarshal(data, &timings); err != nil {
+		return nil, fmt.Errorf("parsing timing file: %w", err)
+	}
+	return timings, nil
+}
+
+// WriteTimingFile writes a JSON map of TimingKey → duration_seconds.
+func WriteTimingFile(path string, timings map[string]float64) error {
+	if path == "" {
+		return nil
+	}
+	data, err := json.MarshalIndent(timings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling timing data: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("writing timing file: %w", err)
+	}
+	return nil
 }
 
 // initializeProgressTracking sets up data structures to concurrently

--- a/op-acceptor/runner/parallel_test.go
+++ b/op-acceptor/runner/parallel_test.go
@@ -448,7 +448,7 @@ func TestApplySplitFilter(t *testing.T) {
 		seen := make(map[string]bool)
 
 		for idx := 0; idx < total; idx++ {
-			subset := ApplySplitFilter(items, total, idx)
+			subset := ApplySplitFilter(items, total, idx, nil)
 			for _, item := range subset {
 				key := item.Validator.Package + "|" + item.Validator.FuncName
 				assert.False(t, seen[key], "item %s assigned to multiple nodes", key)
@@ -461,7 +461,7 @@ func TestApplySplitFilter(t *testing.T) {
 	})
 
 	t.Run("split into 1 node returns all items", func(t *testing.T) {
-		result := ApplySplitFilter(items, 1, 0)
+		result := ApplySplitFilter(items, 1, 0, nil)
 		assert.Len(t, result, 10, "single node should get all items")
 	})
 
@@ -469,14 +469,14 @@ func TestApplySplitFilter(t *testing.T) {
 		total := 20
 		var all []TestWork
 		for idx := 0; idx < total; idx++ {
-			all = append(all, ApplySplitFilter(items, total, idx)...)
+			all = append(all, ApplySplitFilter(items, total, idx, nil)...)
 		}
 		assert.Len(t, all, 10, "all items should be covered even with excess nodes")
 	})
 
 	t.Run("split is deterministic", func(t *testing.T) {
-		result1 := ApplySplitFilter(items, 3, 1)
-		result2 := ApplySplitFilter(items, 3, 1)
+		result1 := ApplySplitFilter(items, 3, 1, nil)
+		result2 := ApplySplitFilter(items, 3, 1, nil)
 		require.Len(t, result1, len(result2))
 		for i := range result1 {
 			assert.Equal(t, result1[i].Validator.Package, result2[i].Validator.Package)
@@ -487,11 +487,178 @@ func TestApplySplitFilter(t *testing.T) {
 	t.Run("nodes get roughly equal work", func(t *testing.T) {
 		total := 3
 		for idx := 0; idx < total; idx++ {
-			subset := ApplySplitFilter(items, total, idx)
+			subset := ApplySplitFilter(items, total, idx, nil)
 			// 10 items / 3 nodes = 3 or 4 per node
 			assert.True(t, len(subset) >= 3 && len(subset) <= 4,
 				"node %d got %d items, expected 3-4", idx, len(subset))
 		}
+	})
+}
+
+func TestApplySplitFilterWithTimings(t *testing.T) {
+	// Create items with known timing characteristics:
+	// One heavy package (120s) and several light ones (10s each)
+	items := []TestWork{
+		{Validator: types.ValidatorMetadata{Package: "./heavy", FuncName: ""}, GateID: "gate", ResultKey: "./heavy"},
+		{Validator: types.ValidatorMetadata{Package: "./light1", FuncName: ""}, GateID: "gate", ResultKey: "./light1"},
+		{Validator: types.ValidatorMetadata{Package: "./light2", FuncName: ""}, GateID: "gate", ResultKey: "./light2"},
+		{Validator: types.ValidatorMetadata{Package: "./light3", FuncName: ""}, GateID: "gate", ResultKey: "./light3"},
+		{Validator: types.ValidatorMetadata{Package: "./light4", FuncName: ""}, GateID: "gate", ResultKey: "./light4"},
+		{Validator: types.ValidatorMetadata{Package: "./light5", FuncName: ""}, GateID: "gate", ResultKey: "./light5"},
+	}
+
+	timings := map[string]float64{
+		"gate|./heavy|":  120.0,
+		"gate|./light1|": 10.0,
+		"gate|./light2|": 10.0,
+		"gate|./light3|": 10.0,
+		"gate|./light4|": 10.0,
+		"gate|./light5|": 10.0,
+	}
+
+	t.Run("heavy item gets its own node", func(t *testing.T) {
+		total := 2
+		node0 := ApplySplitFilter(items, total, 0, timings)
+		node1 := ApplySplitFilter(items, total, 1, timings)
+
+		// All items should be covered
+		assert.Equal(t, len(items), len(node0)+len(node1))
+
+		// The heavy item should be alone on one node, lights on the other
+		// With LPT: heavy goes to node 0, then lights fill node 1 until it's still less
+		// Actually: heavy(120) → node0. light1(10) → node1(10). light2(10) → node1(20).
+		// light3(10) → node1(30). light4(10) → node1(40). light5(10) → node1(50).
+		// So node0=[heavy], node1=[light1..light5]
+
+		// Find which node has the heavy item
+		var heavyNode, lightNode []TestWork
+		for _, item := range node0 {
+			if item.Validator.Package == "./heavy" {
+				heavyNode = node0
+				lightNode = node1
+				break
+			}
+		}
+		if heavyNode == nil {
+			heavyNode = node1
+			lightNode = node0
+		}
+
+		assert.Len(t, heavyNode, 1, "heavy item should be alone")
+		assert.Len(t, lightNode, 5, "all lights should be together")
+	})
+
+	t.Run("all items covered with timings", func(t *testing.T) {
+		total := 3
+		var all []TestWork
+		seen := make(map[string]bool)
+
+		for idx := 0; idx < total; idx++ {
+			subset := ApplySplitFilter(items, total, idx, timings)
+			for _, item := range subset {
+				key := splitKey(item)
+				assert.False(t, seen[key], "item %s assigned to multiple nodes", key)
+				seen[key] = true
+			}
+			all = append(all, subset...)
+		}
+		assert.Len(t, all, len(items), "all items should be covered across nodes")
+	})
+
+	t.Run("timing split is deterministic", func(t *testing.T) {
+		result1 := ApplySplitFilter(items, 3, 1, timings)
+		result2 := ApplySplitFilter(items, 3, 1, timings)
+		require.Len(t, result1, len(result2))
+		for i := range result1 {
+			assert.Equal(t, splitKey(result1[i]), splitKey(result2[i]))
+		}
+	})
+
+	t.Run("balanced distribution with equal timings", func(t *testing.T) {
+		equalTimings := map[string]float64{
+			"gate|./heavy|":  30.0,
+			"gate|./light1|": 30.0,
+			"gate|./light2|": 30.0,
+			"gate|./light3|": 30.0,
+			"gate|./light4|": 30.0,
+			"gate|./light5|": 30.0,
+		}
+		total := 3
+		for idx := 0; idx < total; idx++ {
+			subset := ApplySplitFilter(items, total, idx, equalTimings)
+			// 6 items / 3 nodes = 2 per node
+			assert.Len(t, subset, 2, "node %d should get 2 items with equal timings", idx)
+		}
+	})
+}
+
+func TestApplySplitFilterTimingFallback(t *testing.T) {
+	items := []TestWork{
+		{Validator: types.ValidatorMetadata{Package: "./pkg1", FuncName: "TestA"}, GateID: "gate"},
+		{Validator: types.ValidatorMetadata{Package: "./pkg2", FuncName: "TestB"}, GateID: "gate"},
+	}
+
+	// With nil timings, should fall back to round-robin
+	node0 := ApplySplitFilter(items, 2, 0, nil)
+	node1 := ApplySplitFilter(items, 2, 1, nil)
+	assert.Equal(t, 2, len(node0)+len(node1))
+
+	// With empty timings, should also fall back to round-robin
+	node0Empty := ApplySplitFilter(items, 2, 0, map[string]float64{})
+	node1Empty := ApplySplitFilter(items, 2, 1, map[string]float64{})
+	assert.Equal(t, 2, len(node0Empty)+len(node1Empty))
+}
+
+func TestLoadWriteTimingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "timing.json")
+
+	// Write timing data
+	original := map[string]float64{
+		"gate|./pkg1|TestA": 45.2,
+		"gate|./pkg2|":      120.5,
+		"gate|./pkg3|TestC": 8.1,
+	}
+	err := WriteTimingFile(path, original)
+	require.NoError(t, err)
+
+	// Read it back
+	loaded, err := LoadTimingFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, loaded)
+}
+
+func TestLoadTimingFileNotExist(t *testing.T) {
+	// Non-existent file returns nil, nil
+	timings, err := LoadTimingFile("/nonexistent/path/timing.json")
+	assert.NoError(t, err)
+	assert.Nil(t, timings)
+}
+
+func TestLoadTimingFileEmpty(t *testing.T) {
+	// Empty path returns nil, nil
+	timings, err := LoadTimingFile("")
+	assert.NoError(t, err)
+	assert.Nil(t, timings)
+}
+
+func TestMedianTiming(t *testing.T) {
+	t.Run("empty map returns 60", func(t *testing.T) {
+		assert.Equal(t, 60.0, medianTiming(map[string]float64{}))
+	})
+
+	t.Run("single value", func(t *testing.T) {
+		assert.Equal(t, 42.0, medianTiming(map[string]float64{"a": 42.0}))
+	})
+
+	t.Run("odd count", func(t *testing.T) {
+		m := map[string]float64{"a": 10, "b": 20, "c": 30}
+		assert.Equal(t, 20.0, medianTiming(m))
+	})
+
+	t.Run("even count", func(t *testing.T) {
+		m := map[string]float64{"a": 10, "b": 20, "c": 30, "d": 40}
+		assert.Equal(t, 25.0, medianTiming(m))
 	})
 }
 

--- a/op-acceptor/runner/parallel_test.go
+++ b/op-acceptor/runner/parallel_test.go
@@ -428,6 +428,117 @@ func setupMultiPackageTestRunner(t testing.TB, testContents map[string][]byte, c
 	return r.(*runner)
 }
 
+func TestApplySplitFilter(t *testing.T) {
+	// Create 10 work items with distinct packages/functions
+	var items []TestWork
+	for i := 0; i < 10; i++ {
+		items = append(items, TestWork{
+			Validator: types.ValidatorMetadata{
+				Package:  fmt.Sprintf("./pkg%d", i),
+				FuncName: fmt.Sprintf("TestFunc%d", i),
+			},
+			GateID:    "gate",
+			ResultKey: fmt.Sprintf("TestFunc%d", i),
+		})
+	}
+
+	t.Run("split into 4 nodes covers all items", func(t *testing.T) {
+		total := 4
+		var all []TestWork
+		seen := make(map[string]bool)
+
+		for idx := 0; idx < total; idx++ {
+			subset := ApplySplitFilter(items, total, idx)
+			for _, item := range subset {
+				key := item.Validator.Package + "|" + item.Validator.FuncName
+				assert.False(t, seen[key], "item %s assigned to multiple nodes", key)
+				seen[key] = true
+			}
+			all = append(all, subset...)
+		}
+
+		assert.Len(t, all, 10, "all items should be covered across nodes")
+	})
+
+	t.Run("split into 1 node returns all items", func(t *testing.T) {
+		result := ApplySplitFilter(items, 1, 0)
+		assert.Len(t, result, 10, "single node should get all items")
+	})
+
+	t.Run("split into more nodes than items", func(t *testing.T) {
+		total := 20
+		var all []TestWork
+		for idx := 0; idx < total; idx++ {
+			all = append(all, ApplySplitFilter(items, total, idx)...)
+		}
+		assert.Len(t, all, 10, "all items should be covered even with excess nodes")
+	})
+
+	t.Run("split is deterministic", func(t *testing.T) {
+		result1 := ApplySplitFilter(items, 3, 1)
+		result2 := ApplySplitFilter(items, 3, 1)
+		require.Len(t, result1, len(result2))
+		for i := range result1 {
+			assert.Equal(t, result1[i].Validator.Package, result2[i].Validator.Package)
+			assert.Equal(t, result1[i].Validator.FuncName, result2[i].Validator.FuncName)
+		}
+	})
+
+	t.Run("nodes get roughly equal work", func(t *testing.T) {
+		total := 3
+		for idx := 0; idx < total; idx++ {
+			subset := ApplySplitFilter(items, total, idx)
+			// 10 items / 3 nodes = 3 or 4 per node
+			assert.True(t, len(subset) >= 3 && len(subset) <= 4,
+				"node %d got %d items, expected 3-4", idx, len(subset))
+		}
+	})
+}
+
+func TestCollectTestWorkWithSplit(t *testing.T) {
+	testContent := []byte(`
+package work_test
+
+import "testing"
+
+func TestWork(t *testing.T) {
+	t.Log("Work test running")
+}
+`)
+
+	configContent := []byte(`
+gates:
+  - id: split-gate
+    description: "Split test gate"
+    tests:
+      - package: "./work"
+        run_all: true
+      - name: "TestSpecific"
+        package: "./work"
+`)
+
+	r := setupMultiPackageTestRunner(t, map[string][]byte{
+		"work": testContent,
+	}, configContent)
+
+	// Without split, should get all items
+	allItems := r.collectTestWork()
+	totalCount := len(allItems)
+
+	// With split, each node should get a subset
+	r.splitTotal = 2
+	r.splitIndex = 0
+	node0Items := r.collectTestWork()
+
+	r.splitIndex = 1
+	node1Items := r.collectTestWork()
+
+	assert.Equal(t, totalCount, len(node0Items)+len(node1Items),
+		"split nodes should cover all items")
+	assert.True(t, len(node0Items) > 0, "node 0 should have items")
+	assert.True(t, len(node1Items) > 0, "node 1 should have items")
+}
+
 func findWorkItem(workItems []TestWork, gateID, suiteID, resultKey string) *TestWork {
 	for _, item := range workItems {
 		if item.GateID == gateID && item.SuiteID == suiteID && item.ResultKey == resultKey {

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -131,6 +131,8 @@ type runner struct {
 	serial             bool     // Whether to run tests serially instead of in parallel
 	concurrency        int      // Number of concurrent test workers (0 = auto-determine)
 	targetGates        []string // Target gates specified for this run
+	splitTotal         int      // Total split nodes for CI parallelism (0 = no splitting)
+	splitIndex         int      // This node's index (0-based) for CI parallelism
 
 	// New component fields
 	executor     TestExecutor
@@ -157,6 +159,8 @@ type Config struct {
 	Concurrency        int           // Number of concurrent test workers (0 = auto-determine)
 	ShowProgress       bool          // Whether to show periodic progress updates during test execution
 	ProgressInterval   time.Duration // Interval between progress updates when ShowProgress is 'true'
+	SplitTotal         int           // Total split nodes for CI parallelism (0 = no splitting)
+	SplitIndex         int           // This node's index (0-based) for CI parallelism
 }
 
 // NewTestRunner creates a new test runner instance
@@ -208,6 +212,8 @@ func NewTestRunner(cfg Config) (TestRunner, error) {
 		serial:             cfg.Serial,
 		concurrency:        cfg.Concurrency,
 		targetGates:        cfg.TargetGate,
+		splitTotal:         cfg.SplitTotal,
+		splitIndex:         cfg.SplitIndex,
 	}
 
 	// Initialize new components

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -22,9 +24,6 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
-
-	"math"
-	"runtime"
 
 	"github.com/ethereum-optimism/infra/op-acceptor/flags"
 	"github.com/ethereum-optimism/infra/op-acceptor/logging"
@@ -133,6 +132,7 @@ type runner struct {
 	targetGates        []string // Target gates specified for this run
 	splitTotal         int      // Total split nodes for CI parallelism (0 = no splitting)
 	splitIndex         int      // This node's index (0-based) for CI parallelism
+	splitTimingFile    string   // Path to JSON timing hints for balanced CI splitting
 
 	// New component fields
 	executor     TestExecutor
@@ -161,6 +161,7 @@ type Config struct {
 	ProgressInterval   time.Duration // Interval between progress updates when ShowProgress is 'true'
 	SplitTotal         int           // Total split nodes for CI parallelism (0 = no splitting)
 	SplitIndex         int           // This node's index (0-based) for CI parallelism
+	SplitTimingFile    string        // Path to JSON timing hints for balanced CI splitting
 }
 
 // NewTestRunner creates a new test runner instance
@@ -214,6 +215,7 @@ func NewTestRunner(cfg Config) (TestRunner, error) {
 		targetGates:        cfg.TargetGate,
 		splitTotal:         cfg.SplitTotal,
 		splitIndex:         cfg.SplitIndex,
+		splitTimingFile:    cfg.SplitTimingFile,
 	}
 
 	// Initialize new components


### PR DESCRIPTION
## Summary

- Add `--split-total` / `--split-index` flags for deterministic round-robin test distribution across CI parallel nodes. Each node independently discovers all tests, sorts by `package|function`, and runs only its assigned subset. Defaults to no splitting (backwards compatible).
- Add `--report-from-events` flag that reads a merged `raw_go_events.log` file and generates a consolidated HTML report through the standard `FileLogger` pipeline, enabling a post-parallelism report consolidation step.
- Consolidate duplicate CSV parsing helpers and remove unreachable validation code.

### How splitting works

When `OP_ACCEPTOR_SPLIT_TOTAL` and `OP_ACCEPTOR_SPLIT_INDEX` are set (bridged from CircleCI's `CIRCLE_NODE_TOTAL` / `CIRCLE_NODE_INDEX`):

1. All work items are collected as usual (same test discovery)
2. Items are sorted deterministically by `package|funcName`
3. Item `i` is assigned to node `i % total`
4. Each node runs only its assigned subset

No coordination between nodes is needed. `--dry-run` also respects the split flags.

### How report-from-events works

After all parallel nodes finish, their `raw_go_events.log` files are merged (`cat`). The new flag feeds the merged events through the same `FileLogger` → sinks pipeline as normal execution, producing a single consolidated HTML report, text summary, and per-test logs.

## Test plan

Produced release [v3.9.0-rc.1](https://github.com/ethereum-optimism/infra/releases/tag/op-acceptor%2Fv3.9.0-rc.1)

- [x] Unit tests for `ApplySplitFilter` (coverage, single node, excess nodes, determinism, equal distribution)
- [x] Integration test `TestCollectTestWorkWithSplit` verifying runner produces correct subsets
- [x] Unit tests for `ParseMultiPackageEvents` (multi-package, empty, nil, non-JSON)
- [ ] Local dry-run: `op-acceptor --dry-run --split-total 4 --split-index 0 --testdir ./tests/... --validators ./acceptance-tests.yaml`
- [ ] CI validation with companion optimism PR (CircleCI parallelism config)