### PR TITLE
feat(proxyd): log sendRawTransaction forwarding with tx_hash and duration

### DIFF
--- a/proxyd/integration_tests/tx_hash_logging_test.go
+++ b/proxyd/integration_tests/tx_hash_logging_test.go
@@ -49,6 +49,10 @@ func TestTxHashLogging(t *testing.T) {
 		require.Contains(t, logOutput, "req_id")
 		require.Contains(t, logOutput, "chain_id")
 		require.Contains(t, logOutput, "nonce")
+
+		// Verify forwarding log also present with tx_hash and duration
+		require.Contains(t, logOutput, "sendRawTransaction forwarded")
+		require.Contains(t, logOutput, "duration_ms")
 	})
 
 	t.Run("batch sendRawTransaction should log tx hash", func(t *testing.T) {
@@ -121,6 +125,7 @@ func TestTxHashLoggingDisabled(t *testing.T) {
 		// Verify log does NOT contain transaction hash logging
 		logOutput := logBuf.String()
 		require.NotContains(t, logOutput, "processing sendRawTransaction")
+		require.NotContains(t, logOutput, "sendRawTransaction forwarded")
 		require.NotContains(t, logOutput, "0x0cdd497ce38727606708946cd07b83b101b92a29dea7f090f1f09ae849efd1a3")
 	})
 }

--- a/proxyd/integration_tests/tx_hash_logging_test.go
+++ b/proxyd/integration_tests/tx_hash_logging_test.go
@@ -2,15 +2,37 @@ package integration_tests
 
 import (
 	"bytes"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/ethereum-optimism/infra/proxyd"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
+
+// findJSONLogLine searches JSON log output for a line with the given message
+// and returns the parsed fields, or nil if not found.
+func findJSONLogLine(t *testing.T, logOutput string, msg string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(logOutput, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry["msg"] == msg {
+			return entry
+		}
+	}
+	return nil
+}
 
 func TestTxHashLogging(t *testing.T) {
 	// Capture log output
@@ -50,9 +72,16 @@ func TestTxHashLogging(t *testing.T) {
 		require.Contains(t, logOutput, "chain_id")
 		require.Contains(t, logOutput, "nonce")
 
-		// Verify forwarding log also present with tx_hash and duration
-		require.Contains(t, logOutput, "sendRawTransaction forwarded")
-		require.Contains(t, logOutput, "duration_ms")
+		// Verify forwarding log has correct tx_hash and matching req_id
+		recvLog := findJSONLogLine(t, logOutput, "processing sendRawTransaction")
+		require.NotNil(t, recvLog, "expected processing sendRawTransaction log line")
+
+		fwdLog := findJSONLogLine(t, logOutput, "sendRawTransaction forwarded")
+		require.NotNil(t, fwdLog, "expected sendRawTransaction forwarded log line")
+		require.Equal(t, "0x0cdd497ce38727606708946cd07b83b101b92a29dea7f090f1f09ae849efd1a3", fwdLog["tx_hash"])
+		require.Equal(t, recvLog["req_id"], fwdLog["req_id"], "req_id should match between processing and forwarded logs")
+		require.NotEmpty(t, fwdLog["backend"], "backend should be present")
+		require.NotNil(t, fwdLog["duration_ms"], "duration_ms should be present")
 	})
 
 	t.Run("batch sendRawTransaction should log tx hash", func(t *testing.T) {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -568,6 +568,7 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 	responses := make([]*RPCRes, len(reqs))
 	batches := make(map[batchGroup][]batchElem)
 	ids := make(map[string]int, len(reqs))
+	txHashes := make(map[int]common.Hash) // tracks tx hashes by request index for forwarding logs
 
 	for i := range reqs {
 		parsedReq, err := ParseRPCReq(reqs[i])
@@ -653,6 +654,7 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				responses[i] = NewRPCErrorRes(parsedReq.ID, err)
 				continue
 			}
+			txHashes[i] = tx.Hash()
 			if err := s.rateLimitSender(ctx, tx, bypassLimit); err != nil {
 				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)
 				responses[i] = NewRPCErrorRes(parsedReq.ID, err)
@@ -713,8 +715,26 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			start := i * s.maxUpstreamBatchSize
 			end := int(math.Min(float64(start+s.maxUpstreamBatchSize), float64(len(cacheMisses))))
 			elems := cacheMisses[start:end]
+			forwardStart := time.Now()
 			res, sb, err := s.BackendGroups[group.backendGroup].Forward(ctx, createBatchRequest(elems), isBatch)
+			forwardDuration := time.Since(forwardStart)
 			servedBy[sb] = true
+
+			// Log forwarding for sendRawTransaction requests
+			if s.enableTxHashLogging {
+				for _, elem := range elems {
+					if txHash, ok := txHashes[elem.Index]; ok {
+						log.Info("sendRawTransaction forwarded",
+							"tx_hash", txHash,
+							"req_id", GetReqID(ctx),
+							"backend", sb,
+							"backend_group", group.backendGroup,
+							"duration_ms", forwardDuration.Milliseconds(),
+						)
+					}
+				}
+			}
+
 			if err != nil {
 				if errors.Is(err, ErrConsensusGetReceiptsCantBeBatched) ||
 					errors.Is(err, ErrConsensusGetReceiptsInvalidTarget) {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -720,21 +720,6 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			forwardDuration := time.Since(forwardStart)
 			servedBy[sb] = true
 
-			// Log forwarding for sendRawTransaction requests
-			if s.enableTxHashLogging {
-				for _, elem := range elems {
-					if txHash, ok := txHashes[elem.Index]; ok {
-						log.Info("sendRawTransaction forwarded",
-							"tx_hash", txHash,
-							"req_id", GetReqID(ctx),
-							"backend", sb,
-							"backend_group", group.backendGroup,
-							"duration_ms", forwardDuration.Milliseconds(),
-						)
-					}
-				}
-			}
-
 			if err != nil {
 				if errors.Is(err, ErrConsensusGetReceiptsCantBeBatched) ||
 					errors.Is(err, ErrConsensusGetReceiptsInvalidTarget) {
@@ -750,6 +735,21 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				res = nil
 				for _, elem := range elems {
 					res = append(res, NewRPCErrorRes(elem.Req.ID, err))
+				}
+			}
+
+			// Log forwarding for sendRawTransaction requests (success path only)
+			if err == nil && s.enableTxHashLogging {
+				for _, elem := range elems {
+					if txHash, ok := txHashes[elem.Index]; ok {
+						log.Info("sendRawTransaction forwarded",
+							"tx_hash", txHash,
+							"req_id", GetReqID(ctx),
+							"backend", sb,
+							"backend_group", group.backendGroup,
+							"duration_ms", forwardDuration.Milliseconds(),
+						)
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

- When `enable_tx_hash_logging` is enabled, proxyd now emits a `sendRawTransaction forwarded` INFO log after the backend responds
- Log includes `tx_hash`, `req_id`, `backend`, `backend_group`, and `duration_ms`
- Gated behind the same `enable_tx_hash_logging` config flag as the existing request-time log
- Works for both single and batched `eth_sendRawTransaction` / `eth_sendRawTransactionConditional` requests

This complements the existing `processing sendRawTransaction` log (fires at request time) by adding a response-time log. The `req_id` field correlates the two, giving proxyd's internal processing duration. This is used by `op-benchmark latency` to measure the `proxyd_forwarded` stage in flashblocks latency analysis.

### Implementation

The tx hash is captured during request parsing (where it was already extracted for rate limiting) into a request-scoped map. After `Forward()` returns, any sendRawTransaction requests in the batch get a forwarding log with timing. The map is local to `handleBatchRPC` and garbage collected per request — no accumulation across requests.

## Test plan

- [x] Existing `TestTxHashLogging` tests pass with new assertions for `sendRawTransaction forwarded` and `duration_ms`
- [x] `TestTxHashLoggingDisabled` verifies forwarding log does NOT appear when `enable_tx_hash_logging` is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)