### PR TITLE
fix(ci): install zstd for mise archive extraction in go-release job

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -277,6 +277,8 @@ jobs:
       - run:
           name: Setup mise
           command: |
+            # Install zstd (needed to extract mise archive)
+            apt-get update -qq && apt-get install -y -qq zstd
             # Install mise
             curl -fsSL https://mise.run | sh
             echo 'eval "$($HOME/.local/bin/mise activate bash)"' >> $BASH_ENV


### PR DESCRIPTION
## Summary
- The mise installer now ships `.tar.zst` archives, but the `ci-builder` Docker image used by the `go-release` job lacks `zstd`, causing the "Setup mise" step to fail with `zstd: Cannot exec: No such file or directory`
- Adds `apt-get install zstd` before the mise install command to fix the extraction

## Test plan
- [ ] Trigger a release build for op-acceptor and verify the "Setup mise" step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)