### PR TITLE
fix(op-acceptor): use -skip flag for named test exclusions in gateless mode

### DIFF
--- a/op-acceptor/registry/registry.go
+++ b/op-acceptor/registry/registry.go
@@ -217,13 +217,29 @@ func (r *Registry) applyExcludeGates(cfgPath string, gates []string) {
 			filtered = append(filtered, v)
 			continue
 		}
-		// Match by tuple or package
-		if _, ok := s.byTuple[TestRef{Package: v.Package, Name: v.FuncName}]; ok || packagePrefixBlacklisted(v.Package, s.byPackage) {
+		// Package-level exclusion: drop the entire validator
+		if packagePrefixBlacklisted(v.Package, s.byPackage) {
 			excludedCount++
-			name := v.FuncName
-			excludedPrev = append(excludedPrev, formatRef(v.Package, name))
+			excludedPrev = append(excludedPrev, formatRef(v.Package, v.FuncName))
 			r.config.Log.Info("Excluded by blacklist", "package", v.Package, "name", v.FuncName)
 			continue
+		}
+		// Exact tuple match (validator has a specific FuncName)
+		if v.FuncName != "" {
+			if _, ok := s.byTuple[TestRef{Package: v.Package, Name: v.FuncName}]; ok {
+				excludedCount++
+				excludedPrev = append(excludedPrev, formatRef(v.Package, v.FuncName))
+				r.config.Log.Info("Excluded by blacklist", "package", v.Package, "name", v.FuncName)
+				continue
+			}
+		}
+		// RunAll validator (FuncName == ""): check if any tuple entries target tests in this package.
+		// Instead of dropping the whole package, populate SkipTests so the runner can use -skip.
+		if v.RunAll && v.FuncName == "" {
+			if skips := tupleMatchesForPackage(v.Package, s.byTuple); len(skips) > 0 {
+				v.SkipTests = skips
+				r.config.Log.Info("Added skip tests for package", "package", v.Package, "skipTests", skips)
+			}
 		}
 		filtered = append(filtered, v)
 	}
@@ -245,6 +261,21 @@ func packagePrefixBlacklisted(pkg string, byPackage map[string]struct{}) bool {
 		}
 	}
 	return false
+}
+
+// tupleMatchesForPackage returns test names from tuple entries whose package matches
+// or is a prefix of the given package (on segment boundaries).
+func tupleMatchesForPackage(pkg string, byTuple map[TestRef]struct{}) []string {
+	var names []string
+	for ref := range byTuple {
+		if ref.Name == "" {
+			continue
+		}
+		if ref.Package == pkg || (strings.HasPrefix(pkg, ref.Package) && (len(pkg) == len(ref.Package) || pkg[len(ref.Package)] == '/')) {
+			names = append(names, ref.Name)
+		}
+	}
+	return names
 }
 
 func formatRef(pkg string, name string) string {

--- a/op-acceptor/registry/registry_test.go
+++ b/op-acceptor/registry/registry_test.go
@@ -318,6 +318,74 @@ func TestExcludeGates_PackagePrefix_Gateless(t *testing.T) {
 	assert.Len(t, vals, 0, "all discovered tests under ./tests/pkg should be excluded by prefix blacklist")
 }
 
+func TestExcludeGates_NamedTest_Gateless(t *testing.T) {
+	// In gateless mode, validators have FuncName="" (RunAll).
+	// When an excluded gate names a specific test in a package, the validator
+	// should NOT be dropped; instead, SkipTests should be populated.
+	tmpDir := t.TempDir()
+
+	// Create two packages
+	pkg1Dir := filepath.Join(tmpDir, "tests", "pkg1")
+	pkg2Dir := filepath.Join(tmpDir, "tests", "pkg2")
+	require.NoError(t, os.MkdirAll(pkg1Dir, 0755))
+	require.NoError(t, os.MkdirAll(pkg2Dir, 0755))
+
+	// pkg1 has two tests
+	require.NoError(t, os.WriteFile(filepath.Join(pkg1Dir, "pkg1_test.go"), []byte(
+		"package pkg1_test\nimport \"testing\"\nfunc TestA(t *testing.T){}\nfunc TestB(t *testing.T){}\n",
+	), 0644))
+	// pkg2 has one test
+	require.NoError(t, os.WriteFile(filepath.Join(pkg2Dir, "pkg2_test.go"), []byte(
+		"package pkg2_test\nimport \"testing\"\nfunc TestC(t *testing.T){}\n",
+	), 0644))
+
+	// validators.yaml: gate 'shaky' names TestA in ./pkg1
+	cfgPath := filepath.Join(tmpDir, "validators.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`gates:
+  - id: shaky
+    tests:
+      - name: TestA
+        package: ./pkg1
+`), 0644))
+
+	// Save cwd and switch to tmpDir/tests so gateless discovery finds ./pkg1, ./pkg2
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(filepath.Join(tmpDir, "tests")))
+	defer func() { require.NoError(t, os.Chdir(origWd)) }()
+
+	reg, err := NewRegistry(Config{
+		Log:                 log.New(),
+		GatelessMode:        true,
+		TestDir:             ".",
+		ValidatorConfigFile: cfgPath,
+		ExcludeGates:        []string{"shaky"},
+	})
+	require.NoError(t, err)
+
+	vals := reg.GetValidators()
+	// Both packages should still be present
+	require.Len(t, vals, 2, "both packages should remain; named test exclusion should not drop the package")
+
+	// Find the pkg1 validator and verify SkipTests
+	var pkg1Val *types.ValidatorMetadata
+	for i := range vals {
+		if strings.HasSuffix(vals[i].Package, "pkg1") {
+			pkg1Val = &vals[i]
+			break
+		}
+	}
+	require.NotNil(t, pkg1Val, "pkg1 validator should exist")
+	assert.Equal(t, []string{"TestA"}, pkg1Val.SkipTests, "TestA should be in SkipTests")
+
+	// pkg2 should have no SkipTests
+	for _, v := range vals {
+		if strings.HasSuffix(v.Package, "pkg2") {
+			assert.Empty(t, v.SkipTests, "pkg2 should have no SkipTests")
+		}
+	}
+}
+
 func TestExcludeGates_Inheritance(t *testing.T) {
 	// Excluding a gate should also exclude tests it inherits from parents
 	tmpDir := t.TempDir()

--- a/op-acceptor/runner/constants.go
+++ b/op-acceptor/runner/constants.go
@@ -18,6 +18,7 @@ const (
 	TimeoutFlag     = "-timeout"
 	CountFlag       = "-count"
 	RunFlag         = "-run"
+	SkipFlag        = "-skip"
 
 	// Test count to disable caching
 	DisableCacheCount = "1"

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -1179,6 +1179,11 @@ func (r *runner) buildTestArgs(metadata types.ValidatorMetadata) []string {
 		args = append(args, "-run", fmt.Sprintf("^%s$", metadata.FuncName))
 	}
 
+	// Add skip pattern for excluded named tests
+	if len(metadata.SkipTests) > 0 {
+		args = append(args, SkipFlag, fmt.Sprintf("^(%s)$", strings.Join(metadata.SkipTests, "|")))
+	}
+
 	// Always disable caching
 	args = append(args, "-count", "1")
 

--- a/op-acceptor/runner/runner_test.go
+++ b/op-acceptor/runner/runner_test.go
@@ -280,6 +280,15 @@ func TestBuildTestArgs(t *testing.T) {
 			},
 			want: []string{"test", "./...", "-run", "^TestFoo$", "-count", "1", "-v", "-json"},
 		},
+		{
+			name: "run all with skip tests",
+			metadata: types.ValidatorMetadata{
+				Package:   "pkg/foo",
+				RunAll:    true,
+				SkipTests: []string{"TestFlaky", "TestUnstable"},
+			},
+			want: []string{"test", "pkg/foo", "-skip", "^(TestFlaky|TestUnstable)$", "-count", "1", "-timeout", "10m0s", "-v", "-json"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/op-acceptor/types/validator.go
+++ b/op-acceptor/types/validator.go
@@ -27,14 +27,15 @@ type ValidatorConfig struct {
 }
 
 type ValidatorMetadata struct {
-	ID       string
-	Type     ValidatorType
-	Gate     string
-	Suite    string
-	FuncName string
-	Package  string
-	Timeout  time.Duration
-	RunAll   bool
+	ID        string
+	Type      ValidatorType
+	Gate      string
+	Suite     string
+	FuncName  string
+	Package   string
+	Timeout   time.Duration
+	RunAll    bool
+	SkipTests []string // Test function names to skip via -skip flag
 }
 
 // GetName returns a name for the validator based on available fields


### PR DESCRIPTION
## Summary

- Fix `--exclude-gates` not working for named tests in gateless mode. In gateless mode, validators have `FuncName=""` (RunAll), so tuple matches (`package+name`) against the empty `FuncName` always failed — causing excluded named tests to run anyway.
- Instead of dropping the entire package validator, collect matching test names into a new `SkipTests` field on `ValidatorMetadata` and emit Go's `-skip` flag when building test arguments.
- Package-level exclusions (`byPackage`) still drop validators entirely, preserving existing behavior.

## Test plan

- [x] `go test ./registry/... -run TestExcludeGates -v` — all 4 tests pass including new `TestExcludeGates_NamedTest_Gateless`
- [x] `go test ./runner/... -run TestBuildTestArgs -v` — all 4 cases pass including new "run all with skip tests"
- [x] `go vet ./...` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)