### PR TITLE
proxyd: support backend mTLS for websocket upstreams

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -393,6 +393,10 @@ func WithTLSConfig(tlsConfig *tls.Config) BackendOpt {
 			b.client.Transport = &http.Transport{}
 		}
 		b.client.Transport.(*http.Transport).TLSClientConfig = tlsConfig
+		if b.dialer == nil {
+			b.dialer = &websocket.Dialer{}
+		}
+		b.dialer.TLSClientConfig = tlsConfig
 	}
 }
 

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -2,6 +2,7 @@ package proxyd
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -209,6 +210,18 @@ func TestAllowedStatusCodes(t *testing.T) {
 	require.Equal(t, -32000, res[0].Error.Code)
 	require.Equal(t, "backend has a foo problem", res[0].Error.Message)
 	require.Equal(t, http.StatusServiceUnavailable, res[0].Error.HTTPErrorCode)
+}
+
+func TestWithTLSConfigAppliesToHTTPAndWebsocketClients(t *testing.T) {
+	backend := NewBackend("test-backend", "http://example.com", "ws://example.com", semaphore.NewWeighted(1))
+	tlsConfig := &tls.Config{}
+
+	WithTLSConfig(tlsConfig)(backend)
+
+	transport, ok := backend.client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Same(t, tlsConfig, transport.TLSClientConfig)
+	require.Same(t, tlsConfig, backend.dialer.TLSClientConfig)
 }
 
 func getHttpResponseCodeCount(statusCode string) float64 {

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -224,6 +224,17 @@ func TestWithTLSConfigAppliesToHTTPAndWebsocketClients(t *testing.T) {
 	require.Same(t, tlsConfig, backend.dialer.TLSClientConfig)
 }
 
+func TestWithTLSConfigInitializesWebsocketDialerWhenMissing(t *testing.T) {
+	backend := NewBackend("test-backend", "http://example.com", "ws://example.com", semaphore.NewWeighted(1))
+	backend.dialer = nil
+	tlsConfig := &tls.Config{}
+
+	WithTLSConfig(tlsConfig)(backend)
+
+	require.NotNil(t, backend.dialer)
+	require.Same(t, tlsConfig, backend.dialer.TLSClientConfig)
+}
+
 func getHttpResponseCodeCount(statusCode string) float64 {
 	metricFamilies, err := prometheus.DefaultGatherer.Gather()
 	if err != nil {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -696,16 +696,26 @@ func millisecondsToDuration(ms int) time.Duration {
 }
 
 func configureBackendTLS(cfg *BackendConfig) (*tls.Config, error) {
-	if cfg.CAFile == "" {
+	hasCA := cfg.CAFile != ""
+	hasClientCert := cfg.ClientCertFile != "" && cfg.ClientKeyFile != ""
+	if !hasCA && !hasClientCert {
 		return nil, nil
 	}
 
-	tlsConfig, err := CreateTLSClient(cfg.CAFile)
-	if err != nil {
-		return nil, err
+	var (
+		tlsConfig *tls.Config
+		err       error
+	)
+	if hasCA {
+		tlsConfig, err = CreateTLSClient(cfg.CAFile)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		tlsConfig = &tls.Config{}
 	}
 
-	if cfg.ClientCertFile != "" && cfg.ClientKeyFile != "" {
+	if hasClientCert {
 		cert, err := ParseKeyPair(cfg.ClientCertFile, cfg.ClientKeyFile)
 		if err != nil {
 			return nil, err

--- a/proxyd/proxyd_test.go
+++ b/proxyd/proxyd_test.go
@@ -121,6 +121,19 @@ func TestConfigureBackendTLS(t *testing.T) {
 		require.Len(t, tlsConfig.Certificates, 1)
 	})
 
+	t.Run("supports CA file without client cert", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, _ := writeSelfSignedClientCert(t, dir)
+
+		tlsConfig, err := configureBackendTLS(&BackendConfig{
+			CAFile: certPath,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+		require.NotNil(t, tlsConfig.RootCAs)
+		require.Empty(t, tlsConfig.Certificates)
+	})
+
 	t.Run("supports CA and client cert together", func(t *testing.T) {
 		dir := t.TempDir()
 		certPath, keyPath := writeSelfSignedClientCert(t, dir)

--- a/proxyd/proxyd_test.go
+++ b/proxyd/proxyd_test.go
@@ -1,9 +1,19 @@
 package proxyd
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMillisecondsToDuration(t *testing.T) {
@@ -88,4 +98,73 @@ func TestParseCommaSeparatedList(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigureBackendTLS(t *testing.T) {
+	t.Run("returns nil without TLS files", func(t *testing.T) {
+		tlsConfig, err := configureBackendTLS(&BackendConfig{})
+		require.NoError(t, err)
+		require.Nil(t, tlsConfig)
+	})
+
+	t.Run("supports client cert without CA file", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := writeSelfSignedClientCert(t, dir)
+
+		tlsConfig, err := configureBackendTLS(&BackendConfig{
+			ClientCertFile: certPath,
+			ClientKeyFile:  keyPath,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+		require.Nil(t, tlsConfig.RootCAs)
+		require.Len(t, tlsConfig.Certificates, 1)
+	})
+
+	t.Run("supports CA and client cert together", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := writeSelfSignedClientCert(t, dir)
+
+		tlsConfig, err := configureBackendTLS(&BackendConfig{
+			CAFile:         certPath,
+			ClientCertFile: certPath,
+			ClientKeyFile:  keyPath,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+		require.NotNil(t, tlsConfig.RootCAs)
+		require.Len(t, tlsConfig.Certificates, 1)
+	})
+}
+
+func writeSelfSignedClientCert(t *testing.T, dir string) (string, string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "proxyd-test-client"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	certPath := filepath.Join(dir, "client.crt")
+	keyPath := filepath.Join(dir, "client.key")
+
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+
+	return certPath, keyPath
 }


### PR DESCRIPTION
Fixes https://github.com/ethereum-optimism/infra/issues/577

## Summary

This updates proxyd backend TLS handling so the same backend TLS config is applied to both HTTP and WebSocket upstream connections.

It also fixes `configureBackendTLS` so a backend client certificate/key pair can be used without requiring `ca_file` to be set. In that case proxyd builds a
default `tls.Config` and still attaches the configured client certificate for mTLS.

## Changes

- apply backend `tls.Config` to the outbound WebSocket dialer
- allow `client_cert_file` + `client_key_file` without requiring `ca_file`
- add regression tests for:
  - `configureBackendTLS` with cert-only and CA+cert configurations
  - `WithTLSConfig` wiring for both HTTP and WebSocket backend clients

## Testing

- `go test .`
- `go test ./... -run 'TestConfigureBackendTLS|TestWithTLSConfigAppliesToHTTPAndWebsocketClients'`