### PR TITLE
fix(proxyd): separate context for tx validation  middleware

### DIFF
--- a/proxyd/tx_validation_middleware.go
+++ b/proxyd/tx_validation_middleware.go
@@ -81,7 +81,7 @@ func NewTxValidationClient(timeoutSeconds int) *TxValidationClient {
 // Returns a map of tx hashes to unauthorized status.
 func (c *TxValidationClient) Validate(ctx context.Context, endpoint string, payload []byte) (map[string]bool, error) {
 	// Detach from the request context so that client disconnects don't cancel
-	// the middleware request. We still enforce our own timeout.
+	// the middleware request, allowing transactions to bypass validation when failing open.
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.timeout)
 	defer cancel()
 

--- a/proxyd/tx_validation_middleware.go
+++ b/proxyd/tx_validation_middleware.go
@@ -80,7 +80,9 @@ func NewTxValidationClient(timeoutSeconds int) *TxValidationClient {
 // Validate performs the HTTP request to the validation middleware service.
 // Returns a map of tx hashes to unauthorized status.
 func (c *TxValidationClient) Validate(ctx context.Context, endpoint string, payload []byte) (map[string]bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	// Detach from the request context so that client disconnects don't cancel
+	// the middleware request. We still enforce our own timeout.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.timeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(payload))

--- a/proxyd/tx_validation_middleware_test.go
+++ b/proxyd/tx_validation_middleware_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -320,24 +319,6 @@ func TestDecodeSignedTx_Missing0xPrefix(t *testing.T) {
 	txHex := common.Bytes2Hex(txBytes)
 	_, err = decodeSignedTx(context.Background(), txHex)
 	require.Error(t, err)
-}
-
-func TestTxValidationClient_CanceledContext(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(100 * time.Millisecond)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"unauthorized": {}}`))
-	}))
-	defer server.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
-
-	client := NewTxValidationClient(5)
-	_, err := client.Validate(ctx, server.URL, []byte(`{}`))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, context.Canceled))
 }
 
 func TestValidateTransactions_CanceledContext(t *testing.T) {

--- a/proxyd/tx_validation_middleware_test.go
+++ b/proxyd/tx_validation_middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -290,6 +291,33 @@ func TestTxValidationClient_ErrorResponse(t *testing.T) {
 	_, err := client.Validate(context.Background(), server.URL, []byte(`{}`))
 	require.Error(t, err)
 	require.Equal(t, ErrInternal, err)
+}
+
+func TestTxValidationClient_CanceledParentContextStillValidates(t *testing.T) {
+	requestReachedServer := make(chan struct{}, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReachedServer <- struct{}{}
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"unauthorized": {}}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel parent request context before validation call
+
+	client := NewTxValidationClient(5)
+	unauthorized, err := client.Validate(ctx, server.URL, []byte(`{}`))
+	require.NoError(t, err)
+	require.Empty(t, unauthorized)
+
+	select {
+	case <-requestReachedServer:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("validation request did not reach server")
+	}
 }
 
 func TestDecodeSignedTx(t *testing.T) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

We've been seeing warning logs in Unichain Sepolia about tx validation service errors, due to clients canceling their request in the middle of the tx validation middleware request:

```
{
  "req_id": "xxx",
  "tx_count": 1,
  "level": "WARN",
  "time": "2026-03-12T14:53:24.18263982Z",
  "error": "Post \"https://tx-validation-middleware\": context canceled"
}
```

**We should have a separate request context for the tx validation service that isn't affected by client cancels, to ensure transactions cannot bypass tx validation when `fail_open=True`.**

**Tests**

Modified test to expect context to NOT be canceled.
