### PR TITLE
fix(cci-stats): use Contains for flaky status markers

### DIFF
--- a/cci-stats/pkg/service/service.go
+++ b/cci-stats/pkg/service/service.go
@@ -264,10 +264,10 @@ func fetchJobs(ctx context.Context, client *circleci.Client, workflowID string) 
 // and all other statuses pass through unchanged.
 func mapFlakyStatus(result, message string) string {
 	if result == "skipped" {
-		if strings.HasPrefix(message, "FLAKY_FAIL") {
+		if strings.Contains(message, "FLAKY_FAIL") {
 			return "failed"
 		}
-		if strings.HasPrefix(message, "FLAKY_PASS") {
+		if strings.Contains(message, "FLAKY_PASS") {
 			return "flaky_pass"
 		}
 	}

--- a/cci-stats/pkg/service/service.go
+++ b/cci-stats/pkg/service/service.go
@@ -260,12 +260,12 @@ func fetchJobs(ctx context.Context, client *circleci.Client, workflowID string) 
 }
 
 // mapFlakyStatus maps CircleCI test result status based on flaky markers
-// in the skip message. FLAKY_FAIL becomes "failed", FLAKY_PASS becomes "flaky_pass",
+// in the skip message. FLAKY_FAIL becomes "flaky_fail", FLAKY_PASS becomes "flaky_pass",
 // and all other statuses pass through unchanged.
 func mapFlakyStatus(result, message string) string {
 	if result == "skipped" {
 		if strings.Contains(message, "FLAKY_FAIL") {
-			return "failed"
+			return "flaky_fail"
 		}
 		if strings.Contains(message, "FLAKY_PASS") {
 			return "flaky_pass"

--- a/cci-stats/pkg/service/service_test.go
+++ b/cci-stats/pkg/service/service_test.go
@@ -65,10 +65,10 @@ func TestFlakyStatusMapping(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "flaky fail becomes failed",
+			name:     "flaky fail becomes flaky_fail",
 			result:   "skipped",
 			message:  "FLAKY_FAIL: test-reason: assertion failed",
-			expected: "failed",
+			expected: "flaky_fail",
 		},
 		{
 			name:     "flaky pass becomes flaky_pass",
@@ -92,7 +92,7 @@ func TestFlakyStatusMapping(t *testing.T) {
 			name:     "flaky fail with log prefix",
 			result:   "skipped",
 			message:  "=== RUN TestFoo\ntestlog.go:151: writing test log\ntesting.go:259: FLAKY_FAIL: assertion failed\n--- SKIP: TestFoo (0.00s)",
-			expected: "failed",
+			expected: "flaky_fail",
 		},
 		{
 			name:     "regular skip stays skipped",

--- a/cci-stats/pkg/service/service_test.go
+++ b/cci-stats/pkg/service/service_test.go
@@ -77,6 +77,24 @@ func TestFlakyStatusMapping(t *testing.T) {
 			expected: "flaky_pass",
 		},
 		{
+			name:     "flaky pass with log prefix",
+			result:   "skipped",
+			message:  "=== RUN TestFoo\ntestlog.go:151: writing test log\ntesting.go:259: FLAKY_PASS: tracked as flaky\n--- SKIP: TestFoo (0.00s)",
+			expected: "flaky_pass",
+		},
+		{
+			name:     "flaky pass without reason",
+			result:   "skipped",
+			message:  "=== RUN TestFoo\ntestlog.go:151: writing test log\ntesting.go:259: FLAKY_PASS\n--- SKIP: TestFoo (0.00s)",
+			expected: "flaky_pass",
+		},
+		{
+			name:     "flaky fail with log prefix",
+			result:   "skipped",
+			message:  "=== RUN TestFoo\ntestlog.go:151: writing test log\ntesting.go:259: FLAKY_FAIL: assertion failed\n--- SKIP: TestFoo (0.00s)",
+			expected: "failed",
+		},
+		{
 			name:     "regular skip stays skipped",
 			result:   "skipped",
 			message:  "precondition not met",


### PR DESCRIPTION
## Summary
- `mapFlakyStatus` used `strings.HasPrefix` to detect `FLAKY_PASS`/`FLAKY_FAIL` markers, but the Go test framework embeds these markers in the middle of the message (after log output lines), so they never matched real CircleCI data
- Changed to `strings.Contains` so flaky tests are correctly classified instead of all being stored as `skipped`
- `FLAKY_PASS` maps to `flaky_pass`, `FLAKY_FAIL` maps to `flaky_fail` (previously mapped to `failed`, making it indistinguishable from real failures)
- Added test cases matching the real message format from CircleCI

## Test plan
- [x] Existing tests still pass
- [x] New test cases cover real-world message format with log prefixes and newlines
- [x] Test case for `FLAKY_PASS` without a reason suffix
- [x] `FLAKY_FAIL` tests verify `flaky_fail` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)