### PR TITLE
chore: remove unused runtime dependencies from proxyd, op-ufm, peer-mgmt-service

### DIFF
--- a/op-ufm/Dockerfile
+++ b/op-ufm/Dockerfile
@@ -12,23 +12,15 @@ WORKDIR /app
 
 RUN make ufm
 
-FROM dhi.io/alpine-base:3.23-dev
-
-COPY --from=builder /app/entrypoint.sh /bin/entrypoint.sh
-COPY --from=builder /app/bin/ufm /bin/ufm
-
-RUN chmod +x /bin/entrypoint.sh
-
-RUN apk add --no-cache jq curl bind-tools
+FROM dhi.io/alpine-base:3.23
 
 VOLUME /etc/ufm
 
 EXPOSE 8080
 
-RUN /bin/ufm 2>&1 || [ $? -lt 127 ] && \
-    test -x /bin/entrypoint.sh && \
-    jq --version > /dev/null && curl --version > /dev/null && \
-    dig -v 2>&1 > /dev/null
+COPY --from=builder /app/bin/ufm /bin/ufm
 
-ENTRYPOINT ["/bin/entrypoint.sh"]
-CMD ["/bin/ufm", "/etc/ufm/config.toml"]
+RUN /bin/ufm 2>&1 || [ $? -lt 127 ]
+
+ENTRYPOINT ["/bin/ufm"]
+CMD ["/etc/ufm/config.toml"]

--- a/op-ufm/entrypoint.sh
+++ b/op-ufm/entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-echo "Updating CA certificates."
-update-ca-certificates
-echo "Running CMD."
-exec "$@"

--- a/peer-mgmt-service/Dockerfile
+++ b/peer-mgmt-service/Dockerfile
@@ -6,12 +6,8 @@ WORKDIR /app
 RUN apk add --no-cache make jq bash git alpine-sdk
 RUN make build
 
-FROM dhi.io/alpine-base:3.23-dev
+FROM dhi.io/alpine-base:3.23
 
-RUN apk --no-cache add make jq bash git alpine-sdk redis
-
-RUN addgroup -S app && adduser -S app -G app
-USER app
 WORKDIR /app
 
 COPY --from=builder /app/bin/pms /app/

--- a/proxyd/Dockerfile
+++ b/proxyd/Dockerfile
@@ -12,13 +12,7 @@ WORKDIR /app
 
 RUN make proxyd
 
-FROM dhi.io/alpine-base:3.23-dev
-
-RUN apk add --no-cache bind-tools jq curl bash git redis
-
-COPY ./proxyd/entrypoint.sh /bin/entrypoint.sh
-
-RUN chmod +x /bin/entrypoint.sh
+FROM dhi.io/alpine-base:3.23
 
 EXPOSE 8080
 
@@ -26,10 +20,7 @@ VOLUME /etc/proxyd
 
 COPY --from=builder /app/bin/proxyd /bin/proxyd
 
-RUN /bin/proxyd 2>&1 || [ $? -lt 127 ] && \
-    bash --version > /dev/null && jq --version > /dev/null && \
-    curl --version > /dev/null && dig -v 2>&1 > /dev/null && \
-    redis-cli --version > /dev/null
+RUN /bin/proxyd 2>&1 || [ $? -lt 127 ]
 
-ENTRYPOINT ["/bin/entrypoint.sh"]
-CMD ["/bin/proxyd", "/etc/proxyd/proxyd.toml"]
+ENTRYPOINT ["/bin/proxyd"]
+CMD ["/etc/proxyd/proxyd.toml"]

--- a/proxyd/README.md
+++ b/proxyd/README.md
@@ -143,4 +143,4 @@ The metrics port is configurable via the `metrics.port` and `metrics.host` keys 
 
 ## Adding Backend SSL Certificates in Docker
 
-The Docker image runs on Alpine Linux. If you get SSL errors when connecting to a backend within Docker, you may need to add additional certificates to Alpine's certificate store. To do this, bind mount the certificate bundle into a file in `/usr/local/share/ca-certificates`. The `entrypoint.sh` script will then update the store with whatever is in the `ca-certificates` directory prior to starting `proxyd`.
+The Docker image includes the default Alpine CA certificate bundle. To add custom certificates, bind mount PEM files directly into `/etc/ssl/certs/`.

--- a/proxyd/entrypoint.sh
+++ b/proxyd/entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-echo "Updating CA certificates."
-update-ca-certificates
-echo "Running CMD."
-exec "$@"


### PR DESCRIPTION
## Summary

- Switch proxyd, op-ufm, and peer-mgmt-service runtime images from `dhi.io/alpine-base:3.23-dev` to `dhi.io/alpine-base:3.23`
- Remove unused `apk add` runtime packages (jq, curl, bind-tools, bash, git, redis, alpine-sdk)
- Delete vestigial `entrypoint.sh` scripts from proxyd and op-ufm
- Set Go binaries as direct entrypoints instead of wrapping through shell scripts

### Why

Git history shows these runtime tools were added as "debug tools" in late 2023 or cargo-culted from other Dockerfiles. None of the three Go binaries shell out to any of these tools (`exec.Command` search returns zero hits). The Kubernetes manifests in the k8s repo confirm no external tooling is needed: all three services use HTTP health probes on `/healthz`, receive config via ConfigMap mounts, and have no init containers, sidecars, exec probes, or mounted scripts.

The `entrypoint.sh` scripts only called `update-ca-certificates` before exec-ing the binary. DHI images ship CA certificates by default, and the k8s manifests mount custom CA PEM files directly into `/etc/ssl/certs/`, making the `update-ca-certificates` call redundant.

### Image mapping (updated)

| Stage | Image | Used by |
|---|---|---|
| Builder | `dhi.io/golang:1.26-alpine3.23-dev` | All modules |
| Runtime (minimal) | `dhi.io/alpine-base:3.23` | op-signer, op-txproxy, cci-stats, **proxyd**, **op-ufm**, **peer-mgmt-service** |
| Runtime (Go needed) | `dhi.io/golang:1.26-alpine3.23-dev` | op-acceptor |

### Grype vulnerability scan (#579 vs this PR)

Scanned the three affected container images using `grype` (DB 2026-03-25).

| Image | #579 | This PR | Delta |
|---|---|---|---|
| proxyd | 0C 4H 3M 1L = **8** | 0C 1H 3M 0L = **4** | **-4** |
| op-ufm | 1C 5H 4M 0L = **10** | 1C 2H 4M 0L = **7** | **-3** |
| peer-mgmt-service | 0C 10H 10M 1L = **21** | 0C 4H 9M 0L = **13** | **-8** |
| **Total** | **1C 19H 17M 2L = 39** | **1C 7H 16M 0L = 24** | **-15 (-38%)** |

C = Critical, H = High, M = Medium, L = Low. The reductions come from removing the `-dev` base image (which includes `apk` and supporting libraries) and the explicitly installed runtime packages. Remaining findings are Go dependency CVEs inherited from the application code.

## Test plan

- [x] CI Docker builds pass for proxyd, op-ufm, peer-mgmt-service (amd64 + arm64)
- [x] Smoke tests pass (binary executes in minimal image)
- [x] Grype scan shows -15 total vulnerabilities (-38%) across affected images
- [x] Verified no k8s deployment changes needed (commands already use binary directly)