### PR TITLE
fix(op-conductor-mon): harden container image with DHI base images

### DIFF
--- a/op-conductor-mon/Dockerfile
+++ b/op-conductor-mon/Dockerfile
@@ -1,18 +1,12 @@
-FROM golang:1.23-alpine AS builder
+FROM dhi.io/golang:1.24-dev AS builder
 
 COPY ./op-conductor-mon /app
 
 WORKDIR /app
-RUN apk add --no-cache make jq bash git alpine-sdk
-RUN make build
+RUN CGO_ENABLED=0 make build
 
-FROM alpine:3.18
-RUN apk --no-cache add make jq bash git alpine-sdk redis
+FROM dhi.io/alpine-base:3.22
 
-RUN addgroup -S app && adduser -S app -G app
-USER app
-WORKDIR /app
-
-COPY --from=builder /app/bin/op-conductor-mon /app
+COPY --from=builder /app/bin/op-conductor-mon /app/op-conductor-mon
 
 ENTRYPOINT ["/app/op-conductor-mon"]


### PR DESCRIPTION
## Summary

Switch op-conductor-mon to Docker Hardened Images (DHI) for both build and runtime stages:

- **Builder**: `golang:1.23-alpine` -> `dhi.io/golang:1.24-dev` (Go 1.24.13, zero CVEs, includes make/git/gcc)
- **Runtime**: `alpine:3.18` (EOL) -> `dhi.io/alpine-base:3.22` (zero CVEs, runs as nonroot by default)
- Build with `CGO_ENABLED=0` for a static binary (no glibc/musl dependency)
- Remove unnecessary runtime packages: `redis`, `alpine-sdk`, `git`, `make`, `jq`, `bash` (none are used at runtime -- the binary is a pure Go HTTP service with no subprocess calls)
- Drop manual user creation (DHI alpine-base already runs as uid 65532/nonroot)

## Context

The current v0.0.3 image has **59 grype findings** including critical CVEs from the EOL Alpine 3.18 base and unnecessary packages installed in the runtime stage. See ethereum-optimism/cloud-security#13.

## Scan results

| Image | grype findings |
|-------|:-:|
| Current (v0.0.3) | 59 |
| This PR | 9 |

All 9 remaining findings are Go module dependency CVEs (golang.org/x/crypto, golang.org/x/net, golang-jwt, gnark-crypto) that require bumping deps in go.mod.

## Verified

- Image builds successfully
- Binary starts, loads config, and serves `/healthz` (returns `OK`) and `/metrics` endpoints
- Confirmed none of the removed packages (redis, alpine-sdk, git, make, jq, bash) are used at runtime via source code audit