### PR TITLE
Refactor IP address extraction using net.SplitHostPort

### DIFF
--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -15,7 +15,6 @@ import (
 	"net"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -11,8 +11,8 @@ import (
 	"io"
 	"math"
 	"math/big"
-	"net/http"
 	"net"
+	"net/http"
 	"regexp"
 	"strconv"
 	"sync"
@@ -829,8 +829,8 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 	authorization := vars["authorization"]
 	xff := r.Header.Get(s.rateLimitHeader)
 	if xff == "" {
-        if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
-            xff = host
+		if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+			xff = host
 		}
 	}
 

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"math/big"
 	"net/http"
+	"net"
 	"regexp"
 	"strconv"
 	"strings"
@@ -829,9 +830,8 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 	authorization := vars["authorization"]
 	xff := r.Header.Get(s.rateLimitHeader)
 	if xff == "" {
-		ipPort := strings.Split(r.RemoteAddr, ":")
-		if len(ipPort) == 2 {
-			xff = ipPort[0]
+        if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+            xff = host
 		}
 	}
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

It's necessary to add X-Forwarded-For header for any request to proxyd, but looking at the code it shouldn't be needed.

Failing request:
```
$ curl -X POST http://localhost:8080 \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
{"jsonrpc":"2.0","error":{"code":-32600,"message":"request does not include a remote IP"},"id":null}
```

Request with X-Forwarded-For header works:
```
$curl -X POST http://localhost:8080     -H "Content-Type: application/json" -H "X-Forwarded-For: 127.0.0.1"    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
{"jsonrpc":"2.0","result":"0x178e8e3","id":1}
```

It seems that's caused by ipv6 stack enabled on my machine - ipv6 can't be parsed with simple `strings.Split`.

Changing it to `net.SplitHostPort` should fix the issue.

**Tests**

Built locally with the change and it works:

```
$ curl -X POST http://localhost:8080     -H "Content-Type: application/json"     -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
{"jsonrpc":"2.0","result":"0x178e987","id":1}
```
**Additional context**


**Metadata**

