### PR TITLE
chore: bump Go to 1.26 and migrate to Docker Hardened Images

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -196,12 +196,7 @@ jobs:
             if [ "<<parameters.module>>" = "op-acceptor" ]; then
               make lint
             else
-              # Original lint command for other projects
-              if [ -f .golangci.yml ]; then
-               golangci-lint run -c .golangci.yml -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint -e "errors.As" -e "errors.Is" --timeout "5m0s" ./...
-              else
-               golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint -e "errors.As" -e "errors.Is" --timeout "5m0s" ./...
-              fi
+              golangci-lint run ./...
             fi
           working_directory: <<parameters.module>>
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -176,7 +176,7 @@ jobs:
         description: Go Module Name
         type: string
     docker:
-      - image: cimg/go:1.23
+      - image: cimg/go:1.26
         user: root
     steps:
       - circleci-utils/checkout-with-mise
@@ -211,7 +211,7 @@ jobs:
         description: Go Module Name
         type: string
     docker:
-      - image: cimg/go:1.23
+      - image: cimg/go:1.26
         user: root
       - image: cimg/postgres:14.6
         environment:
@@ -297,7 +297,7 @@ jobs:
   # Run full op-acceptor suite, including acceptance tests via make test-all
   op-acceptor-test-all:
     docker:
-      - image: cimg/go:1.23
+      - image: cimg/go:1.26
         user: root
     resource_class: medium
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,9 +7,6 @@ linters:
     - asciicheck
     - misspell
     - errorlint
-  settings:
-    staticcheck:
-      checks: ["all"]
   exclusions:
     presets:
       - comments
@@ -19,10 +16,6 @@ linters:
     rules:
       - text: "errors\\.As"
       - text: "errors\\.Is"
-      - path: "pkg/provider/roundtrip.go"
-        linters:
-          - staticcheck
-        text: "SA4006"
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,11 @@ linters:
       - std-error-handling
     rules:
       - text: "errors\\.As"
+        linters:
+          - errorlint
       - text: "errors\\.Is"
+        linters:
+          - errorlint
 
 formatters:
   enable:

--- a/cci-stats/Dockerfile
+++ b/cci-stats/Dockerfile
@@ -18,4 +18,6 @@ WORKDIR /app
 
 COPY --from=builder /app/bin/cci-stats /app
 
+RUN /app/cci-stats 2>&1 || [ $? -lt 127 ]
+
 ENTRYPOINT ["/app/cci-stats"]

--- a/cci-stats/Dockerfile
+++ b/cci-stats/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-alpine3.20 as builder
+FROM golang:1.26.1-alpine3.22 as builder
 
 ARG GITCOMMIT=docker
 ARG GITDATE=docker
@@ -10,7 +10,7 @@ WORKDIR /app
 RUN apk add --no-cache make jq bash git alpine-sdk
 RUN make build
 
-FROM alpine:3.20
+FROM alpine:3.22
 RUN addgroup -S app && adduser -S app -G app
 RUN apk add --no-cache ca-certificates
 USER app

--- a/cci-stats/Dockerfile
+++ b/cci-stats/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine3.22 as builder
+FROM dhi.io/golang:1.26-alpine3.23-dev AS builder
 
 ARG GITCOMMIT=docker
 ARG GITDATE=docker
@@ -10,14 +10,10 @@ WORKDIR /app
 RUN apk add --no-cache make jq bash git alpine-sdk
 RUN make build
 
-FROM alpine:3.22
-RUN addgroup -S app && adduser -S app -G app
-RUN apk add --no-cache ca-certificates
-USER app
+FROM dhi.io/alpine-base:3.23
+
 WORKDIR /app
 
-COPY --from=builder /app/bin/cci-stats /app
-
-RUN /app/cci-stats 2>&1 || [ $? -lt 127 ]
+COPY --from=builder /app/bin/cci-stats /app/
 
 ENTRYPOINT ["/app/cci-stats"]

--- a/cci-stats/go.mod
+++ b/cci-stats/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/infra/cci-stats
 
-go 1.23.1
+go 1.26.1
 
 require (
 	github.com/axelKingsley/go-circleci v0.9.1

--- a/cci-stats/go.mod
+++ b/cci-stats/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/infra/cci-stats
 
-go 1.26.1
+go 1.26.0
 
 require (
 	github.com/axelKingsley/go-circleci v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ethereum-optimism/infra
 
-go 1.26.1
+go 1.26.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ethereum-optimism/infra
 
-go 1.21
+go 1.26.1

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 # Shared tools for Go projects
 [tools]
-go = "1.26.1"
+go = "1.26"
 
 # Fake deps
 asterisc = "1.3.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 # Shared tools for Go projects
 [tools]
-go = "1.23.12"  # Matches CI: cimg/go:1.23
+go = "1.26.1"
 
 # Fake deps
 asterisc = "1.3.0"

--- a/op-acceptor/Dockerfile
+++ b/op-acceptor/Dockerfile
@@ -1,24 +1,16 @@
-FROM golang:1.26.1-alpine3.22 AS builder
+FROM dhi.io/golang:1.26-alpine3.23-dev AS builder
 
 WORKDIR /app
 
-# Install make and other build dependencies
 RUN apk add --no-cache make git
 
 COPY op-acceptor/ .
 
 RUN make build
 
-FROM golang:1.26.1-alpine3.22
+FROM dhi.io/golang:1.26-alpine3.23-dev
 
-RUN apk add --no-cache ca-certificates build-base git zstd
-
-# Install Go binary
-# (we copy Go directly from the builder stage for simplicity and consistency)
-COPY --from=builder /usr/local/go /usr/local/go
-ENV PATH="/usr/local/go/bin:${PATH}"
-ENV GOPATH="/go"
-ENV PATH="${GOPATH}/bin:${PATH}"
+RUN apk add --no-cache build-base git zstd
 
 WORKDIR /app
 
@@ -26,15 +18,13 @@ RUN addgroup -S app && adduser -S app -G app && \
     mkdir -p /devnets && \
     chown -R app:app /devnets
 
-# Modify ownership of /go to app user (as we need write permissions)
 RUN mkdir -p /go && \
-mkdir -p /go/pkg /go/bin /go/src && \
-chown -R app:app /go
+    mkdir -p /go/pkg /go/bin /go/src && \
+    chown -R app:app /go
 
 COPY --from=builder /app/bin/op-acceptor /app/
 COPY op-acceptor/example-validators.yaml /app/
 
-# Set ownership of the /app directory to allow the application to write logs and other files at runtime
 RUN chown -R app:app /app/
 
 RUN /app/op-acceptor --help && \

--- a/op-acceptor/Dockerfile
+++ b/op-acceptor/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.5-alpine3.21 AS builder
+FROM golang:1.26.1-alpine3.22 AS builder
 
 WORKDIR /app
 
@@ -9,7 +9,7 @@ COPY op-acceptor/ .
 
 RUN make build
 
-FROM golang:1.24.5-alpine3.21
+FROM golang:1.26.1-alpine3.22
 
 RUN apk add --no-cache ca-certificates build-base git zstd
 

--- a/op-acceptor/Dockerfile
+++ b/op-acceptor/Dockerfile
@@ -37,6 +37,9 @@ COPY op-acceptor/example-validators.yaml /app/
 # Set ownership of the /app directory to allow the application to write logs and other files at runtime
 RUN chown -R app:app /app/
 
+RUN /app/op-acceptor --help && \
+    go version && git --version && zstd --version
+
 USER app
 
 VOLUME /devnets

--- a/op-acceptor/go.mod
+++ b/op-acceptor/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/infra/op-acceptor
 
-go 1.26.1
+go 1.26.0
 
 replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-0.20250523133920-e3f85bf38455
 

--- a/op-acceptor/go.mod
+++ b/op-acceptor/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/infra/op-acceptor
 
-go 1.23.5
+go 1.26.1
 
 replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-0.20250523133920-e3f85bf38455
 

--- a/op-acceptor/logging/filelogger.go
+++ b/op-acceptor/logging/filelogger.go
@@ -646,7 +646,7 @@ func (s *AllLogsFileSink) Consume(result *types.TestResult, runID string) error 
 	if result.Error != nil {
 		content.WriteString("ERROR:\n")
 		content.WriteString("~~~~~~\n")
-		content.WriteString(fmt.Sprintf("%s\n\n", result.Error.Error()))
+		fmt.Fprintf(&content, "%s\n\n", result.Error.Error())
 	}
 
 	if result.Stdout != "" {
@@ -654,7 +654,7 @@ func (s *AllLogsFileSink) Consume(result *types.TestResult, runID string) error 
 		content.WriteString("~~~~~~~\n")
 		// Indent the stdout for better readability
 		indentedOutput := indentText(result.Stdout, "  ")
-		content.WriteString(fmt.Sprintf("%s\n", indentedOutput))
+		fmt.Fprintf(&content, "%s\n", indentedOutput)
 	}
 
 	// Add a clear separator at the end

--- a/op-acceptor/nat.go
+++ b/op-acceptor/nat.go
@@ -182,7 +182,7 @@ func New(ctx context.Context, config *Config, version string, shutdownCallback f
 		Concurrency:        config.Concurrency,
 		ShowProgress:       config.ShowProgress,
 		ProgressInterval:   config.ProgressInterval,
-		RuntimeCachePath: filepath.Join(config.LogDir, "runtime-cache.json"),
+		RuntimeCachePath:   filepath.Join(config.LogDir, "runtime-cache.json"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test runner: %w", err)

--- a/op-acceptor/reporting/tree_formatters.go
+++ b/op-acceptor/reporting/tree_formatters.go
@@ -326,18 +326,18 @@ func (f *TreeTextFormatter) Format(tree *types.TestTree) (string, error) {
 
 	// Overall statistics
 	if f.includeStats {
-		buf.WriteString(fmt.Sprintf("Run ID: %s\n", tree.RunID))
+		fmt.Fprintf(&buf, "Run ID: %s\n", tree.RunID)
 		if tree.NetworkName != "" {
-			buf.WriteString(fmt.Sprintf("Network: %s\n", tree.NetworkName))
+			fmt.Fprintf(&buf, "Network: %s\n", tree.NetworkName)
 		}
-		buf.WriteString(fmt.Sprintf("Duration: %s\n", formatDuration(tree.Duration)))
-		buf.WriteString(fmt.Sprintf("Total Tests: %d\n", tree.Stats.Total))
-		buf.WriteString(fmt.Sprintf("Passed: %d\n", tree.Stats.Passed))
-		buf.WriteString(fmt.Sprintf("Failed: %d\n", tree.Stats.Failed))
-		buf.WriteString(fmt.Sprintf("Skipped: %d\n", tree.Stats.Skipped))
-		buf.WriteString(fmt.Sprintf("Errored: %d\n", tree.Stats.Errored))
-		buf.WriteString(fmt.Sprintf("Pass Rate: %.1f%%\n", tree.Stats.PassRate))
-		buf.WriteString(fmt.Sprintf("Status: %s\n", strings.ToUpper(getStatusString(tree.Stats.Status))))
+		fmt.Fprintf(&buf, "Duration: %s\n", formatDuration(tree.Duration))
+		fmt.Fprintf(&buf, "Total Tests: %d\n", tree.Stats.Total)
+		fmt.Fprintf(&buf, "Passed: %d\n", tree.Stats.Passed)
+		fmt.Fprintf(&buf, "Failed: %d\n", tree.Stats.Failed)
+		fmt.Fprintf(&buf, "Skipped: %d\n", tree.Stats.Skipped)
+		fmt.Fprintf(&buf, "Errored: %d\n", tree.Stats.Errored)
+		fmt.Fprintf(&buf, "Pass Rate: %.1f%%\n", tree.Stats.PassRate)
+		fmt.Fprintf(&buf, "Status: %s\n", strings.ToUpper(getStatusString(tree.Stats.Status)))
 		buf.WriteString("\n")
 	}
 
@@ -365,9 +365,9 @@ func (f *TreeTextFormatter) Format(tree *types.TestTree) (string, error) {
 		buf.WriteString("\nFailed Tests:\n")
 		buf.WriteString(strings.Repeat("-", 20) + "\n")
 		for _, node := range tree.FailedNodes {
-			buf.WriteString(fmt.Sprintf("- %s", node.GetPath()))
+			fmt.Fprintf(&buf, "- %s", node.GetPath())
 			if f.includeDetails && node.Error != nil {
-				buf.WriteString(fmt.Sprintf(" (Error: %s)", node.Error.Error()))
+				fmt.Fprintf(&buf, " (Error: %s)", node.Error.Error())
 			}
 			buf.WriteString("\n")
 		}

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -162,7 +162,7 @@ type Config struct {
 	Concurrency        int           // Number of concurrent test workers (0 = auto-determine)
 	ShowProgress       bool          // Whether to show periodic progress updates during test execution
 	ProgressInterval   time.Duration // Interval between progress updates when ShowProgress is 'true'
-	RuntimeCachePath string // Path to runtime cache file (empty = no caching)
+	RuntimeCachePath   string        // Path to runtime cache file (empty = no caching)
 }
 
 // NewTestRunner creates a new test runner instance

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -815,12 +815,16 @@ func (r *runner) allTestsWouldBeSkipped(ctx context.Context, metadata types.Vali
 
 // scanTestFunctions opens a Go test source file and returns the names of all
 // top-level Test* functions found in it.
-func scanTestFunctions(path string) ([]string, error) {
+func scanTestFunctions(path string) (_ []string, err error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	var funcs []string
 	scanner := bufio.NewScanner(f)
@@ -829,7 +833,10 @@ func scanTestFunctions(path string) ([]string, error) {
 			funcs = append(funcs, m[1])
 		}
 	}
-	return funcs, scanner.Err()
+	if err = scanner.Err(); err != nil {
+		return nil, err
+	}
+	return funcs, nil
 }
 
 // runTestList runs a list of tests and aggregates their results
@@ -916,9 +923,9 @@ func (r *runner) runTestList(ctx context.Context, metadata types.ValidatorMetada
 			// Collect stdout from failing tests
 			if testResult.Stdout != "" {
 				if testResult.TimedOut {
-					failedTestsStdout.WriteString(fmt.Sprintf("\n--- Test: %s (TIMED OUT) ---\n", testName))
+					fmt.Fprintf(&failedTestsStdout, "\n--- Test: %s (TIMED OUT) ---\n", testName)
 				} else {
-					failedTestsStdout.WriteString(fmt.Sprintf("\n--- Test: %s ---\n", testName))
+					fmt.Fprintf(&failedTestsStdout, "\n--- Test: %s ---\n", testName)
 				}
 				failedTestsStdout.WriteString(testResult.Stdout)
 			}
@@ -1371,25 +1378,25 @@ func formatDuration(d time.Duration) string {
 // String returns a formatted string representation of the test results
 func (r *RunnerResult) String() string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Test Run Results (%s):\n", formatDuration(r.Duration)))
-	b.WriteString(fmt.Sprintf("Total: %d, Passed: %d, Failed: %d, Skipped: %d\n",
-		r.Stats.Total, r.Stats.Passed, r.Stats.Failed, r.Stats.Skipped))
+	fmt.Fprintf(&b, "Test Run Results (%s):\n", formatDuration(r.Duration))
+	fmt.Fprintf(&b, "Total: %d, Passed: %d, Failed: %d, Skipped: %d\n",
+		r.Stats.Total, r.Stats.Passed, r.Stats.Failed, r.Stats.Skipped)
 
 	for gateName, gate := range r.Gates {
-		b.WriteString(fmt.Sprintf("\nGate: %s (%s)\n", gateName, formatDuration(gate.Duration)))
-		b.WriteString(fmt.Sprintf("%sStatus: %s\n", ui.TreeBranch, gate.Status))
-		b.WriteString(fmt.Sprintf("%sTests: %d passed, %d failed, %d skipped\n", ui.TreeBranch,
-			gate.Stats.Passed, gate.Stats.Failed, gate.Stats.Skipped))
+		fmt.Fprintf(&b, "\nGate: %s (%s)\n", gateName, formatDuration(gate.Duration))
+		fmt.Fprintf(&b, "%sStatus: %s\n", ui.TreeBranch, gate.Status)
+		fmt.Fprintf(&b, "%sTests: %d passed, %d failed, %d skipped\n", ui.TreeBranch,
+			gate.Stats.Passed, gate.Stats.Failed, gate.Stats.Skipped)
 
 		// Print direct gate tests
 		for testName, test := range gate.Tests {
 			// Get a display name for the test
 			displayName := types.GetTestDisplayName(testName, test.Metadata)
 
-			b.WriteString(fmt.Sprintf("%sTest: %s (%s) [status=%s]\n", ui.TreeBranch,
-				displayName, formatDuration(test.Duration), test.Status))
+			fmt.Fprintf(&b, "%sTest: %s (%s) [status=%s]\n", ui.TreeBranch,
+				displayName, formatDuration(test.Duration), test.Status)
 			if test.Error != nil {
-				b.WriteString(fmt.Sprintf("%sError: %s\n", ui.BuildTreePrefix(2, true, []bool{false}), test.Error.Error()))
+				fmt.Fprintf(&b, "%sError: %s\n", ui.BuildTreePrefix(2, true, []bool{false}), test.Error.Error())
 			}
 
 			// Print subtests recursively
@@ -1398,20 +1405,20 @@ func (r *RunnerResult) String() string {
 
 		// Print suites
 		for suiteName, suite := range gate.Suites {
-			b.WriteString(fmt.Sprintf("%sSuite: %s (%s)\n", ui.TreeLastBranch, suiteName, formatDuration(suite.Duration)))
-			b.WriteString(fmt.Sprintf("%sStatus: %s\n", ui.SuiteBranch, suite.Status))
-			b.WriteString(fmt.Sprintf("%sTests: %d passed, %d failed, %d skipped\n", ui.SuiteBranch,
-				suite.Stats.Passed, suite.Stats.Failed, suite.Stats.Skipped))
+			fmt.Fprintf(&b, "%sSuite: %s (%s)\n", ui.TreeLastBranch, suiteName, formatDuration(suite.Duration))
+			fmt.Fprintf(&b, "%sStatus: %s\n", ui.SuiteBranch, suite.Status)
+			fmt.Fprintf(&b, "%sTests: %d passed, %d failed, %d skipped\n", ui.SuiteBranch,
+				suite.Stats.Passed, suite.Stats.Failed, suite.Stats.Skipped)
 
 			// Print suite tests
 			for testName, test := range suite.Tests {
 				// Get a display name for the test
 				displayName := types.GetTestDisplayName(testName, test.Metadata)
 
-				b.WriteString(fmt.Sprintf("%sTest: %s (%s) [status=%s]\n", ui.SuiteBranch,
-					displayName, formatDuration(test.Duration), test.Status))
+				fmt.Fprintf(&b, "%sTest: %s (%s) [status=%s]\n", ui.SuiteBranch,
+					displayName, formatDuration(test.Duration), test.Status)
 				if test.Error != nil {
-					b.WriteString(fmt.Sprintf("%sError: %s\n", ui.BuildTreePrefix(3, true, []bool{true, false}), test.Error.Error()))
+					fmt.Fprintf(&b, "%sError: %s\n", ui.BuildTreePrefix(3, true, []bool{true, false}), test.Error.Error())
 				}
 
 				// Print subtests recursively with suite indentation

--- a/op-acceptor/runner/runner.go
+++ b/op-acceptor/runner/runner.go
@@ -1102,8 +1102,11 @@ func (r *runner) runSingleTest(ctx context.Context, metadata types.ValidatorMeta
 	_ = stdoutFile.Sync()
 	_ = stdoutFile.Close()
 
-	// Check for timeout first and set flag
-	if ctx.Err() == context.DeadlineExceeded {
+	// Check for timeout: context deadline or Go's internal test timeout panic.
+	// Go 1.26+ exits quickly after an internal timeout, often before the
+	// context deadline is reached, so we also check stderr for the panic.
+	if ctx.Err() == context.DeadlineExceeded ||
+		(err != nil && bytes.Contains(stderr.Bytes(), []byte("panic: test timed out"))) {
 		timeoutOccurred = true
 		r.log.Error("Test timed out",
 			"test", metadata.FuncName,

--- a/op-signer/Dockerfile
+++ b/op-signer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.7-alpine3.22 AS builder
+FROM golang:1.26.1-alpine3.22 AS builder
 
 COPY ./op-signer /app
 

--- a/op-signer/Dockerfile
+++ b/op-signer/Dockerfile
@@ -15,4 +15,6 @@ WORKDIR /app
 
 COPY --from=builder /app/bin/op-signer /app
 
+RUN /app/op-signer --help
+
 ENTRYPOINT ["/app/op-signer"]

--- a/op-signer/Dockerfile
+++ b/op-signer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine3.22 AS builder
+FROM dhi.io/golang:1.26-alpine3.23-dev AS builder
 
 COPY ./op-signer /app
 
@@ -6,15 +6,12 @@ WORKDIR /app
 RUN apk --no-cache add make jq bash git alpine-sdk
 RUN make build
 
-FROM alpine:3.22
-RUN apk --no-cache add ca-certificates
+FROM dhi.io/alpine-base:3.23
 
-RUN addgroup -S app && adduser -S app -G app
-USER app
 WORKDIR /app
 
-COPY --from=builder /app/bin/op-signer /app
+COPY --from=builder /app/bin/op-signer /app/
 
-RUN /app/op-signer --help
+RUN ["/app/op-signer", "--help"]
 
 ENTRYPOINT ["/app/op-signer"]

--- a/op-signer/go.mod
+++ b/op-signer/go.mod
@@ -1,8 +1,6 @@
 module github.com/ethereum-optimism/infra/op-signer
 
-go 1.24.0
-
-toolchain go1.24.3
+go 1.26.1
 
 require (
 	cloud.google.com/go/kms v1.23.0

--- a/op-signer/go.mod
+++ b/op-signer/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/infra/op-signer
 
-go 1.26.1
+go 1.26.0
 
 require (
 	cloud.google.com/go/kms v1.23.0

--- a/op-signer/provider/utils.go
+++ b/op-signer/provider/utils.go
@@ -29,7 +29,7 @@ func marshalECDSAPublicKey(pub *ecdsa.PublicKey) ([]byte, error) {
 	}
 
 	// Marshal the public key point (X, Y)
-	publicKeyBytes := secp256k1.S256().Marshal(pub.X, pub.Y)
+	publicKeyBytes := secp256k1.S256().Marshal(pub.X, pub.Y) //nolint:staticcheck // secp256k1 is not a standard curve; no alternative to raw X/Y access
 
 	// Construct the publicKeyInfo structure
 	pkix := publicKeyInfo{

--- a/op-signer/service/auth.go
+++ b/op-signer/service/auth.go
@@ -22,12 +22,12 @@ func NewAuthMiddleware() oprpc.Middleware {
 			// PeerTLSInfo is attached to context by upstream op-service middleware
 			peerTlsInfo := optls.PeerTLSInfoFromContext(r.Context())
 			if peerTlsInfo.LeafCertificate == nil {
-				http.Error(w, "client certificate was not provided", 401)
+				http.Error(w, "client certificate was not provided", http.StatusUnauthorized)
 				return
 			}
 			// Note that the certificate is already verified by http server if we get here
 			if len(peerTlsInfo.LeafCertificate.DNSNames) < 1 {
-				http.Error(w, "client certificate verified but did not contain DNS SAN extension", 401)
+				http.Error(w, "client certificate verified but did not contain DNS SAN extension", http.StatusUnauthorized)
 				return
 			}
 			clientInfo.ClientName = peerTlsInfo.LeafCertificate.DNSNames[0]

--- a/op-txproxy/Dockerfile
+++ b/op-txproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as builder
+FROM golang:1.26.1-alpine3.22 as builder
 
 COPY ./op-txproxy /app
 WORKDIR /app
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN apk --no-cache add make jq bash git alpine-sdk
 RUN make build
 
-FROM alpine:3.18
+FROM alpine:3.22
 RUN apk --no-cache add ca-certificates
 
 COPY --from=builder /app/bin/op-txproxy /bin/op-txproxy

--- a/op-txproxy/Dockerfile
+++ b/op-txproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine3.22 as builder
+FROM dhi.io/golang:1.26-alpine3.23-dev AS builder
 
 COPY ./op-txproxy /app
 WORKDIR /app
@@ -6,12 +6,10 @@ WORKDIR /app
 RUN apk --no-cache add make jq bash git alpine-sdk
 RUN make build
 
-FROM alpine:3.22
-RUN apk --no-cache add ca-certificates
+FROM dhi.io/alpine-base:3.23
 
 COPY --from=builder /app/bin/op-txproxy /bin/op-txproxy
 
-RUN /bin/op-txproxy --help
+RUN ["/bin/op-txproxy", "--help"]
 
 ENTRYPOINT ["/bin/op-txproxy"]
-CMD ["/bin/op-txproxy"]

--- a/op-txproxy/Dockerfile
+++ b/op-txproxy/Dockerfile
@@ -11,5 +11,7 @@ RUN apk --no-cache add ca-certificates
 
 COPY --from=builder /app/bin/op-txproxy /bin/op-txproxy
 
+RUN /bin/op-txproxy --help
+
 ENTRYPOINT ["/bin/op-txproxy"]
 CMD ["/bin/op-txproxy"]

--- a/op-txproxy/go.mod
+++ b/op-txproxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/infra/op-txproxy
 
-go 1.22
+go 1.26.1
 
 require (
 	github.com/ethereum-optimism/optimism v1.9.1-0.20240827163921-45e129c8ca4b

--- a/op-txproxy/go.mod
+++ b/op-txproxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/infra/op-txproxy
 
-go 1.26.1
+go 1.26.0
 
 require (
 	github.com/ethereum-optimism/optimism v1.9.1-0.20240827163921-45e129c8ca4b

--- a/op-ufm/.golangci.yml
+++ b/op-ufm/.golangci.yml
@@ -18,7 +18,11 @@ linters:
       - std-error-handling
     rules:
       - text: "errors\\.As"
+        linters:
+          - errorlint
       - text: "errors\\.Is"
+        linters:
+          - errorlint
       - path: "pkg/provider/roundtrip.go"
         linters:
           - staticcheck

--- a/op-ufm/Dockerfile
+++ b/op-ufm/Dockerfile
@@ -26,5 +26,10 @@ VOLUME /etc/ufm
 
 EXPOSE 8080
 
+RUN /bin/ufm 2>&1 || [ $? -lt 127 ] && \
+    test -x /bin/entrypoint.sh && \
+    jq --version > /dev/null && curl --version > /dev/null && \
+    dig -v 2>&1 > /dev/null
+
 ENTRYPOINT ["/bin/entrypoint.sh"]
 CMD ["/bin/ufm", "/etc/ufm/config.toml"]

--- a/op-ufm/Dockerfile
+++ b/op-ufm/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine3.22 as builder
+FROM dhi.io/golang:1.26-alpine3.23-dev AS builder
 
 ARG GITCOMMIT=docker
 ARG GITDATE=docker
@@ -12,15 +12,14 @@ WORKDIR /app
 
 RUN make ufm
 
-FROM alpine:3.22
+FROM dhi.io/alpine-base:3.23-dev
 
 COPY --from=builder /app/entrypoint.sh /bin/entrypoint.sh
 COPY --from=builder /app/bin/ufm /bin/ufm
 
-RUN apk update && \
-    chmod +x /bin/entrypoint.sh
+RUN chmod +x /bin/entrypoint.sh
 
-RUN apk add ca-certificates jq curl bind-tools
+RUN apk add --no-cache jq curl bind-tools
 
 VOLUME /etc/ufm
 

--- a/op-ufm/Dockerfile
+++ b/op-ufm/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.1-alpine3.18 as builder
+FROM golang:1.26.1-alpine3.22 as builder
 
 ARG GITCOMMIT=docker
 ARG GITDATE=docker
@@ -12,7 +12,7 @@ WORKDIR /app
 
 RUN make ufm
 
-FROM alpine:3.18
+FROM alpine:3.22
 
 COPY --from=builder /app/entrypoint.sh /bin/entrypoint.sh
 COPY --from=builder /app/bin/ufm /bin/ufm

--- a/op-ufm/go.mod
+++ b/op-ufm/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/optimism/op-ufm
 
-go 1.26.1
+go 1.26.0
 
 require (
 	cloud.google.com/go/kms v1.12.1

--- a/op-ufm/go.mod
+++ b/op-ufm/go.mod
@@ -1,8 +1,6 @@
 module github.com/ethereum-optimism/optimism/op-ufm
 
-go 1.21
-
-toolchain go1.21.6
+go 1.26.1
 
 require (
 	cloud.google.com/go/kms v1.12.1

--- a/op-ufm/pkg/metrics/clients/signer.go
+++ b/op-ufm/pkg/metrics/clients/signer.go
@@ -30,9 +30,9 @@ func NewSignerClient(providerName string, logger log.Logger, endpoint string, tl
 	return &InstrumentedSignerClient{c: c, providerName: providerName}, nil
 }
 
-func (i *InstrumentedSignerClient) SignTransaction(ctx context.Context, chainId *big.Int, from *common.Address, tx *types.Transaction) (*types.Transaction, error) {
+func (i *InstrumentedSignerClient) SignTransaction(ctx context.Context, chainID *big.Int, from *common.Address, tx *types.Transaction) (*types.Transaction, error) {
 	start := time.Now()
-	tx, err := i.c.SignTransaction(ctx, chainId, *from, tx)
+	tx, err := i.c.SignTransaction(ctx, chainID, *from, tx)
 	if err != nil {
 		metrics.RecordErrorDetails(i.providerName, "signer.SignTransaction", err)
 		return nil, err

--- a/op-ufm/pkg/provider/roundtrip.go
+++ b/op-ufm/pkg/provider/roundtrip.go
@@ -285,7 +285,8 @@ func (p *Provider) createTx(ctx context.Context, client *iclients.InstrumentedEt
 }
 
 func (p *Provider) sign(ctx context.Context, from *common.Address, tx *types.Transaction) (*types.Transaction, error) {
-	if p.walletConfig.SignerMethod == "static" {
+	switch p.walletConfig.SignerMethod {
+	case "static":
 		log.Debug("using static signer")
 		privateKey, err := crypto.HexToECDSA(p.walletConfig.PrivateKey)
 		if err != nil {
@@ -293,7 +294,7 @@ func (p *Provider) sign(ctx context.Context, from *common.Address, tx *types.Tra
 			return nil, err
 		}
 		return types.SignTx(tx, types.LatestSignerForChainID(&p.walletConfig.ChainID), privateKey)
-	} else if p.walletConfig.SignerMethod == "signer" {
+	case "signer":
 		tlsConfig := tls.CLIConfig{
 			TLSCaCert: p.signerConfig.TLSCaCert,
 			TLSCert:   p.signerConfig.TLSCert,
@@ -314,7 +315,7 @@ func (p *Provider) sign(ctx context.Context, from *common.Address, tx *types.Tra
 		}
 
 		return signedTx, nil
-	} else {
+	default:
 		return nil, errors.New("invalid signer method")
 	}
 }

--- a/peer-mgmt-service/Dockerfile
+++ b/peer-mgmt-service/Dockerfile
@@ -15,4 +15,6 @@ WORKDIR /app
 
 COPY --from=builder /app/bin/pms /app
 
+RUN /app/pms 2>&1 || [ $? -lt 127 ]
+
 ENTRYPOINT ["/app/pms"]

--- a/peer-mgmt-service/Dockerfile
+++ b/peer-mgmt-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-alpine3.18 as builder
+FROM golang:1.26.1-alpine3.22 as builder
 
 COPY ./peer-mgmt-service /app
 
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN apk add --no-cache make jq bash git alpine-sdk
 RUN make build
 
-FROM alpine:3.18
+FROM alpine:3.22
 RUN apk --no-cache add make jq bash git alpine-sdk redis
 
 RUN addgroup -S app && adduser -S app -G app

--- a/peer-mgmt-service/Dockerfile
+++ b/peer-mgmt-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine3.22 as builder
+FROM dhi.io/golang:1.26-alpine3.23-dev AS builder
 
 COPY ./peer-mgmt-service /app
 
@@ -6,14 +6,15 @@ WORKDIR /app
 RUN apk add --no-cache make jq bash git alpine-sdk
 RUN make build
 
-FROM alpine:3.22
+FROM dhi.io/alpine-base:3.23-dev
+
 RUN apk --no-cache add make jq bash git alpine-sdk redis
 
 RUN addgroup -S app && adduser -S app -G app
 USER app
 WORKDIR /app
 
-COPY --from=builder /app/bin/pms /app
+COPY --from=builder /app/bin/pms /app/
 
 RUN /app/pms 2>&1 || [ $? -lt 127 ]
 

--- a/peer-mgmt-service/go.mod
+++ b/peer-mgmt-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/infra/peer-mgmt-service
 
-go 1.21
+go 1.26.1
 
 require (
 	github.com/ethereum-optimism/optimism v1.5.0-rc.3.0.20240131131533-152d1e0a458d

--- a/peer-mgmt-service/go.mod
+++ b/peer-mgmt-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/infra/peer-mgmt-service
 
-go 1.26.1
+go 1.26.0
 
 require (
 	github.com/ethereum-optimism/optimism v1.5.0-rc.3.0.20240131131533-152d1e0a458d

--- a/proxyd/Dockerfile
+++ b/proxyd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine3.22 AS builder
+FROM dhi.io/golang:1.26-alpine3.23-dev AS builder
 
 ARG GITCOMMIT=docker
 ARG GITDATE=docker
@@ -12,15 +12,13 @@ WORKDIR /app
 
 RUN make proxyd
 
-FROM alpine:3.22
+FROM dhi.io/alpine-base:3.23-dev
 
-RUN apk add bind-tools jq curl bash git redis
+RUN apk add --no-cache bind-tools jq curl bash git redis
 
 COPY ./proxyd/entrypoint.sh /bin/entrypoint.sh
 
-RUN apk update && \
-    apk add ca-certificates && \
-    chmod +x /bin/entrypoint.sh
+RUN chmod +x /bin/entrypoint.sh
 
 EXPOSE 8080
 

--- a/proxyd/Dockerfile
+++ b/proxyd/Dockerfile
@@ -28,5 +28,10 @@ VOLUME /etc/proxyd
 
 COPY --from=builder /app/bin/proxyd /bin/proxyd
 
+RUN /bin/proxyd 2>&1 || [ $? -lt 127 ] && \
+    bash --version > /dev/null && jq --version > /dev/null && \
+    curl --version > /dev/null && dig -v 2>&1 > /dev/null && \
+    redis-cli --version > /dev/null
+
 ENTRYPOINT ["/bin/entrypoint.sh"]
 CMD ["/bin/proxyd", "/etc/proxyd/proxyd.toml"]

--- a/proxyd/Dockerfile
+++ b/proxyd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.6-alpine3.20 AS builder
+FROM golang:1.26.1-alpine3.22 AS builder
 
 ARG GITCOMMIT=docker
 ARG GITDATE=docker
@@ -12,7 +12,7 @@ WORKDIR /app
 
 RUN make proxyd
 
-FROM alpine:3.20
+FROM alpine:3.22
 
 RUN apk add bind-tools jq curl bash git redis
 

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -820,7 +820,7 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 		defer httpRes.Body.Close()
 	}
 	if err != nil {
-		if !(errors.Is(err, context.Canceled) || errors.Is(err, ErrTooManyRequests)) {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, ErrTooManyRequests) {
 			b.intermittentErrorsSlidingWindow.Incr()
 			RecordBackendNetworkErrorRateSlidingWindow(b, b.ErrorRate())
 		}

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -258,7 +258,7 @@ func ParseInteropError(err error) *RPCErr {
 				HTTPErrorCode: httpErr.StatusCode,
 			}
 
-			err = fmt.Errorf(rpcErrJson.Error.Message)
+			err = errors.New(rpcErrJson.Error.Message)
 		}
 	}
 

--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -1,8 +1,6 @@
 module github.com/ethereum-optimism/infra/proxyd
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/infra/proxyd
 
-go 1.26.1
+go 1.26.0
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/proxyd/integration_tests/multicall_test.go
+++ b/proxyd/integration_tests/multicall_test.go
@@ -441,16 +441,16 @@ func TestMulticall(t *testing.T) {
 			triggerBackend2 := make(chan struct{})
 			triggerBackend3 := make(chan struct{})
 
-			switch {
-			case i == 1:
+			switch i {
+			case 1:
 				nodes["node1"].mockBackend.SetHandler(TriggerResponseHandler(200, txAccepted, triggerBackend1))
 				nodes["node2"].mockBackend.SetHandler(TriggerResponseHandler(429, dummyRes, triggerBackend2))
 				nodes["node3"].mockBackend.SetHandler(TriggerResponseHandler(503, dummyRes, triggerBackend3))
-			case i == 2:
+			case 2:
 				nodes["node1"].mockBackend.SetHandler(TriggerResponseHandler(404, dummyRes, triggerBackend1))
 				nodes["node2"].mockBackend.SetHandler(TriggerResponseHandler(200, nonceErrorResponse, triggerBackend2))
 				nodes["node3"].mockBackend.SetHandler(TriggerResponseHandler(405, dummyRes, triggerBackend3))
-			case i == 3:
+			case 3:
 				// Return the quickest response
 				nodes["node1"].mockBackend.SetHandler(TriggerResponseHandler(404, dummyRes, triggerBackend1))
 				nodes["node2"].mockBackend.SetHandler(TriggerResponseHandler(500, dummyRes, triggerBackend2))
@@ -482,20 +482,20 @@ func TestMulticall(t *testing.T) {
 			rpcRes := &proxyd.RPCRes{}
 			require.NoError(t, json.NewDecoder(resp.Body).Decode(rpcRes))
 
-			switch {
-			case i == 1:
+			switch i {
+			case 1:
 				servedBy := "node/node1"
 				require.NotNil(t, rpcRes.Result)
 				require.Equal(t, 200, resp.StatusCode, "expected 200 response from node1")
 				require.Equal(t, resp.Header["X-Served-By"], []string{servedBy}, "Error incorrect node served the request")
 				require.False(t, rpcRes.IsError())
-			case i == 2:
+			case 2:
 				servedBy := "node/node2"
 				require.Nil(t, rpcRes.Result)
 				require.Equal(t, 200, resp.StatusCode, "expected 200 response from node2")
 				require.Equal(t, resp.Header["X-Served-By"], []string{servedBy}, "Error incorrect node served the request")
 				require.True(t, rpcRes.IsError())
-			case i == 3:
+			case 3:
 				servedBy := "node/node3"
 				require.Nil(t, rpcRes.Result)
 				require.Equal(t, 200, resp.StatusCode, "expected 200 response from node3")

--- a/proxyd/rewriter_test.go
+++ b/proxyd/rewriter_test.go
@@ -642,7 +642,7 @@ func generalize(tests []rewriteTest, baseMethod string, generalizedMethod string
 	newCases := make([]rewriteTest, 0)
 	for _, t := range tests {
 		if t.args.req.Method == baseMethod {
-			newName := strings.Replace(t.name, baseMethod, generalizedMethod, -1)
+			newName := strings.ReplaceAll(t.name, baseMethod, generalizedMethod)
 			var req *RPCReq
 			var res *RPCRes
 


### PR DESCRIPTION
## Summary

- Bump Go from various EOL versions (1.21–1.24) to **1.26** across all modules except `op-conductor-mon`
- Migrate all Dockerfiles to **Docker Hardened Images (DHI)** for reduced attack surface
- Add Dockerfile smoke tests to verify binaries execute and runtime dependencies are present during `docker build`
- Fix Go 1.26 vet error in `proxyd/backend.go` (non-constant format string in `fmt.Errorf`)
- Bump CircleCI image to `cimg/go:1.26`, which ships **golangci-lint v2**
- Migrate linter configuration to golangci-lint v2 format (root `.golangci.yml`, updated `op-ufm/.golangci.yml`)
- Fix all golangci-lint v2 findings across op-acceptor, op-signer, op-ufm, and proxyd
- Fix op-acceptor test timeout detection for Go 1.26 (faster exit after internal timeout panic)

### DHI image mapping

| Stage | Image | Used by |
|---|---|---|
| Builder | `dhi.io/golang:1.26-alpine3.23-dev` | All modules |
| Runtime (minimal) | `dhi.io/alpine-base:3.23` | op-signer, op-txproxy, cci-stats |
| Runtime (with tools) | `dhi.io/alpine-base:3.23-dev` | proxyd, op-ufm, peer-mgmt-service |
| Runtime (Go needed) | `dhi.io/golang:1.26-alpine3.23-dev` | op-acceptor |

DHI images include TLS certificates by default (no `ca-certificates` install needed) and run as non-root in non-dev variants.

### Exclusions

`op-conductor-mon` is excluded from the Go bump because its `go-ethereum@v1.13.15` dependency transitively requires `fjl/memsize`, which uses a Go runtime internal (`runtime.stopTheWorld`) removed in Go 1.26. It needs a dependency update in a separate PR. Its Dockerfile already uses DHI.

### Grype vulnerability scan (main vs this PR)

Scanned all 10 container images from `main` and this branch using `grype` (DB 2026-03-25).

| Image | main | PR | Delta |
|---|---|---|---|
| cci-stats | 3C 12H 21M 2L = **38** | 1C 1H 2M 0L = **4** | **-34** |
| op-acceptor | 23C 240H 279M 29L = **571** | 1C 8H 9M 1L = **19** | **-552** |
| op-conductor-mon | 0C 2H 4M 1L = **7** | 0C 2H 4M 1L = **7** | 0 (unchanged) |
| op-conductor-ops | 5C 28H 51M 7L = **625** | 5C 28H 51M 7L = **625** | 0 (unchanged) |
| op-signer | 2C 12H 17M 1L = **32** | 1C 1H 3M 0L = **5** | **-27** |
| op-txproxy | 3C 14H 18M 8L = **43** | 1C 3H 2M 0L = **6** | **-37** |
| op-ufm | 5C 33H 42M 9L = **89** | 1C 5H 4M 0L = **10** | **-79** |
| peer-mgmt-service | 4C 37H 59M 11L = **111** | 0C 10H 10M 1L = **21** | **-90** |
| proxyd | 3C 21H 32M 6L = **62** | 0C 4H 3M 1L = **8** | **-54** |
| replica-healthcheck | 1C 56H 31M 18L = **106** | 1C 56H 31M 18L = **106** | 0 (unchanged) |
| **Total** | **49C 455H 554M 92L = 1684** | **11C 118H 119M 29L = 811** | **-873 (-52%)** |

C = Critical, H = High, M = Medium, L = Low. `op-conductor-mon` already used DHI. `op-conductor-ops` and `replica-healthcheck` were not part of this migration.

Remaining critical/high findings in migrated images are Go dependency vulns (outdated `golang.org/x/crypto`, `gnark-crypto`, `grpc`, `quic-go`) and Alpine package CVEs with no fix available yet (`openssl 3.5.5`, `nghttp2 1.68.0`, `binutils 2.46.0`). These require separate dependency bumps.

## Test plan

- [x] All 8 bumped modules compile locally with Go 1.26.1
- [x] All tests pass locally (`go test ./...`)
- [x] Docker builds pass locally with DHI images
- [x] Smoke tests pass in DHI images
- [x] CI Docker builds pass for all modules (amd64 + arm64)
- [x] CI lint jobs pass (all modules)
- [x] CI test jobs pass (all modules, including op-acceptor-test-all)
- [x] Grype scan shows -873 total vulnerabilities (-52%) across all images