### PR TITLE
fix(proxyd): pass chain ID to interop access list validation

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -254,6 +254,7 @@ type Config struct {
 type InteropValidationConfig struct {
 	Urls                              []string                  `toml:"urls"`
 	Strategy                          InteropValidationStrategy `toml:"strategy"`
+	ChainID                           uint64                    `toml:"chain_id"`
 	LoadBalancingUnhealthinessTimeout time.Duration             `toml:"load_balancing_unhealthiness_timeout"`
 	ReqSizeLimit                      int                       `toml:"req_size_limit"`
 	AccessListSizeLimit               int                       `toml:"access_list_size_limit"`

--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/golang-lru v1.0.2
+	github.com/holiman/uint256 v1.3.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/redis/go-redis/v9 v9.2.1
@@ -75,7 +76,6 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
-	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -7,11 +7,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	supervisorTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/eth/interop"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
 )
 
 type InteropStrategy interface {
@@ -20,6 +22,7 @@ type InteropStrategy interface {
 
 type commonInteropStrategy struct {
 	urls                                    []string
+	chainID                                 eth.ChainID
 	accessListSizeLimit                     int
 	reqSizeLimit                            int
 	validateAndDeduplicateInteropAccessList bool
@@ -69,6 +72,12 @@ var WithValidateAndDeduplicateInteropAccessList = func(validateAndDeduplicateInt
 var WithSkipOnNoSupervisorBackend = func(skipOnNoSupervisorBackend bool) commonStrategyOpt {
 	return func(s *commonInteropStrategy) {
 		s.skipOnNoSupervisorBackend = skipOnNoSupervisorBackend
+	}
+}
+
+var WithChainID = func(chainID uint64) commonStrategyOpt {
+	return func(s *commonInteropStrategy) {
+		s.chainID = eth.ChainIDFromUInt64(chainID)
 	}
 }
 
@@ -136,7 +145,7 @@ func (s *firstSupervisorStrategyImpl) ValidateAccessList(ctx context.Context, in
 	firstSupervisorUrl := s.urls[0]
 
 	ctx = context.WithValue(ctx, ContextKeyInteropValidationStrategy, FirstSupervisorStrategy) // nolint:staticcheck
-	_, _, err = performCheckAccessListOp(ctx, accessListToValidate, firstSupervisorUrl)
+	_, _, err = performCheckAccessListOp(ctx, accessListToValidate, firstSupervisorUrl, s.chainID)
 	return err
 }
 
@@ -167,7 +176,7 @@ func (s *multicallStrategyImpl) ValidateAccessList(ctx context.Context, interopA
 		wg.Add(1)
 		go func(ctx context.Context, url string) {
 			defer wg.Done()
-			_, _, err := performCheckAccessListOp(ctx, accessListToValidate, url)
+			_, _, err := performCheckAccessListOp(ctx, accessListToValidate, url, s.chainID)
 			resultChan <- err
 		}(ctx, url)
 	}
@@ -238,7 +247,7 @@ func (s *healthAwareLoadBalancingStrategyImpl) ValidateAccessList(ctx context.Co
 			continue
 		}
 
-		httpCode, err := backend.Validate(ctx, accessListToValidate)
+		httpCode, err := backend.Validate(ctx, accessListToValidate, s.chainID)
 		if err == nil {
 			return nil
 		}
@@ -290,17 +299,18 @@ func (b *healthAwareBackend) MarkUnhealthy() {
 	b.lastUnhealthy = time.Now()
 }
 
-func (b *healthAwareBackend) Validate(ctx context.Context, accessList []common.Hash) (int, error) {
-	httpCode, _, err := performCheckAccessListOp(ctx, accessList, b.url)
+func (b *healthAwareBackend) Validate(ctx context.Context, accessList []common.Hash, chainID eth.ChainID) (int, error) {
+	httpCode, _, err := performCheckAccessListOp(ctx, accessList, b.url, chainID)
 	if err != nil {
 		return httpCode, ParseInteropError(err)
 	}
 	return httpCode, nil
 }
 
-func performCheckAccessListOp(ctx context.Context, accessList []common.Hash, url string) (int, string, error) {
+func performCheckAccessListOp(ctx context.Context, accessList []common.Hash, url string, chainID eth.ChainID) (int, string, error) {
 	validatingBackend := interop.NewInteropClient(url)
 	err := validatingBackend.CheckAccessList(ctx, accessList, interoptypes.CrossUnsafe, interoptypes.ExecutingDescriptor{
+		ChainID:   uint256.Int(chainID),
 		Timestamp: getInteropExecutingDescriptorTimestamp(),
 	})
 

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -454,6 +454,7 @@ func Start(config *Config) (*Server, func(), error) {
 	opts := CommonStrategyOpts(
 		WithReqSizeLimit(config.InteropValidationConfig.ReqSizeLimit),
 		WithAccessListSizeLimit(config.InteropValidationConfig.AccessListSizeLimit),
+		WithChainID(config.InteropValidationConfig.ChainID),
 	)
 
 	switch config.InteropValidationConfig.Strategy {


### PR DESCRIPTION
## Summary
- Adds `chain_id` field to `InteropValidationConfig` so proxyd can pass the correct chain ID when validating interop access lists
- Threads the `ChainID` through all three validation strategies (first-supervisor, multicall, health-aware load balancing)
- Populates the `ExecutingDescriptor.ChainID` in `CheckAccessList` calls, which was previously left as zero

Without this fix, every interop transaction sent through proxyd fails with `executing chain 0: unknown chain` because the interop-filter rejects chain ID 0 (no such chain exists in its chain map).

## Test plan
- Deployed to interop-v0 devnet and verified interop executing messages succeed end-to-end through proxyd (previously all failed with "unknown chain")

🤖 Generated with [Claude Code](https://claude.com/claude-code)