### PR TITLE
feat(cci-stats): map flaky test markers to structured statuses

### DIFF
--- a/cci-stats/pkg/service/service.go
+++ b/cci-stats/pkg/service/service.go
@@ -264,7 +264,7 @@ func fetchJobs(ctx context.Context, client *circleci.Client, workflowID string) 
 // and all other statuses pass through unchanged.
 func mapFlakyStatus(result, message string) string {
 	if result == "skipped" {
-		if strings.HasPrefix(message, "FLAKY_FAIL:") {
+		if strings.HasPrefix(message, "FLAKY_FAIL") {
 			return "failed"
 		}
 		if strings.HasPrefix(message, "FLAKY_PASS") {

--- a/cci-stats/pkg/service/service.go
+++ b/cci-stats/pkg/service/service.go
@@ -259,6 +259,21 @@ func fetchJobs(ctx context.Context, client *circleci.Client, workflowID string) 
 	return jobs.Items, nil
 }
 
+// mapFlakyStatus maps CircleCI test result status based on flaky markers
+// in the skip message. Returns the mapped status and whether to keep the result.
+func mapFlakyStatus(result, message string) (status string, keep bool) {
+	if result == "skipped" {
+		if strings.HasPrefix(message, "FLAKY_FAIL:") {
+			return "failed", true
+		}
+		if strings.HasPrefix(message, "FLAKY_PASS:") {
+			return "flaky_pass", true
+		}
+		return "", false
+	}
+	return result, true
+}
+
 func isNotFoundError(err error) bool {
 	return err != nil && strings.Contains(strings.ToLower(err.Error()), "not found")
 }
@@ -283,9 +298,11 @@ func fetchTestMetadata(ctx context.Context, config config.Config, client *circle
 
 	var out []*circleci.TestMetadata
 	for _, m := range md.Items {
-		if m.Result == "skipped" {
+		status, keep := mapFlakyStatus(m.Result, m.Message)
+		if !keep {
 			continue
 		}
+		m.Result = status
 
 		if m.Result == "success" && config.SlowTestThresholdSeconds > m.RunTime {
 			continue

--- a/cci-stats/pkg/service/service.go
+++ b/cci-stats/pkg/service/service.go
@@ -260,18 +260,18 @@ func fetchJobs(ctx context.Context, client *circleci.Client, workflowID string) 
 }
 
 // mapFlakyStatus maps CircleCI test result status based on flaky markers
-// in the skip message. Returns the mapped status and whether to keep the result.
-func mapFlakyStatus(result, message string) (status string, keep bool) {
+// in the skip message. FLAKY_FAIL becomes "failed", FLAKY_PASS becomes "flaky_pass",
+// and all other statuses pass through unchanged.
+func mapFlakyStatus(result, message string) string {
 	if result == "skipped" {
 		if strings.HasPrefix(message, "FLAKY_FAIL:") {
-			return "failed", true
+			return "failed"
 		}
 		if strings.HasPrefix(message, "FLAKY_PASS:") {
-			return "flaky_pass", true
+			return "flaky_pass"
 		}
-		return "", false
 	}
-	return result, true
+	return result
 }
 
 func isNotFoundError(err error) bool {
@@ -298,11 +298,7 @@ func fetchTestMetadata(ctx context.Context, config config.Config, client *circle
 
 	var out []*circleci.TestMetadata
 	for _, m := range md.Items {
-		status, keep := mapFlakyStatus(m.Result, m.Message)
-		if !keep {
-			continue
-		}
-		m.Result = status
+		m.Result = mapFlakyStatus(m.Result, m.Message)
 
 		if m.Result == "success" && config.SlowTestThresholdSeconds > m.RunTime {
 			continue

--- a/cci-stats/pkg/service/service.go
+++ b/cci-stats/pkg/service/service.go
@@ -267,7 +267,7 @@ func mapFlakyStatus(result, message string) string {
 		if strings.HasPrefix(message, "FLAKY_FAIL:") {
 			return "failed"
 		}
-		if strings.HasPrefix(message, "FLAKY_PASS:") {
+		if strings.HasPrefix(message, "FLAKY_PASS") {
 			return "flaky_pass"
 		}
 	}

--- a/cci-stats/pkg/service/service_test.go
+++ b/cci-stats/pkg/service/service_test.go
@@ -59,57 +59,53 @@ func TestIsNotFoundError(t *testing.T) {
 
 func TestFlakyStatusMapping(t *testing.T) {
 	tests := []struct {
-		name           string
-		result         string
-		message        string
-		expectedResult string
-		filtered       bool
+		name     string
+		result   string
+		message  string
+		expected string
 	}{
 		{
-			name:           "flaky fail becomes failed",
-			result:         "skipped",
-			message:        "FLAKY_FAIL: test-reason: assertion failed",
-			expectedResult: "failed",
+			name:     "flaky fail becomes failed",
+			result:   "skipped",
+			message:  "FLAKY_FAIL: test-reason: assertion failed",
+			expected: "failed",
 		},
 		{
-			name:           "flaky pass becomes flaky_pass",
-			result:         "skipped",
-			message:        "FLAKY_PASS: test-reason",
-			expectedResult: "flaky_pass",
+			name:     "flaky pass becomes flaky_pass",
+			result:   "skipped",
+			message:  "FLAKY_PASS: test-reason",
+			expected: "flaky_pass",
 		},
 		{
-			name:     "regular skip is filtered",
+			name:     "regular skip stays skipped",
 			result:   "skipped",
 			message:  "precondition not met",
-			filtered: true,
+			expected: "skipped",
 		},
 		{
-			name:     "empty skip is filtered",
+			name:     "empty skip stays skipped",
 			result:   "skipped",
 			message:  "",
-			filtered: true,
+			expected: "skipped",
 		},
 		{
-			name:           "regular failure unchanged",
-			result:         "failed",
-			message:        "test failed",
-			expectedResult: "failed",
+			name:     "regular failure unchanged",
+			result:   "failed",
+			message:  "test failed",
+			expected: "failed",
 		},
 		{
-			name:           "success unchanged",
-			result:         "success",
-			message:        "",
-			expectedResult: "success",
+			name:     "success unchanged",
+			result:   "success",
+			message:  "",
+			expected: "success",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, keep := mapFlakyStatus(tt.result, tt.message)
-			if keep == tt.filtered {
-				t.Errorf("mapFlakyStatus() filtered = %v, want %v", !keep, tt.filtered)
-			}
-			if !tt.filtered && got != tt.expectedResult {
-				t.Errorf("mapFlakyStatus() result = %q, want %q", got, tt.expectedResult)
+			got := mapFlakyStatus(tt.result, tt.message)
+			if got != tt.expected {
+				t.Errorf("mapFlakyStatus(%q, %q) = %q, want %q", tt.result, tt.message, got, tt.expected)
 			}
 		})
 	}

--- a/cci-stats/pkg/service/service_test.go
+++ b/cci-stats/pkg/service/service_test.go
@@ -56,3 +56,61 @@ func TestIsNotFoundError(t *testing.T) {
 		})
 	}
 }
+
+func TestFlakyStatusMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		result         string
+		message        string
+		expectedResult string
+		filtered       bool
+	}{
+		{
+			name:           "flaky fail becomes failed",
+			result:         "skipped",
+			message:        "FLAKY_FAIL: test-reason: assertion failed",
+			expectedResult: "failed",
+		},
+		{
+			name:           "flaky pass becomes flaky_pass",
+			result:         "skipped",
+			message:        "FLAKY_PASS: test-reason",
+			expectedResult: "flaky_pass",
+		},
+		{
+			name:     "regular skip is filtered",
+			result:   "skipped",
+			message:  "precondition not met",
+			filtered: true,
+		},
+		{
+			name:     "empty skip is filtered",
+			result:   "skipped",
+			message:  "",
+			filtered: true,
+		},
+		{
+			name:           "regular failure unchanged",
+			result:         "failed",
+			message:        "test failed",
+			expectedResult: "failed",
+		},
+		{
+			name:           "success unchanged",
+			result:         "success",
+			message:        "",
+			expectedResult: "success",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, keep := mapFlakyStatus(tt.result, tt.message)
+			if keep == tt.filtered {
+				t.Errorf("mapFlakyStatus() filtered = %v, want %v", !keep, tt.filtered)
+			}
+			if !tt.filtered && got != tt.expectedResult {
+				t.Errorf("mapFlakyStatus() result = %q, want %q", got, tt.expectedResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Stop filtering out skipped tests — record all test results in the database for complete visibility
- Add `mapFlakyStatus()` helper that detects `FLAKY_FAIL:` and `FLAKY_PASS:` prefixes in skip messages, mapping them to `"failed"` and `"flaky_pass"` statuses respectively
- Regular skips pass through as `"skipped"`

This provides more complete test data and enables tracking flaky test outcomes from devtest's MarkFlaky annotations. Flaky failures show as `"failed"` (matching previous op-acceptor behavior), `"flaky_pass"` entries enable querying for tests that have stabilized, and regular skips are now recorded too.

No schema migration needed — `status` is VARCHAR and the existing index covers new values.

Companion PR: ethereum-optimism/optimism#19719 — devtest changes that emit the FLAKY_FAIL/FLAKY_PASS markers.

## Test plan

- [x] New test: `TestFlakyStatusMapping` — table-driven test covering all 6 cases (flaky fail, flaky pass, regular skip, empty skip, regular failure, success)
- [x] All existing tests pass
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>