### PR TITLE
fix(op-acceptor): skip RunAll package when all tests excluded by --exclude-gates

### DIFF
--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -747,20 +747,40 @@ func (r *runner) runAllTestsInPackage(ctx context.Context, metadata types.Valida
 	return res, err
 }
 
-// allTestsWouldBeSkipped returns true if every top-level test function in the
-// package is present in metadata.SkipTests, meaning no tests would actually run.
-// It uses "go test -list ." to enumerate the package's test functions without
-// executing them, so it is cheap and does not start any test infrastructure.
+// testFuncPattern matches top-level Go test function declarations. We only
+// match Test* here because SkipTests comes from explicit YAML entries which
+// are invariably Test* functions; Benchmark* and Fuzz* are not skipped via
+// -skip in normal acceptance test runs.
+var testFuncPattern = regexp.MustCompile(`^func (Test\w+)\(`)
+
+// allTestsWouldBeSkipped returns true if every top-level Test* function in the
+// package source is present in metadata.SkipTests, meaning no tests would
+// actually run.
+//
+// Critically, this must NOT invoke the test binary because TestMain can start
+// expensive infrastructure (devnets) that hangs on teardown when 0 tests run.
+// Instead we use "go list -json" to resolve the package's test source files
+// and scan them with a regex — no compilation or execution required.
 func (r *runner) allTestsWouldBeSkipped(ctx context.Context, metadata types.ValidatorMetadata) (bool, error) {
-	cmd, cleanup := r.testCommandContext(ctx, r.goBinary, "test", "-list", ".", metadata.Package)
+	// Resolve test source files via "go list -json" (no build, no test binary).
+	listCmd, cleanup := r.testCommandContext(ctx, r.goBinary, "list", "-json", metadata.Package)
 	defer cleanup()
 
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = io.Discard
+	var listOut bytes.Buffer
+	listCmd.Stdout = &listOut
+	listCmd.Stderr = io.Discard
 
-	if err := cmd.Run(); err != nil {
-		return false, fmt.Errorf("go test -list failed for %s: %w", metadata.Package, err)
+	if err := listCmd.Run(); err != nil {
+		return false, fmt.Errorf("go list -json failed for %s: %w", metadata.Package, err)
+	}
+
+	var pkgInfo struct {
+		Dir          string
+		TestGoFiles  []string
+		XTestGoFiles []string
+	}
+	if err := json.Unmarshal(listOut.Bytes(), &pkgInfo); err != nil {
+		return false, fmt.Errorf("parsing go list output for %s: %w", metadata.Package, err)
 	}
 
 	skipSet := make(map[string]struct{}, len(metadata.SkipTests))
@@ -768,28 +788,43 @@ func (r *runner) allTestsWouldBeSkipped(ctx context.Context, metadata types.Vali
 		skipSet[s] = struct{}{}
 	}
 
-	// "go test -list" outputs one test name per line, followed by a summary line
-	// like "ok  <package>  0.001s". Only count lines that look like test names
-	// (no spaces, non-empty, not the "ok" summary).
+	testFiles := append(pkgInfo.TestGoFiles, pkgInfo.XTestGoFiles...)
 	foundAny := false
-	scanner := bufio.NewScanner(&out)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "ok ") || strings.HasPrefix(line, "?") {
-			continue
+	for _, file := range testFiles {
+		fns, err := scanTestFunctions(filepath.Join(pkgInfo.Dir, file))
+		if err != nil {
+			return false, fmt.Errorf("scanning %s: %w", file, err)
 		}
-		foundAny = true
-		if _, skip := skipSet[line]; !skip {
-			return false, nil // at least one test would run
+		for _, fn := range fns {
+			foundAny = true
+			if _, skip := skipSet[fn]; !skip {
+				return false, nil // at least one test would run
+			}
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return false, fmt.Errorf("scanning go test -list output: %w", err)
 	}
 
-	// If no test functions were found at all, don't treat that as "all skipped";
-	// let the normal execution handle the empty-package case.
+	// If no Test* functions were found at all, do not treat that as "all
+	// skipped" — let the normal execution path handle the empty-package case.
 	return foundAny, nil
+}
+
+// scanTestFunctions opens a Go test source file and returns the names of all
+// top-level Test* functions found in it.
+func scanTestFunctions(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var funcs []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if m := testFuncPattern.FindStringSubmatch(scanner.Text()); m != nil {
+			funcs = append(funcs, m[1])
+		}
+	}
+	return funcs, scanner.Err()
 }
 
 // runTestList runs a list of tests and aggregates their results

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -715,6 +716,24 @@ func (r *runner) RunTest(ctx context.Context, metadata types.ValidatorMetadata) 
 // runAllTestsInPackage discovers and runs all tests in a package
 // Executes the entire package as a single go test process to preserve intra-package parallelism.
 func (r *runner) runAllTestsInPackage(ctx context.Context, metadata types.ValidatorMetadata) (*types.TestResult, error) {
+	// If the validator has a non-empty SkipTests list, check whether every test
+	// in the package would be skipped. If so, skip the entire invocation to avoid
+	// spinning up expensive test infrastructure (e.g. devnets) that will never
+	// actually run any tests and may hang on teardown.
+	if len(metadata.SkipTests) > 0 {
+		if all, err := r.allTestsWouldBeSkipped(ctx, metadata); err != nil {
+			r.log.Warn("Could not determine if all tests are skipped; proceeding normally",
+				"package", metadata.Package, "err", err)
+		} else if all {
+			r.log.Info("All tests in package are excluded by skip filter; skipping package invocation",
+				"package", metadata.Package, "skipTests", metadata.SkipTests)
+			return &types.TestResult{
+				Metadata: metadata,
+				Status:   types.TestStatusSkip,
+			}, nil
+		}
+	}
+
 	pkgMeta := metadata
 	pkgMeta.RunAll = false
 	pkgMeta.FuncName = ""
@@ -726,6 +745,51 @@ func (r *runner) runAllTestsInPackage(ctx context.Context, metadata types.Valida
 		res.Metadata.RunAll = true
 	}
 	return res, err
+}
+
+// allTestsWouldBeSkipped returns true if every top-level test function in the
+// package is present in metadata.SkipTests, meaning no tests would actually run.
+// It uses "go test -list ." to enumerate the package's test functions without
+// executing them, so it is cheap and does not start any test infrastructure.
+func (r *runner) allTestsWouldBeSkipped(ctx context.Context, metadata types.ValidatorMetadata) (bool, error) {
+	cmd, cleanup := r.testCommandContext(ctx, r.goBinary, "test", "-list", ".", metadata.Package)
+	defer cleanup()
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("go test -list failed for %s: %w", metadata.Package, err)
+	}
+
+	skipSet := make(map[string]struct{}, len(metadata.SkipTests))
+	for _, s := range metadata.SkipTests {
+		skipSet[s] = struct{}{}
+	}
+
+	// "go test -list" outputs one test name per line, followed by a summary line
+	// like "ok  <package>  0.001s". Only count lines that look like test names
+	// (no spaces, non-empty, not the "ok" summary).
+	foundAny := false
+	scanner := bufio.NewScanner(&out)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "ok ") || strings.HasPrefix(line, "?") {
+			continue
+		}
+		foundAny = true
+		if _, skip := skipSet[line]; !skip {
+			return false, nil // at least one test would run
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, fmt.Errorf("scanning go test -list output: %w", err)
+	}
+
+	// If no test functions were found at all, don't treat that as "all skipped";
+	// let the normal execution handle the empty-package case.
+	return foundAny, nil
 }
 
 // runTestList runs a list of tests and aggregates their results

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -796,6 +796,11 @@ func (r *runner) allTestsWouldBeSkipped(ctx context.Context, metadata types.Vali
 			return false, fmt.Errorf("scanning %s: %w", file, err)
 		}
 		for _, fn := range fns {
+			// TestMain is the test harness entry point, not an actual test function.
+			// The Go testing framework never runs it as a test, so exclude it.
+			if fn == "TestMain" {
+				continue
+			}
 			foundAny = true
 			if _, skip := skipSet[fn]; !skip {
 				return false, nil // at least one test would run

--- a/op-acceptor/runner/runner_test.go
+++ b/op-acceptor/runner/runner_test.go
@@ -2375,10 +2375,17 @@ gates:
     tests:
       - package: ./feature
 `)
+	// Include a TestMain to verify it is not mistaken for a test function and
+	// does not prevent the all-skipped detection from working.
 	testContent := []byte(`
 package feature_test
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) { os.Exit(m.Run()) }
 
 func TestOnlyTest(t *testing.T) { t.Log("only test") }
 `)

--- a/op-acceptor/runner/runner_test.go
+++ b/op-acceptor/runner/runner_test.go
@@ -2354,3 +2354,68 @@ func TestChildPkg(t *testing.T) { t.Log("child ok") }
 	assert.True(t, hasParent, "should contain TestParentPkg from parent package")
 	assert.True(t, hasChild, "should contain TestChildPkg from child subpackage")
 }
+
+// TestRunAllTests_SkipWhenAllTestsExcluded verifies that when every test in a RunAll
+// package appears in the SkipTests list, the package is not invoked at all and the
+// result is reported as skipped. This prevents expensive test infrastructure (like
+// devnets) from starting when no tests would actually run.
+func TestRunAllTests_SkipWhenAllTestsExcluded(t *testing.T) {
+	ctx := context.Background()
+
+	// Package has one test: TestOnlyTest.
+	// It is listed in a "quarantine" gate so that exclude-gates sets SkipTests.
+	// The "production" gate uses a RunAll validator for the same package.
+	configContent := []byte(`
+gates:
+  - id: quarantine
+    tests:
+      - package: ./feature
+        name: TestOnlyTest
+  - id: production
+    tests:
+      - package: ./feature
+`)
+	testContent := []byte(`
+package feature_test
+
+import "testing"
+
+func TestOnlyTest(t *testing.T) { t.Log("only test") }
+`)
+
+	testDir := t.TempDir()
+	initGoModule(t, testDir, "test")
+	featureDir := filepath.Join(testDir, "feature")
+	require.NoError(t, os.MkdirAll(featureDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(featureDir, "example_test.go"), testContent, 0644))
+
+	validatorConfigPath := filepath.Join(testDir, "validators.yaml")
+	require.NoError(t, os.WriteFile(validatorConfigPath, configContent, 0644))
+
+	reg, err := registry.NewRegistry(registry.Config{
+		ValidatorConfigFile: validatorConfigPath,
+		ExcludeGates:        []string{"quarantine"},
+	})
+	require.NoError(t, err)
+
+	r, err := NewTestRunner(Config{
+		Registry: reg,
+		WorkDir:  testDir,
+		Log:      testlog.Logger(t, slog.LevelDebug),
+	})
+	require.NoError(t, err)
+
+	result, err := r.RunAllTests(ctx)
+	require.NoError(t, err)
+
+	// The production gate should have a skipped result for the package (not a failure).
+	require.Contains(t, result.Gates, "production")
+	gate := result.Gates["production"]
+	require.Len(t, gate.Tests, 1)
+	var pkgResult *types.TestResult
+	for _, v := range gate.Tests {
+		pkgResult = v
+	}
+	require.NotNil(t, pkgResult)
+	assert.Equal(t, types.TestStatusSkip, pkgResult.Status, "package with all tests excluded should be reported as skipped, not failed")
+}


### PR DESCRIPTION
## Summary

- Fixes a CI hang caused by \`--exclude-gates flake-shake\` on RunAll packages where every test is excluded
- When all tests in a RunAll package are in \`SkipTests\`, \`go test\` is no longer invoked — the package is reported as skipped immediately
- Adds a regression test covering the all-tests-excluded case

## Root cause

When \`--exclude-gates flake-shake\` is applied, named tests in excluded gates are added to \`SkipTests\` on their package's RunAll validator. \`go test -skip\` is then passed to the test binary. If every test in a package is in \`SkipTests\`:

1. \`go test ./reqressyncdisabled -skip ...\` runs
2. \`TestMain\` is called → \`presets.DoMain\` → full devnet starts (EL snap sync between geth nodes begins)
3. \`m.Run()\` returns 0 immediately (all tests skipped by \`-skip\`)
4. \`defer p.Close()\` fires → \`n.server.Stop()\` in go-ethereum blocks waiting for active snap sync P2P connections to close → **indefinite hang**

## Fix

Before invoking \`go test\` for a RunAll validator with a non-empty \`SkipTests\` list, check whether every \`Test*\` function in the package source is in the skip set. If so, return \`TestStatusSkip\` immediately.

**Why not \`go test -list\`?** \`go test -list\` invokes the test binary, which calls \`TestMain\`. \`presets.DoMain\` starts the devnet inside \`TestMain\` _before_ \`m.Run()\` — so the pre-check would hang on the same teardown it was meant to prevent.

**Correct approach — source-level scan:**
1. \`go list -json <package>\` resolves \`TestGoFiles\` and \`XTestGoFiles\` (no build, no binary execution)
2. Scan each file with \`regexp\` for \`^func (Test\\w+)(\` declarations
3. If every found \`Test*\` function is in \`SkipTests\`, skip the package invocation entirely

This never runs \`TestMain\` or starts any test infrastructure.

## Affected scenario

The \`reqressyncdisabled\` package in gateless/memory-all mode with \`--exclude-gates flake-shake\`. Its single test (\`TestUnsafeChainNotStalling_DisabledReqRespSync\`) is in the flake-shake gate. With this fix, the package is skipped entirely instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)