### PR TITLE
feat(op-acceptor): add --shard-index/--shard-total for parallel gateless sharding

### DIFF
--- a/op-acceptor/config.go
+++ b/op-acceptor/config.go
@@ -37,6 +37,8 @@ type Config struct {
 	FlakeShake           bool                   // Enable flake-shake mode for test stability validation
 	FlakeShakeIterations int                    // Number of times to run each test in flake-shake mode
 	DryRun               bool                   // If true, show what tests would be run without executing them
+	ShardIndex           int                    // Zero-based shard index (-1 = no sharding)
+	ShardTotal           int                    // Total number of shards (0 = no sharding)
 	Log                  log.Logger
 	ExcludeGates         []string // List of gate IDs whose tests should be excluded
 }
@@ -122,6 +124,21 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 
 	excludeGates := parseExcludeGates(ctx.String(flags.ExcludeGates.Name))
 
+	// Parse and validate shard flags
+	shardIndex := ctx.Int(flags.ShardIndex.Name)
+	shardTotal := ctx.Int(flags.ShardTotal.Name)
+	if shardIndex >= 0 || shardTotal > 0 {
+		if shardTotal <= 0 {
+			return nil, fmt.Errorf("--shard-total must be > 0 when --shard-index is set")
+		}
+		if shardIndex < 0 || shardIndex >= shardTotal {
+			return nil, fmt.Errorf("--shard-index must be in range [0, %d)", shardTotal)
+		}
+		if !gatelessMode {
+			return nil, fmt.Errorf("--shard-index/--shard-total can only be used in gateless mode (without --gate)")
+		}
+	}
+
 	// Conflict: selected gates are also excluded
 	for _, g := range gates {
 		for _, eg := range excludeGates {
@@ -153,6 +170,8 @@ func NewConfig(ctx *cli.Context, log log.Logger, testDir string, validatorConfig
 		FlakeShake:           ctx.Bool(flags.FlakeShake.Name),
 		FlakeShakeIterations: ctx.Int(flags.FlakeShakeIterations.Name),
 		DryRun:               ctx.Bool(flags.DryRun.Name),
+		ShardIndex:           shardIndex,
+		ShardTotal:           shardTotal,
 		LogDir:               logDir,
 		Log:                  log,
 		ExcludeGates:         excludeGates,

--- a/op-acceptor/flags/flags.go
+++ b/op-acceptor/flags/flags.go
@@ -185,6 +185,18 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "EXCLUDE_GATES"),
 		Usage:   "Comma-separated list of gate IDs to blacklist globally across all modes.",
 	}
+	ShardIndex = &cli.IntFlag{
+		Name:    "shard-index",
+		Value:   -1,
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "SHARD_INDEX"),
+		Usage:   "Zero-based shard index for this worker. Must be used with --shard-total. Only applies in gateless mode.",
+	}
+	ShardTotal = &cli.IntFlag{
+		Name:    "shard-total",
+		Value:   0,
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "SHARD_TOTAL"),
+		Usage:   "Total number of shards. Must be used with --shard-index. Only applies in gateless mode.",
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -211,6 +223,8 @@ var optionalFlags = []cli.Flag{
 	FlakeShake,
 	FlakeShakeIterations,
 	ExcludeGates,
+	ShardIndex,
+	ShardTotal,
 	DryRun,
 }
 var Flags []cli.Flag

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -113,6 +113,8 @@ func New(ctx context.Context, config *Config, version string, shutdownCallback f
 		GatelessMode:        config.GatelessMode,
 		TestDir:             config.TestDir,
 		ExcludeGates:        config.ExcludeGates,
+		ShardIndex:          config.ShardIndex,
+		ShardTotal:          config.ShardTotal,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create registry: %w", err)

--- a/op-acceptor/registry/registry.go
+++ b/op-acceptor/registry/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -34,6 +35,9 @@ type Config struct {
 	TestDir      string
 	// Skip behavior
 	ExcludeGates []string
+	// Sharding (gateless mode only)
+	ShardIndex int // Zero-based shard index (-1 = no sharding)
+	ShardTotal int // Total number of shards (0 = no sharding)
 }
 
 // NewRegistry creates a new registry instance
@@ -99,6 +103,25 @@ func (r *Registry) loadGatelessValidators() error {
 	}
 
 	r.config.Log.Debug("Found test packages", "count", len(packages), "packages", packages)
+
+	// Apply shard filtering if configured
+	if r.config.ShardTotal > 0 && r.config.ShardIndex >= 0 {
+		sort.Strings(packages) // deterministic ordering before sharding
+		var sharded []string
+		for i, pkg := range packages {
+			if i%r.config.ShardTotal == r.config.ShardIndex {
+				sharded = append(sharded, pkg)
+			}
+		}
+		r.config.Log.Info("Shard filtering applied",
+			"shard", fmt.Sprintf("%d/%d", r.config.ShardIndex, r.config.ShardTotal),
+			"before", len(packages), "after", len(sharded))
+		packages = sharded
+		if len(packages) == 0 {
+			r.config.Log.Warn("Shard has no test packages",
+				"shardIndex", r.config.ShardIndex, "shardTotal", r.config.ShardTotal)
+		}
+	}
 
 	// Create synthetic validators for each discovered package
 	var validators []types.ValidatorMetadata

--- a/op-acceptor/registry/registry_test.go
+++ b/op-acceptor/registry/registry_test.go
@@ -1,8 +1,10 @@
 package registry
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -495,6 +497,219 @@ func TestExample2(t *testing.T) {
 	}
 	expected := []string{"./pkg1", "./subdir/pkg2"}
 	require.ElementsMatch(t, expected, packages)
+}
+
+// createTestPackages creates n test packages under tmpDir and returns their
+// expected relative paths (e.g., "./pkg-00", "./pkg-01", ...).
+func createTestPackages(t *testing.T, tmpDir string, n int) []string {
+	t.Helper()
+	var paths []string
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("pkg-%02d", i)
+		dir := filepath.Join(tmpDir, name)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		content := fmt.Sprintf("package %s\nimport \"testing\"\nfunc Test%s(t *testing.T){}\n", name, name)
+		// Package names can't have hyphens — use underscore in Go but keep dir name for path
+		content = strings.ReplaceAll(content, "-", "_")
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name+"_test.go"), []byte(content), 0644))
+		paths = append(paths, "./"+name)
+	}
+	return paths
+}
+
+func TestShardFiltering_Basic(t *testing.T) {
+	tmpDir := t.TempDir()
+	createTestPackages(t, tmpDir, 8)
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { require.NoError(t, os.Chdir(originalWd)) }()
+
+	// Create 4 shards and verify each gets 2 packages
+	for shard := 0; shard < 4; shard++ {
+		reg, err := NewRegistry(Config{
+			Log:          log.New(),
+			GatelessMode: true,
+			TestDir:      ".",
+			ShardIndex:   shard,
+			ShardTotal:   4,
+		})
+		require.NoError(t, err)
+
+		vals := reg.GetValidators()
+		assert.Len(t, vals, 2, "shard %d should have 2 packages", shard)
+	}
+}
+
+func TestShardFiltering_Coverage(t *testing.T) {
+	// Verify that the union of all shards equals the full package set (no gaps, no duplicates).
+	tmpDir := t.TempDir()
+	allPkgs := createTestPackages(t, tmpDir, 10)
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { require.NoError(t, os.Chdir(originalWd)) }()
+
+	shardTotal := 3
+	var allShardedPkgs []string
+
+	for shard := 0; shard < shardTotal; shard++ {
+		reg, err := NewRegistry(Config{
+			Log:          log.New(),
+			GatelessMode: true,
+			TestDir:      ".",
+			ShardIndex:   shard,
+			ShardTotal:   shardTotal,
+		})
+		require.NoError(t, err)
+
+		for _, v := range reg.GetValidators() {
+			allShardedPkgs = append(allShardedPkgs, v.Package)
+		}
+	}
+
+	sort.Strings(allPkgs)
+	sort.Strings(allShardedPkgs)
+	assert.Equal(t, allPkgs, allShardedPkgs, "union of all shards should equal the full package set")
+}
+
+func TestShardFiltering_Deterministic(t *testing.T) {
+	// Running the same shard twice should produce identical results.
+	tmpDir := t.TempDir()
+	createTestPackages(t, tmpDir, 6)
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { require.NoError(t, os.Chdir(originalWd)) }()
+
+	var runs [2][]string
+	for i := 0; i < 2; i++ {
+		reg, err := NewRegistry(Config{
+			Log:          log.New(),
+			GatelessMode: true,
+			TestDir:      ".",
+			ShardIndex:   1,
+			ShardTotal:   3,
+		})
+		require.NoError(t, err)
+		for _, v := range reg.GetValidators() {
+			runs[i] = append(runs[i], v.Package)
+		}
+	}
+	assert.Equal(t, runs[0], runs[1], "shard assignment should be deterministic")
+}
+
+func TestShardFiltering_NoOverlap(t *testing.T) {
+	// No package should appear in more than one shard.
+	tmpDir := t.TempDir()
+	createTestPackages(t, tmpDir, 7)
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { require.NoError(t, os.Chdir(originalWd)) }()
+
+	shardTotal := 3
+	seen := make(map[string]int) // package -> which shard
+
+	for shard := 0; shard < shardTotal; shard++ {
+		reg, err := NewRegistry(Config{
+			Log:          log.New(),
+			GatelessMode: true,
+			TestDir:      ".",
+			ShardIndex:   shard,
+			ShardTotal:   shardTotal,
+		})
+		require.NoError(t, err)
+
+		for _, v := range reg.GetValidators() {
+			prev, dup := seen[v.Package]
+			assert.False(t, dup, "package %s appears in shard %d and %d", v.Package, prev, shard)
+			seen[v.Package] = shard
+		}
+	}
+}
+
+func TestShardFiltering_MoreShardsThanPackages(t *testing.T) {
+	// When there are more shards than packages, some shards should be empty.
+	tmpDir := t.TempDir()
+	createTestPackages(t, tmpDir, 2)
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { require.NoError(t, os.Chdir(originalWd)) }()
+
+	nonEmpty := 0
+	for shard := 0; shard < 5; shard++ {
+		reg, err := NewRegistry(Config{
+			Log:          log.New(),
+			GatelessMode: true,
+			TestDir:      ".",
+			ShardIndex:   shard,
+			ShardTotal:   5,
+		})
+		require.NoError(t, err)
+		if len(reg.GetValidators()) > 0 {
+			nonEmpty++
+		}
+	}
+	assert.Equal(t, 2, nonEmpty, "only 2 shards should have packages when there are 2 packages and 5 shards")
+}
+
+func TestShardFiltering_SinglePackage(t *testing.T) {
+	tmpDir := t.TempDir()
+	createTestPackages(t, tmpDir, 1)
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { require.NoError(t, os.Chdir(originalWd)) }()
+
+	// Shard 0 should get the package, shard 1 should be empty
+	reg0, err := NewRegistry(Config{
+		Log:          log.New(),
+		GatelessMode: true,
+		TestDir:      ".",
+		ShardIndex:   0,
+		ShardTotal:   2,
+	})
+	require.NoError(t, err)
+	assert.Len(t, reg0.GetValidators(), 1)
+
+	reg1, err := NewRegistry(Config{
+		Log:          log.New(),
+		GatelessMode: true,
+		TestDir:      ".",
+		ShardIndex:   1,
+		ShardTotal:   2,
+	})
+	require.NoError(t, err)
+	assert.Len(t, reg1.GetValidators(), 0)
+}
+
+func TestShardFiltering_Disabled(t *testing.T) {
+	// Default values (-1, 0) should mean no sharding — all packages returned.
+	tmpDir := t.TempDir()
+	createTestPackages(t, tmpDir, 4)
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { require.NoError(t, os.Chdir(originalWd)) }()
+
+	reg, err := NewRegistry(Config{
+		Log:          log.New(),
+		GatelessMode: true,
+		TestDir:      ".",
+		ShardIndex:   -1,
+		ShardTotal:   0,
+	})
+	require.NoError(t, err)
+	assert.Len(t, reg.GetValidators(), 4, "no sharding should return all packages")
 }
 
 func TestRegistryGatelessModeEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `--shard-index` and `--shard-total` flags to op-acceptor for round-robin test package sharding in gateless mode
- After package discovery, packages are sorted alphabetically (deterministic), then filtered by `index % total == shardIndex`
- New test packages are automatically picked up by shards; removed packages disappear — **no manual gate curation needed**

## Motivation

The Optimism monorepo's `memory-all` CI job runs ~40 acceptance test packages in a single worker, which is the critical path bottleneck. With this change, CI can parallelize into N shards:

```yaml
# .circleci matrix
matrix:
  parameters:
    shard: [0, 1, 2, 3, 4, 5, 6, 7]
```

```bash
op-acceptor \
  --testdir ./op-acceptance-tests/... \
  --shard-index $SHARD --shard-total 8 \
  --exclude-gates flake-shake \
  --allow-skips --timeout 120m \
  --orchestrator sysgo
```

This eliminates the need for manually maintained `ci-shard-*` gates in `acceptance-tests.yaml` and orphan detection scripts.

## Changes

| File | Change |
|------|--------|
| `flags/flags.go` | New `--shard-index` (default -1) and `--shard-total` (default 0) flags with env vars |
| `config.go` | Parse + validate: both must be set together, index in `[0, total)`, gateless-only |
| `nat.go` | Thread shard config into registry |
| `registry/registry.go` | Sort packages, apply `i % total == index` filter in `loadGatelessValidators()` |
| `registry/registry_test.go` | 7 new tests covering basic sharding, coverage, determinism, no-overlap, edge cases |

## Test plan

- [x] `TestShardFiltering_Basic` — 8 packages / 4 shards = 2 each
- [x] `TestShardFiltering_Coverage` — union of all shards == full package set
- [x] `TestShardFiltering_Deterministic` — same shard twice = same result
- [x] `TestShardFiltering_NoOverlap` — no package in multiple shards
- [x] `TestShardFiltering_MoreShardsThanPackages` — empty shards handled
- [x] `TestShardFiltering_SinglePackage` — 1 package / 2 shards
- [x] `TestShardFiltering_Disabled` — default values = no sharding
- [x] All 18 registry tests pass (11 existing + 7 new)
- [x] `go vet` clean on all changed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)