### PR TITLE
feat: proxyd cl layer consensus mode

### DIFF
--- a/proxyd/Dockerfile
+++ b/proxyd/Dockerfile
@@ -1,4 +1,7 @@
-FROM dhi.io/golang:1.26-alpine3.23-dev AS builder
+ARG BUILDER_IMAGE=golang:1.26.1-alpine3.23
+ARG RUNTIME_IMAGE=alpine:3.23
+
+FROM ${BUILDER_IMAGE} AS builder
 
 ARG GITCOMMIT=docker
 ARG GITDATE=docker
@@ -12,7 +15,7 @@ WORKDIR /app
 
 RUN make proxyd
 
-FROM dhi.io/alpine-base:3.23
+FROM ${RUNTIME_IMAGE}
 
 EXPOSE 8080
 

--- a/proxyd/Makefile
+++ b/proxyd/Makefile
@@ -3,6 +3,15 @@ LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.GitVersion=$(GITVERSION)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
+IMAGE_NAME ?= proxyd
+IMAGE_TAG ?= latest
+PLATFORM ?= linux/amd64
+
+DHI_BUILDER_IMAGE ?= dhi.io/golang:1.26-alpine3.23-dev
+DHI_RUNTIME_IMAGE ?= dhi.io/alpine-base:3.23
+DEV_BUILDER_IMAGE ?= golang:1.26.1-alpine3.23
+DEV_RUNTIME_IMAGE ?= alpine:3.23
+
 proxyd:
 	go build -v $(LDFLAGS) -o ./bin/proxyd ./cmd/proxyd
 .PHONY: proxyd
@@ -24,3 +33,21 @@ lint:
 test-%:
 	go test -v ./... -test.run ^Test$*$$
 .PHONY: test-%
+
+docker:
+	docker build \
+		--platform $(PLATFORM) \
+		--build-arg BUILDER_IMAGE=$(DHI_BUILDER_IMAGE) \
+		--build-arg RUNTIME_IMAGE=$(DHI_RUNTIME_IMAGE) \
+		-t $(IMAGE_NAME):$(IMAGE_TAG) \
+		-f Dockerfile ..
+.PHONY: docker
+
+docker-dev:
+	docker build \
+		--platform $(PLATFORM) \
+		--build-arg BUILDER_IMAGE=$(DEV_BUILDER_IMAGE) \
+		--build-arg RUNTIME_IMAGE=$(DEV_RUNTIME_IMAGE) \
+		-t $(IMAGE_NAME):$(IMAGE_TAG) \
+		-f Dockerfile ..
+.PHONY: docker-dev

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1067,6 +1067,30 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 		return backendResp.RPCRes, backendResp.ServedBy, backendResp.error
 	}
 
+	// Post-process CL consensus responses (e.g. override unsafe_l2 in optimism_syncStatus).
+	// This is a separate path from OverwriteConsensusResponses because it operates on the
+	// actual backend response rather than synthesizing a pre-flight override.
+	if bg.Consensus != nil && bg.Consensus.IsConsensusLayer() {
+		rctx := RewriteContext{
+			latest:         bg.Consensus.GetLatestBlockNumber(),
+			safe:           bg.Consensus.GetSafeBlockNumber(),
+			finalized:      bg.Consensus.GetFinalizedBlockNumber(),
+			maxBlockRange:  bg.Consensus.maxBlockRange,
+			latestHash:     bg.Consensus.GetLatestBlockHash(),
+			safeHash:       bg.Consensus.GetSafeBlockHash(),
+			localSafe:      bg.Consensus.GetLocalSafeBlockNumber(),
+			localSafeHash:  bg.Consensus.GetLocalSafeBlockHash(),
+			finalizedHash:  bg.Consensus.GetFinalizedBlockHash(),
+			consensusMode:  true,
+			consensusLayer: true,
+		}
+		for i, req := range rpcReqs {
+			if i < len(backendResp.RPCRes) {
+				RewriteConsensusBackendResponse(rctx, req, backendResp.RPCRes[i])
+			}
+		}
+	}
+
 	// re-apply overridden responses
 	log.Trace("successfully served request overriding responses",
 		"req_id", GetReqID(ctx),
@@ -1771,11 +1795,13 @@ func OverrideResponses(res []*RPCRes, overriddenResponses []*indexedReqRes) []*R
 
 func (bg *BackendGroup) OverwriteConsensusResponses(rpcReqs []*RPCReq, overriddenResponses []*indexedReqRes, rewrittenReqs []*RPCReq) ([]*RPCReq, []*indexedReqRes) {
 	rctx := RewriteContext{
-		latest:        bg.Consensus.GetLatestBlockNumber(),
-		safe:          bg.Consensus.GetSafeBlockNumber(),
-		finalized:     bg.Consensus.GetFinalizedBlockNumber(),
-		maxBlockRange: bg.Consensus.maxBlockRange,
-		consensusMode: true,
+		latest:         bg.Consensus.GetLatestBlockNumber(),
+		safe:           bg.Consensus.GetSafeBlockNumber(),
+		finalized:      bg.Consensus.GetFinalizedBlockNumber(),
+		maxBlockRange:  bg.Consensus.maxBlockRange,
+		latestHash:     bg.Consensus.GetLatestBlockHash(),
+		consensusMode:  true,
+		consensusLayer: bg.Consensus.IsConsensusLayer(),
 	}
 
 	for i, req := range rpcReqs {

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1035,8 +1035,9 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 	// When routing_strategy is set to `consensus_aware` the backend group acts as a load balancer
 	// serving traffic from any backend that agrees in the consensus group
 	// We also rewrite block tags to enforce compliance with consensus
+	var clRctx RewriteContext
 	if bg.Consensus != nil {
-		rpcReqs, overriddenResponses = bg.OverwriteConsensusResponses(rpcReqs, overriddenResponses, rewrittenReqs)
+		rpcReqs, overriddenResponses, clRctx = bg.PrepareConsensusRequests(rpcReqs, overriddenResponses, rewrittenReqs)
 	} else if bg.maxBlockRange > 0 {
 		rpcReqs, overriddenResponses = bg.OverwriteNonConsensusRequests(rpcReqs, overriddenResponses)
 	}
@@ -1067,29 +1068,10 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 		return backendResp.RPCRes, backendResp.ServedBy, backendResp.error
 	}
 
-	// Post-process CL consensus responses (e.g. override unsafe_l2 in optimism_syncStatus).
-	// This is a separate path from OverwriteConsensusResponses because it operates on the
-	// actual backend response rather than synthesizing a pre-flight override.
-	if bg.Consensus != nil && bg.Consensus.IsConsensusLayer() {
-		rctx := RewriteContext{
-			latest:         bg.Consensus.GetLatestBlockNumber(),
-			safe:           bg.Consensus.GetSafeBlockNumber(),
-			finalized:      bg.Consensus.GetFinalizedBlockNumber(),
-			maxBlockRange:  bg.Consensus.maxBlockRange,
-			latestHash:     bg.Consensus.GetLatestBlockHash(),
-			safeHash:       bg.Consensus.GetSafeBlockHash(),
-			localSafe:      bg.Consensus.GetLocalSafeBlockNumber(),
-			localSafeHash:  bg.Consensus.GetLocalSafeBlockHash(),
-			finalizedHash:  bg.Consensus.GetFinalizedBlockHash(),
-			consensusMode:  true,
-			consensusLayer: true,
-		}
-		for i, req := range rpcReqs {
-			if i < len(backendResp.RPCRes) {
-				RewriteConsensusBackendResponse(rctx, req, backendResp.RPCRes[i])
-			}
-		}
-	}
+	// Apply CL post-fetch field rewrites (e.g. overwrite L2 block fields in
+	// optimism_syncStatus). The context was built in PrepareConsensusRequests;
+	// the rewrite runs here because it requires the real backend response.
+	bg.ApplyConsensusLayerRewrites(clRctx, rpcReqs, backendResp.RPCRes)
 
 	// re-apply overridden responses
 	log.Trace("successfully served request overriding responses",
@@ -1793,13 +1775,21 @@ func OverrideResponses(res []*RPCRes, overriddenResponses []*indexedReqRes) []*R
 	return res
 }
 
-func (bg *BackendGroup) OverwriteConsensusResponses(rpcReqs []*RPCReq, overriddenResponses []*indexedReqRes, rewrittenReqs []*RPCReq) ([]*RPCReq, []*indexedReqRes) {
+// PrepareConsensusRequests partitions rpcReqs into responses that can be synthesized from
+// consensus state (overriddenResponses) and requests that still need a backend roundtrip
+// (rewrittenReqs). The returned RewriteContext should be passed to ApplyConsensusLayerRewrites
+// after the backend responds.
+func (bg *BackendGroup) PrepareConsensusRequests(rpcReqs []*RPCReq, overriddenResponses []*indexedReqRes, rewrittenReqs []*RPCReq) ([]*RPCReq, []*indexedReqRes, RewriteContext) {
 	rctx := RewriteContext{
 		latest:         bg.Consensus.GetLatestBlockNumber(),
 		safe:           bg.Consensus.GetSafeBlockNumber(),
 		finalized:      bg.Consensus.GetFinalizedBlockNumber(),
 		maxBlockRange:  bg.Consensus.maxBlockRange,
 		latestHash:     bg.Consensus.GetLatestBlockHash(),
+		safeHash:       bg.Consensus.GetSafeBlockHash(),
+		localSafe:      bg.Consensus.GetLocalSafeBlockNumber(),
+		localSafeHash:  bg.Consensus.GetLocalSafeBlockHash(),
+		finalizedHash:  bg.Consensus.GetFinalizedBlockHash(),
 		consensusMode:  true,
 		consensusLayer: bg.Consensus.IsConsensusLayer(),
 	}
@@ -1863,7 +1853,25 @@ func (bg *BackendGroup) OverwriteConsensusResponses(rpcReqs []*RPCReq, overridde
 			rewrittenReqs = append(rewrittenReqs, req)
 		}
 	}
-	return rewrittenReqs, overriddenResponses
+	return rewrittenReqs, overriddenResponses, rctx
+}
+
+// ApplyConsensusLayerRewrites applies post-fetch field overwrites to CL backend responses.
+// It is called after ForwardRequestToBackendGroup returns, using the RewriteContext produced
+// by PrepareConsensusRequests. CL responses (e.g. optimism_syncStatus) cannot be
+// pre-synthesized because they contain passthrough fields (current_l1, head_l1, timestamps)
+// that the consensus poller does not track — the backend response must be fetched first, then
+// only the four consensus-tracked L2 fields are overwritten.
+func (bg *BackendGroup) ApplyConsensusLayerRewrites(rctx RewriteContext, rpcReqs []*RPCReq, responses []*RPCRes) {
+	if !rctx.consensusLayer {
+		return
+	}
+	for i, req := range rpcReqs {
+		// A backend may return fewer responses than requests (e.g. partial batch failure).
+		if i < len(responses) {
+			RewriteConsensusBackendResponse(rctx, req, responses[i])
+		}
+	}
 }
 
 func (bg *BackendGroup) OverwriteNonConsensusRequests(rpcReqs []*RPCReq, overriddenResponses []*indexedReqRes) ([]*RPCReq, []*indexedReqRes) {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -160,6 +160,8 @@ func (b *BackendGroupConfig) ValidateRoutingStrategy(bgName string) bool {
 	switch b.RoutingStrategy {
 	case ConsensusAwareRoutingStrategy:
 		return true
+	case ConsensusAwareCLRoutingStrategy:
+		return true
 	case MulticallRoutingStrategy:
 		return true
 	case FallbackRoutingStrategy:
@@ -174,9 +176,10 @@ func (b *BackendGroupConfig) ValidateRoutingStrategy(bgName string) bool {
 }
 
 const (
-	ConsensusAwareRoutingStrategy RoutingStrategy = "consensus_aware"
-	MulticallRoutingStrategy      RoutingStrategy = "multicall"
-	FallbackRoutingStrategy       RoutingStrategy = "fallback"
+	ConsensusAwareRoutingStrategy   RoutingStrategy = "consensus_aware"
+	ConsensusAwareCLRoutingStrategy RoutingStrategy = "consensus_aware_consensus_layer"
+	MulticallRoutingStrategy        RoutingStrategy = "multicall"
+	FallbackRoutingStrategy         RoutingStrategy = "fallback"
 )
 
 type BackendGroupConfig struct {
@@ -203,6 +206,20 @@ type BackendGroupConfig struct {
 	// Will set Max Block Range for non-consensus eth_getLogs and eth_newFilter
 	// Will override consensus_max_block_range if consensus_max_block range is also set
 	MaxBlockRange uint64 `toml:"max_block_range"`
+
+	// consensus_cl_sync_threshold is the maximum number of L1 blocks a CL (op-node) backend
+	// may lag behind the network's head_l1 before it is considered out of sync and excluded
+	// from the consensus group. Computed as head_l1.number - current_l1.number.
+	// Default: 10 (~2 minutes at 12s L1 block time). Only applies when
+	// routing_strategy = "consensus_aware_consensus_layer".
+	ConsensusCLSyncThreshold uint64 `toml:"consensus_cl_sync_threshold"`
+
+	// consensus_cl_head_l1_max_age is the maximum age of a CL backend's head_l1 timestamp
+	// before the backend is considered stale and excluded from the consensus group.
+	// A backend whose L1 head is older than this duration has likely lost its L1 connection.
+	// Default: 5m. Set to 0 to disable the age check. Only applies when
+	// routing_strategy = "consensus_aware_consensus_layer".
+	ConsensusCLHeadL1MaxAge TOMLDuration `toml:"consensus_cl_head_l1_max_age"`
 
 	ConsensusHA                  bool         `toml:"consensus_ha"`
 	ConsensusHAHeartbeatInterval TOMLDuration `toml:"consensus_ha_heartbeat_interval"`

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -336,7 +336,7 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		return
 	}
 
-	inSync, err := cp.isInSync(ctx, be)
+	inSync, err := cp.isELInSync(ctx, be)
 	RecordConsensusBackendInSync(be, err == nil && inSync)
 	if err != nil {
 		log.Warn("error updating backend sync state", "name", be.Name, "err", err)
@@ -358,7 +358,7 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		RecordConsensusBackendPeerCount(be, peerCount)
 	}
 
-	latestBlockNumber, latestBlockHash, err := cp.fetchBlock(ctx, be, "latest")
+	latestBlockNumber, latestBlockHash, err := cp.fetchELBlock(ctx, be, "latest")
 	if err != nil {
 		log.Warn("error updating backend - latest block will not be updated", "name", be.Name, "err", err)
 		return
@@ -369,7 +369,7 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		return
 	}
 
-	safeBlockNumber, safeBlockHash, err := cp.fetchBlock(ctx, be, "safe")
+	safeBlockNumber, safeBlockHash, err := cp.fetchELBlock(ctx, be, "safe")
 	if err != nil {
 		log.Warn("error updating backend - safe block will not be updated", "name", be.Name, "err", err)
 		return
@@ -381,7 +381,7 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		return
 	}
 
-	finalizedBlockNumber, finalizedBlockHash, err := cp.fetchBlock(ctx, be, "finalized")
+	finalizedBlockNumber, finalizedBlockHash, err := cp.fetchELBlock(ctx, be, "finalized")
 	if err != nil {
 		log.Warn("error updating backend - finalized block will not be updated", "name", be.Name, "err", err)
 		return
@@ -624,7 +624,7 @@ type blockHashFetcher func(ctx context.Context, be *Backend, bs *backendState, b
 
 // elBlockFetcher is a blockHashFetcher for EL backends; bs is unused.
 func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
-	return cp.fetchBlock(ctx, be, block.String())
+	return cp.fetchELBlock(ctx, be, block.String())
 }
 
 // findConsensusBlock walks back from startBlock until all candidates agree on the same block hash.
@@ -677,9 +677,13 @@ func (cp *ConsensusPoller) findConsensusBlock(
 	}
 }
 
-// fetchBlock is a convenient wrapper to make a request to get a block directly from the backend
-func (cp *ConsensusPoller) fetchBlock(ctx context.Context, be *Backend, block string) (blockNumber hexutil.Uint64, blockHash string, err error) {
+// fetchELBlock calls eth_getBlockByNumber and returns the block number and hash.
+func (cp *ConsensusPoller) fetchELBlock(ctx context.Context, be *Backend, block string) (blockNumber hexutil.Uint64, blockHash string, err error) {
 	var rpcRes RPCRes
+	log.Trace("executing fetchELBlock for backend",
+		"backend", be.Name,
+		"block", block,
+	)
 	err = be.ForwardRPC(ctx, &rpcRes, "67", "eth_getBlockByNumber", block, false)
 	if err != nil {
 		return 0, "", err
@@ -689,14 +693,27 @@ func (cp *ConsensusPoller) fetchBlock(ctx context.Context, be *Backend, block st
 	if !ok {
 		return 0, "", fmt.Errorf("unexpected response to eth_getBlockByNumber on backend %s", be.Name)
 	}
-	blockNumber = hexutil.Uint64(hexutil.MustDecodeUint64(jsonMap["number"].(string)))
-	blockHash = jsonMap["hash"].(string)
+	numStr, ok := jsonMap["number"].(string)
+	if !ok {
+		return 0, "", fmt.Errorf("missing or invalid number in eth_getBlockByNumber response on backend %s", be.Name)
+	}
+	hashStr, ok := jsonMap["hash"].(string)
+	if !ok {
+		return 0, "", fmt.Errorf("missing or invalid hash in eth_getBlockByNumber response on backend %s", be.Name)
+	}
+	blockNumber = hexutil.Uint64(hexutil.MustDecodeUint64(numStr))
+	blockHash = hashStr
 
 	return
 }
 
-// getPeerCount is a convenient wrapper to retrieve the current peer count from the backend
+// getPeerCount retrieves the current peer count from the backend.
 func (cp *ConsensusPoller) getPeerCount(ctx context.Context, be *Backend) (count uint64, err error) {
+	return cp.fetchELPeerCount(ctx, be)
+}
+
+// fetchELPeerCount calls net_peerCount and returns the peer count.
+func (cp *ConsensusPoller) fetchELPeerCount(ctx context.Context, be *Backend) (count uint64, err error) {
 	var rpcRes RPCRes
 	err = be.ForwardRPC(ctx, &rpcRes, "67", "net_peerCount")
 	if err != nil {
@@ -713,8 +730,8 @@ func (cp *ConsensusPoller) getPeerCount(ctx context.Context, be *Backend) (count
 	return count, nil
 }
 
-// isInSync is a convenient wrapper to check if the backend is in sync from the network
-func (cp *ConsensusPoller) isInSync(ctx context.Context, be *Backend) (result bool, err error) {
+// isELInSync checks if an EL backend is in sync by calling eth_syncing.
+func (cp *ConsensusPoller) isELInSync(ctx context.Context, be *Backend) (result bool, err error) {
 	var rpcRes RPCRes
 	err = be.ForwardRPC(ctx, &rpcRes, "67", "eth_syncing")
 	if err != nil {

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -48,7 +48,9 @@ type backendState struct {
 	latestBlockNumber    hexutil.Uint64
 	latestBlockHash      string
 	safeBlockNumber      hexutil.Uint64
+	safeBlockHash        string
 	finalizedBlockNumber hexutil.Uint64
+	finalizedBlockHash   string
 
 	peerCount uint64
 	inSync    bool
@@ -104,6 +106,21 @@ func (cp *ConsensusPoller) GetSafeBlockNumber() hexutil.Uint64 {
 // GetFinalizedBlockNumber returns the `finalized` agreed block number in a consensus
 func (cp *ConsensusPoller) GetFinalizedBlockNumber() hexutil.Uint64 {
 	return cp.tracker.GetState().Finalized
+}
+
+// GetLatestBlockHash returns the hash of the `latest` agreed block in a consensus
+func (cp *ConsensusPoller) GetLatestBlockHash() string {
+	return cp.tracker.GetState().LatestHash
+}
+
+// GetSafeBlockHash returns the hash of the `safe` agreed block in a consensus
+func (cp *ConsensusPoller) GetSafeBlockHash() string {
+	return cp.tracker.GetState().SafeHash
+}
+
+// GetFinalizedBlockHash returns the hash of the `finalized` agreed block in a consensus
+func (cp *ConsensusPoller) GetFinalizedBlockHash() string {
+	return cp.tracker.GetState().FinalizedHash
 }
 
 func (cp *ConsensusPoller) Shutdown() {
@@ -352,7 +369,7 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		return
 	}
 
-	safeBlockNumber, _, err := cp.fetchBlock(ctx, be, "safe")
+	safeBlockNumber, safeBlockHash, err := cp.fetchBlock(ctx, be, "safe")
 	if err != nil {
 		log.Warn("error updating backend - safe block will not be updated", "name", be.Name, "err", err)
 		return
@@ -364,7 +381,7 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		return
 	}
 
-	finalizedBlockNumber, _, err := cp.fetchBlock(ctx, be, "finalized")
+	finalizedBlockNumber, finalizedBlockHash, err := cp.fetchBlock(ctx, be, "finalized")
 	if err != nil {
 		log.Warn("error updating backend - finalized block will not be updated", "name", be.Name, "err", err)
 		return
@@ -384,7 +401,9 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		latestBlockNumber:    latestBlockNumber,
 		latestBlockHash:      latestBlockHash,
 		safeBlockNumber:      safeBlockNumber,
+		safeBlockHash:        safeBlockHash,
 		finalizedBlockNumber: finalizedBlockNumber,
+		finalizedBlockHash:   finalizedBlockHash,
 	})
 
 	RecordBackendLatestBlock(be, latestBlockNumber)
@@ -461,11 +480,12 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	candidates := cp.getConsensusCandidates()
 
 	// update the lowest latest block number and hash
-	//        the lowest safe block number
+	//        the lowest safe block number and hash
 	//        the lowest finalized block number
 	var lowestLatestBlock hexutil.Uint64
 	var lowestLatestBlockHash string
 	var lowestFinalizedBlock hexutil.Uint64
+	var lowestSafeBlockHash string
 	var lowestSafeBlock hexutil.Uint64
 	for _, bs := range candidates {
 		if lowestLatestBlock == 0 || bs.latestBlockNumber < lowestLatestBlock {
@@ -477,6 +497,7 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 		}
 		if lowestSafeBlock == 0 || bs.safeBlockNumber < lowestSafeBlock {
 			lowestSafeBlock = bs.safeBlockNumber
+			lowestSafeBlockHash = bs.safeBlockHash
 		}
 	}
 
@@ -510,9 +531,11 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 
 	// update tracker
 	cp.tracker.SetState(ConsensusTrackerState{
-		Latest:    proposedBlock,
-		Safe:      lowestSafeBlock,
-		Finalized: lowestFinalizedBlock,
+		Latest:     proposedBlock,
+		Safe:       lowestSafeBlock,
+		Finalized:  lowestFinalizedBlock,
+		LatestHash: proposedBlockHash,
+		SafeHash:   lowestSafeBlockHash,
 	})
 
 	// update consensus group
@@ -727,7 +750,9 @@ func (cp *ConsensusPoller) GetBackendState(be *Backend) *backendState {
 		latestBlockNumber:    bs.latestBlockNumber,
 		latestBlockHash:      bs.latestBlockHash,
 		safeBlockNumber:      bs.safeBlockNumber,
+		safeBlockHash:        bs.safeBlockHash,
 		finalizedBlockNumber: bs.finalizedBlockNumber,
+		finalizedBlockHash:   bs.finalizedBlockHash,
 		peerCount:            bs.peerCount,
 		inSync:               bs.inSync,
 		lastUpdate:           bs.lastUpdate,
@@ -750,7 +775,9 @@ type backendStateUpdate struct {
 	latestBlockNumber    hexutil.Uint64
 	latestBlockHash      string
 	safeBlockNumber      hexutil.Uint64
+	safeBlockHash        string
 	finalizedBlockNumber hexutil.Uint64
+	finalizedBlockHash   string
 }
 
 func (cp *ConsensusPoller) setBackendState(be *Backend, upd backendStateUpdate) bool {
@@ -761,8 +788,10 @@ func (cp *ConsensusPoller) setBackendState(be *Backend, upd backendStateUpdate) 
 	bs.inSync = upd.inSync
 	bs.latestBlockNumber = upd.latestBlockNumber
 	bs.latestBlockHash = upd.latestBlockHash
-	bs.finalizedBlockNumber = upd.finalizedBlockNumber
 	bs.safeBlockNumber = upd.safeBlockNumber
+	bs.safeBlockHash = upd.safeBlockHash
+	bs.finalizedBlockNumber = upd.finalizedBlockNumber
+	bs.finalizedBlockHash = upd.finalizedBlockHash
 	bs.lastUpdate = time.Now()
 	bs.backendStateMux.Unlock()
 	return changed

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -419,22 +419,7 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		}
 	}
 
-	if cp.consensusLayer && localSafeBlockNumber == 0 {
-		log.Warn("error backend responded with blockheight 0 for local_safe block", "name", be.Name)
-		be.intermittentErrorsSlidingWindow.Incr()
-		return
-	}
-
-	// On interop chains, cross-safe (safe_l2) always lags behind or equals local-safe.
-	// A backend reporting safe > local_safe is in an invalid state and must be excluded.
-	if cp.consensusLayer && safeBlockNumber > 0 && localSafeBlockNumber > 0 && safeBlockNumber > localSafeBlockNumber {
-		log.Warn("banning CL backend: safe > local_safe (invalid interop state)",
-			"backend", be.Name,
-			"safe", safeBlockNumber,
-			"local_safe", localSafeBlockNumber,
-		)
-		RecordCLBan(be, "interop_safe_gt_local_safe")
-		cp.Ban(be)
+	if cp.consensusLayer && !cp.validateCLBackendUpdate(be, safeBlockNumber, localSafeBlockNumber) {
 		return
 	}
 
@@ -551,20 +536,14 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 		}
 		if lowestFinalizedBlock == 0 || bs.finalizedBlockNumber < lowestFinalizedBlock {
 			lowestFinalizedBlock = bs.finalizedBlockNumber
-			if cp.consensusLayer {
-				lowestFinalizedBlockHash = bs.finalizedBlockHash
-			}
 		}
 		if lowestSafeBlock == 0 || bs.safeBlockNumber < lowestSafeBlock {
 			lowestSafeBlock = bs.safeBlockNumber
 			lowestSafeBlockHash = bs.safeBlockHash
 		}
-		if cp.consensusLayer {
-			if lowestLocalSafeBlock == 0 || bs.localSafeBlockNumber < lowestLocalSafeBlock {
-				lowestLocalSafeBlock = bs.localSafeBlockNumber
-				lowestLocalSafeBlockHash = bs.localSafeBlockHash
-			}
-		}
+	}
+	if cp.consensusLayer {
+		lowestFinalizedBlockHash, lowestLocalSafeBlock, lowestLocalSafeBlockHash = cp.computeCLGroupMinimums(candidates, lowestFinalizedBlock)
 	}
 
 	// find the proposed block among the candidates
@@ -587,24 +566,8 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 		proposedBlock, proposedBlockHash, broken = cp.findConsensusBlock(ctx, candidates, currentConsensusBlockNumber, proposedBlock, proposedBlockHash, fetch, "unsafe")
 	}
 
-	// CL mode: warn if any backend's safe_l2 is far ahead of the peer minimum.
-	// This detects the op-node premature finalization bug (https://github.com/ethereum-optimism/optimism/issues/17631)
-	// where a node finishing EL sync incorrectly reports safe == finalized == unsafe == EL sync tip.
-	// The minimum-safe logic below already protects the served value; this is observability only.
-	if cp.consensusLayer && cp.clSafeLeapWarnThreshold > 0 && lowestSafeBlock > 0 {
-		for be, bs := range candidates {
-			leap := uint64(bs.safeBlockNumber) - uint64(lowestSafeBlock)
-			RecordCLBackendSafeLeap(be, leap)
-			if leap > cp.clSafeLeapWarnThreshold {
-				log.Warn("CL backend safe head far ahead of peer minimum — possible premature finalization",
-					"backend", be.Name,
-					"safe", bs.safeBlockNumber,
-					"peer_min_safe", lowestSafeBlock,
-					"leap", leap,
-					"threshold", cp.clSafeLeapWarnThreshold,
-				)
-			}
-		}
+	if cp.consensusLayer {
+		cp.warnCLSafeLeap(candidates, lowestSafeBlock)
 	}
 
 	// CL mode: hash-verify safe_l2 via walk-back. local_safe_l2 and finalized_l2 use

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -47,6 +47,12 @@ type ConsensusPoller struct {
 	maxBlockLag        uint64
 	maxBlockRange      uint64
 	interval           time.Duration
+
+	// CL (op-node) consensus fields — only populated when consensusLayer is true.
+	// All logic that reads these fields lives in consensus_poller_cl.go.
+	consensusLayer  bool
+	clSyncThreshold uint64
+	clHeadL1MaxAge  time.Duration
 }
 
 type backendState struct {
@@ -56,6 +62,8 @@ type backendState struct {
 	latestBlockHash      string
 	safeBlockNumber      hexutil.Uint64
 	safeBlockHash        string
+	localSafeBlockNumber hexutil.Uint64
+	localSafeBlockHash   string
 	finalizedBlockNumber hexutil.Uint64
 	finalizedBlockHash   string
 
@@ -125,9 +133,24 @@ func (cp *ConsensusPoller) GetSafeBlockHash() string {
 	return cp.tracker.GetState().SafeHash
 }
 
+// GetLocalSafeBlockNumber returns the `local_safe` agreed block number in a consensus (CL mode only)
+func (cp *ConsensusPoller) GetLocalSafeBlockNumber() hexutil.Uint64 {
+	return cp.tracker.GetState().LocalSafe
+}
+
+// GetLocalSafeBlockHash returns the hash of the `local_safe` agreed block in a consensus (CL mode only)
+func (cp *ConsensusPoller) GetLocalSafeBlockHash() string {
+	return cp.tracker.GetState().LocalSafeHash
+}
+
 // GetFinalizedBlockHash returns the hash of the `finalized` agreed block in a consensus
 func (cp *ConsensusPoller) GetFinalizedBlockHash() string {
 	return cp.tracker.GetState().FinalizedHash
+}
+
+// IsConsensusLayer returns true if this poller is operating in CL (op-node) mode
+func (cp *ConsensusPoller) IsConsensusLayer() bool {
+	return cp.consensusLayer
 }
 
 func (cp *ConsensusPoller) Shutdown() {
@@ -306,6 +329,8 @@ func NewConsensusPoller(bg *BackendGroup, opts ...ConsensusOpt) *ConsensusPoller
 		maxBlockLag:        8, // 8*12 seconds = 96 seconds ~ 1.6 minutes
 		minPeerCount:       3,
 		interval:           DefaultPollerInterval,
+		clSyncThreshold:    10,              // 10 L1 blocks ~ 2 minutes
+		clHeadL1MaxAge:     5 * time.Minute, // L1 head older than this → node is stalled
 	}
 
 	for _, opt := range opts {
@@ -339,18 +364,15 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 	// if backend is not healthy state we'll only resume checking it after ban
 	if !be.IsHealthy() && !be.forcedCandidate {
 		log.Warn("backend banned - not healthy", "backend", be.Name)
+		if cp.consensusLayer {
+			RecordCLBan(be, "not_healthy")
+		}
 		cp.Ban(be)
 		return
 	}
 
-	inSync, err := cp.isELInSync(ctx, be)
-	RecordConsensusBackendInSync(be, err == nil && inSync)
-	if err != nil {
-		log.Warn("error updating backend sync state", "name", be.Name, "err", err)
-		return
-	}
-
 	var peerCount uint64
+	var err error
 	if !be.skipPeerCountCheck {
 		peerCount, err = cp.getPeerCount(ctx, be)
 		if err != nil {
@@ -365,8 +387,52 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		RecordConsensusBackendPeerCount(be, peerCount)
 	}
 
-	latestBlockNumber, latestBlockHash, safeBlockNumber, safeBlockHash, finalizedBlockNumber, finalizedBlockHash, err := cp.updateELBackend(ctx, be)
-	if err != nil {
+	var inSync bool
+	var latestBlockNumber, safeBlockNumber, localSafeBlockNumber, finalizedBlockNumber hexutil.Uint64
+	var latestBlockHash, safeBlockHash, localSafeBlockHash, finalizedBlockHash string
+	if cp.consensusLayer {
+		syncStatus, clInSync, err := cp.updateCLBackend(ctx, be)
+		if err != nil {
+			return
+		}
+		latestBlockHash = syncStatus.LatestBlockHash
+		latestBlockNumber = syncStatus.LatestBlockNumber
+		safeBlockNumber = syncStatus.SafeBlockNumber
+		safeBlockHash = syncStatus.SafeBlockHash
+		localSafeBlockNumber = syncStatus.LocalSafeBlockNumber
+		localSafeBlockHash = syncStatus.LocalSafeBlockHash
+		finalizedBlockNumber = syncStatus.FinalizedBlockNumber
+		finalizedBlockHash = syncStatus.FinalizedBlockHash
+		inSync = clInSync
+	} else {
+		inSync, err = cp.isELInSync(ctx, be)
+		RecordConsensusBackendInSync(be, err == nil && inSync)
+		if err != nil {
+			log.Warn("error updating backend sync state", "name", be.Name, "err", err)
+			return
+		}
+		latestBlockNumber, latestBlockHash, safeBlockNumber, safeBlockHash, finalizedBlockNumber, finalizedBlockHash, err = cp.updateELBackend(ctx, be)
+		if err != nil {
+			return
+		}
+	}
+
+	if cp.consensusLayer && localSafeBlockNumber == 0 {
+		log.Warn("error backend responded with blockheight 0 for local_safe block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		return
+	}
+
+	// On interop chains, cross-safe (safe_l2) always lags behind or equals local-safe.
+	// A backend reporting safe > local_safe is in an invalid state and must be excluded.
+	if cp.consensusLayer && safeBlockNumber > 0 && localSafeBlockNumber > 0 && safeBlockNumber > localSafeBlockNumber {
+		log.Warn("banning CL backend: safe > local_safe (invalid interop state)",
+			"backend", be.Name,
+			"safe", safeBlockNumber,
+			"local_safe", localSafeBlockNumber,
+		)
+		RecordCLBan(be, "interop_safe_gt_local_safe")
+		cp.Ban(be)
 		return
 	}
 
@@ -379,6 +445,8 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		latestBlockHash:      latestBlockHash,
 		safeBlockNumber:      safeBlockNumber,
 		safeBlockHash:        safeBlockHash,
+		localSafeBlockNumber: localSafeBlockNumber,
+		localSafeBlockHash:   localSafeBlockHash,
 		finalizedBlockNumber: finalizedBlockNumber,
 		finalizedBlockHash:   finalizedBlockHash,
 	})
@@ -386,6 +454,9 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 	RecordBackendLatestBlock(be, latestBlockNumber)
 	RecordBackendSafeBlock(be, safeBlockNumber)
 	RecordBackendFinalizedBlock(be, finalizedBlockNumber)
+	if cp.consensusLayer {
+		RecordCLBackendLocalSafeBlock(be, localSafeBlockNumber)
+	}
 
 	if changed {
 		log.Debug("backend state updated",
@@ -418,6 +489,9 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 			"safeBlockNumber", safeBlockNumber,
 			"latestBlockNumber", latestBlockNumber,
 		)
+		if cp.consensusLayer {
+			RecordCLBan(be, "unexpected_block_tags")
+		}
 		cp.Ban(be)
 	}
 }
@@ -459,11 +533,15 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	// update the lowest latest block number and hash
 	//        the lowest safe block number and hash
 	//        the lowest finalized block number
+	//        the lowest local-safe block number and finalized hash (CL mode only)
 	var lowestLatestBlock hexutil.Uint64
 	var lowestLatestBlockHash string
 	var lowestFinalizedBlock hexutil.Uint64
-	var lowestSafeBlockHash string
+	var lowestFinalizedBlockHash string // only populated in CL mode
 	var lowestSafeBlock hexutil.Uint64
+	var lowestSafeBlockHash string
+	var lowestLocalSafeBlock hexutil.Uint64    // only populated in CL mode
+	var lowestLocalSafeBlockHash string        // only populated in CL mode
 	for _, bs := range candidates {
 		if lowestLatestBlock == 0 || bs.latestBlockNumber < lowestLatestBlock {
 			lowestLatestBlock = bs.latestBlockNumber
@@ -471,10 +549,19 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 		}
 		if lowestFinalizedBlock == 0 || bs.finalizedBlockNumber < lowestFinalizedBlock {
 			lowestFinalizedBlock = bs.finalizedBlockNumber
+			if cp.consensusLayer {
+				lowestFinalizedBlockHash = bs.finalizedBlockHash
+			}
 		}
 		if lowestSafeBlock == 0 || bs.safeBlockNumber < lowestSafeBlock {
 			lowestSafeBlock = bs.safeBlockNumber
 			lowestSafeBlockHash = bs.safeBlockHash
+		}
+		if cp.consensusLayer {
+			if lowestLocalSafeBlock == 0 || bs.localSafeBlockNumber < lowestLocalSafeBlock {
+				lowestLocalSafeBlock = bs.localSafeBlockNumber
+				lowestLocalSafeBlockHash = bs.localSafeBlockHash
+			}
 		}
 	}
 
@@ -491,8 +578,20 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	// if there is a block to propose, verify all candidates agree on the same hash,
 	// walking back one block at a time until consensus is found.
 	if proposedBlock > 0 {
-		proposedBlock, proposedBlockHash, broken = cp.findConsensusBlock(
-			ctx, candidates, currentConsensusBlockNumber, proposedBlock, proposedBlockHash, cp.elBlockFetcher, "unsafe")
+		fetch := cp.elBlockFetcher
+		if cp.consensusLayer {
+			fetch = cp.clBlockFetcher
+		}
+		proposedBlock, proposedBlockHash, broken = cp.findConsensusBlock(ctx, candidates, currentConsensusBlockNumber, proposedBlock, proposedBlockHash, fetch, "unsafe")
+	}
+
+	// CL mode: hash-verify safe_l2 via walk-back. local_safe_l2 and finalized_l2 use
+	// their minimum block+hash directly — both are L1-derived/immutable so hash divergence
+	// indicates a broken backend, not a fork requiring walk-back.
+	// EL mode uses raw minimums for all fields.
+	if cp.consensusLayer {
+		lowestSafeBlock, lowestSafeBlockHash = cp.updateCLGroupConsensus(
+			ctx, candidates, lowestSafeBlock, lowestSafeBlockHash)
 	}
 
 	if broken {
@@ -508,11 +607,14 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 
 	// update tracker
 	cp.tracker.SetState(ConsensusTrackerState{
-		Latest:     proposedBlock,
-		Safe:       lowestSafeBlock,
-		Finalized:  lowestFinalizedBlock,
-		LatestHash: proposedBlockHash,
-		SafeHash:   lowestSafeBlockHash,
+		Latest:        proposedBlock,
+		Safe:          lowestSafeBlock,
+		Finalized:     lowestFinalizedBlock,
+		LatestHash:    proposedBlockHash,
+		SafeHash:      lowestSafeBlockHash,
+		LocalSafe:     lowestLocalSafeBlock,
+		LocalSafeHash: lowestLocalSafeBlockHash,
+		FinalizedHash: lowestFinalizedBlockHash,
 	})
 
 	// update consensus group
@@ -536,6 +638,9 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	RecordGroupConsensusLatestBlock(cp.backendGroup, proposedBlock)
 	RecordGroupConsensusSafeBlock(cp.backendGroup, lowestSafeBlock)
 	RecordGroupConsensusFinalizedBlock(cp.backendGroup, lowestFinalizedBlock)
+	if cp.consensusLayer {
+		RecordCLGroupLocalSafeBlock(cp.backendGroup, lowestLocalSafeBlock)
+	}
 
 	RecordGroupConsensusCount(cp.backendGroup, len(group))
 	RecordGroupConsensusFilteredCount(cp.backendGroup, len(filteredBackendsNames))
@@ -588,7 +693,8 @@ func (cp *ConsensusPoller) Unban(be *Backend) {
 	bs.bannedUntil = time.Now().Add(-10 * time.Hour)
 }
 
-// Reset reset all backend states
+// Reset resets all backend states and clears the consensus tracker.
+// This ensures the monotonicity filters in FilterCandidates start from a clean baseline.
 func (cp *ConsensusPoller) Reset() {
 	for _, be := range cp.backendGroup.Backends {
 		cp.backendState[be] = &backendState{}
@@ -597,16 +703,17 @@ func (cp *ConsensusPoller) Reset() {
 }
 
 // blockHashFetcher retrieves the block number and hash for a given block from a backend.
-// bs is provided for fetchers that can use cached state; it may be ignored.
+// bs is provided for fetchers that can use cached state (e.g. CL); it may be ignored.
 type blockHashFetcher func(ctx context.Context, be *Backend, bs *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error)
 
-// elBlockFetcher is a blockHashFetcher for EL backends; bs is unused.
+// elBlockFetcher returns a blockHashFetcher for EL backends.
+// It always calls fetchELBlock; bs is unused.
 func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
 	return cp.fetchELBlock(ctx, be, block.String())
 }
 
 // findConsensusBlock walks back from startBlock until all candidates agree on the same block hash.
-// label identifies the safety level ("unsafe", "safe") for log context.
+// label identifies the safety level ("unsafe", "safe", "finalized") for log context.
 // It returns the agreed block number, hash, and whether consensus was broken relative to currentConsensusBlock.
 func (cp *ConsensusPoller) findConsensusBlock(
 	ctx context.Context,
@@ -721,11 +828,11 @@ func (cp *ConsensusPoller) fetchELBlock(ctx context.Context, be *Backend, block 
 	}
 	numStr, ok := jsonMap["number"].(string)
 	if !ok {
-		return 0, "", fmt.Errorf("missing or invalid number in eth_getBlockByNumber response on backend %s", be.Name)
+		return 0, "", fmt.Errorf("missing or invalid number in eth_getBlockByNumber on backend %s", be.Name)
 	}
 	hashStr, ok := jsonMap["hash"].(string)
 	if !ok {
-		return 0, "", fmt.Errorf("missing or invalid hash in eth_getBlockByNumber response on backend %s", be.Name)
+		return 0, "", fmt.Errorf("missing or invalid hash in eth_getBlockByNumber on backend %s", be.Name)
 	}
 	blockNumber = hexutil.Uint64(hexutil.MustDecodeUint64(numStr))
 	blockHash = hashStr
@@ -735,6 +842,9 @@ func (cp *ConsensusPoller) fetchELBlock(ctx context.Context, be *Backend, block 
 
 // getPeerCount retrieves the current peer count from the backend.
 func (cp *ConsensusPoller) getPeerCount(ctx context.Context, be *Backend) (count uint64, err error) {
+	if cp.consensusLayer {
+		return cp.fetchCLPeerCount(ctx, be)
+	}
 	return cp.fetchELPeerCount(ctx, be)
 }
 
@@ -794,6 +904,8 @@ func (cp *ConsensusPoller) GetBackendState(be *Backend) *backendState {
 		latestBlockHash:      bs.latestBlockHash,
 		safeBlockNumber:      bs.safeBlockNumber,
 		safeBlockHash:        bs.safeBlockHash,
+		localSafeBlockNumber: bs.localSafeBlockNumber,
+		localSafeBlockHash:   bs.localSafeBlockHash,
 		finalizedBlockNumber: bs.finalizedBlockNumber,
 		finalizedBlockHash:   bs.finalizedBlockHash,
 		peerCount:            bs.peerCount,
@@ -811,7 +923,7 @@ func (cp *ConsensusPoller) GetLastUpdate(be *Backend) time.Time {
 }
 
 // backendStateUpdate is a value object passed to setBackendState to avoid
-// transposition bugs with same-typed arguments.
+// a wide positional parameter list of same-typed arguments.
 type backendStateUpdate struct {
 	peerCount            uint64
 	inSync               bool
@@ -819,6 +931,8 @@ type backendStateUpdate struct {
 	latestBlockHash      string
 	safeBlockNumber      hexutil.Uint64
 	safeBlockHash        string
+	localSafeBlockNumber hexutil.Uint64
+	localSafeBlockHash   string
 	finalizedBlockNumber hexutil.Uint64
 	finalizedBlockHash   string
 }
@@ -833,6 +947,8 @@ func (cp *ConsensusPoller) setBackendState(be *Backend, upd backendStateUpdate) 
 	bs.latestBlockHash = upd.latestBlockHash
 	bs.safeBlockNumber = upd.safeBlockNumber
 	bs.safeBlockHash = upd.safeBlockHash
+	bs.localSafeBlockNumber = upd.localSafeBlockNumber
+	bs.localSafeBlockHash = upd.localSafeBlockHash
 	bs.finalizedBlockNumber = upd.finalizedBlockNumber
 	bs.finalizedBlockHash = upd.finalizedBlockHash
 	bs.lastUpdate = time.Now()
@@ -864,9 +980,20 @@ func (cp *ConsensusPoller) getConsensusCandidates() map[*Backend]*backendState {
 //   - in sync
 //   - updated recently
 //   - not lagging latest block
+//   - (CL mode) finalized and local_safe blocks are at or above the current group consensus,
+//     preventing a restarting backend from dragging consensus backward
 func (cp *ConsensusPoller) FilterCandidates(backends []*Backend) map[*Backend]*backendState {
 
 	candidates := make(map[*Backend]*backendState, len(cp.backendGroup.Backends))
+
+	// Snapshot consensus values once for CL monotonicity checks below.
+	// Both are 0 when the tracker is uninitialized (fresh start or in-memory restart),
+	// in which case the checks are vacuous and all backends pass.
+	var consensusFinalized, consensusLocalSafe hexutil.Uint64
+	if cp.consensusLayer {
+		consensusFinalized = cp.GetFinalizedBlockNumber()
+		consensusLocalSafe = cp.GetLocalSafeBlockNumber()
+	}
 
 	for _, be := range backends {
 
@@ -891,6 +1018,28 @@ func (cp *ConsensusPoller) FilterCandidates(backends []*Backend) map[*Backend]*b
 		}
 		if !be.skipIsSyncingCheck && !bs.inSync {
 			continue
+		}
+		// CL mode: exclude backends whose finalized or local_safe block is behind the current
+		// group consensus. This prevents a restarting backend from pulling consensus backward,
+		// which would cause unnecessary EL sync cycles on downstream light nodes.
+		// The checks are vacuous when consensus values are 0 (uninitialized tracker).
+		if cp.consensusLayer {
+			if consensusFinalized > 0 && bs.finalizedBlockNumber < consensusFinalized {
+				log.Debug("backend excluded: finalized block below consensus",
+					"backend_name", be.Name,
+					"backend_finalized", bs.finalizedBlockNumber,
+					"consensus_finalized", consensusFinalized,
+				)
+				continue
+			}
+			if consensusLocalSafe > 0 && bs.localSafeBlockNumber < consensusLocalSafe {
+				log.Debug("backend excluded: local_safe block below consensus",
+					"backend_name", be.Name,
+					"backend_local_safe", bs.localSafeBlockNumber,
+					"consensus_local_safe", consensusLocalSafe,
+				)
+				continue
+			}
 		}
 		if bs.lastUpdate.Add(cp.maxUpdateThreshold).Before(time.Now()) {
 			continue

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -50,9 +50,10 @@ type ConsensusPoller struct {
 
 	// CL (op-node) consensus fields — only populated when consensusLayer is true.
 	// All logic that reads these fields lives in consensus_poller_cl.go.
-	consensusLayer  bool
-	clSyncThreshold uint64
-	clHeadL1MaxAge  time.Duration
+	consensusLayer          bool
+	clSyncThreshold         uint64
+	clHeadL1MaxAge          time.Duration
+	clSafeLeapWarnThreshold uint64
 }
 
 type backendState struct {
@@ -329,8 +330,9 @@ func NewConsensusPoller(bg *BackendGroup, opts ...ConsensusOpt) *ConsensusPoller
 		maxBlockLag:        8, // 8*12 seconds = 96 seconds ~ 1.6 minutes
 		minPeerCount:       3,
 		interval:           DefaultPollerInterval,
-		clSyncThreshold:    10,              // 10 L1 blocks ~ 2 minutes
-		clHeadL1MaxAge:     5 * time.Minute, // L1 head older than this → node is stalled
+		clSyncThreshold:         10,              // 10 L1 blocks ~ 2 minutes
+		clHeadL1MaxAge:          5 * time.Minute, // L1 head older than this → node is stalled
+		clSafeLeapWarnThreshold: 1000,            // warn if a backend's safe is >1000 blocks ahead of peer minimum
 	}
 
 	for _, opt := range opts {
@@ -540,8 +542,8 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	var lowestFinalizedBlockHash string // only populated in CL mode
 	var lowestSafeBlock hexutil.Uint64
 	var lowestSafeBlockHash string
-	var lowestLocalSafeBlock hexutil.Uint64    // only populated in CL mode
-	var lowestLocalSafeBlockHash string        // only populated in CL mode
+	var lowestLocalSafeBlock hexutil.Uint64 // only populated in CL mode
+	var lowestLocalSafeBlockHash string     // only populated in CL mode
 	for _, bs := range candidates {
 		if lowestLatestBlock == 0 || bs.latestBlockNumber < lowestLatestBlock {
 			lowestLatestBlock = bs.latestBlockNumber
@@ -583,6 +585,26 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 			fetch = cp.clBlockFetcher
 		}
 		proposedBlock, proposedBlockHash, broken = cp.findConsensusBlock(ctx, candidates, currentConsensusBlockNumber, proposedBlock, proposedBlockHash, fetch, "unsafe")
+	}
+
+	// CL mode: warn if any backend's safe_l2 is far ahead of the peer minimum.
+	// This detects the op-node premature finalization bug (https://github.com/ethereum-optimism/optimism/issues/17631)
+	// where a node finishing EL sync incorrectly reports safe == finalized == unsafe == EL sync tip.
+	// The minimum-safe logic below already protects the served value; this is observability only.
+	if cp.consensusLayer && cp.clSafeLeapWarnThreshold > 0 && lowestSafeBlock > 0 {
+		for be, bs := range candidates {
+			leap := uint64(bs.safeBlockNumber) - uint64(lowestSafeBlock)
+			RecordCLBackendSafeLeap(be, leap)
+			if leap > cp.clSafeLeapWarnThreshold {
+				log.Warn("CL backend safe head far ahead of peer minimum — possible premature finalization",
+					"backend", be.Name,
+					"safe", bs.safeBlockNumber,
+					"peer_min_safe", lowestSafeBlock,
+					"leap", leap,
+					"threshold", cp.clSafeLeapWarnThreshold,
+				)
+			}
+		}
 	}
 
 	// CL mode: hash-verify safe_l2 via walk-back. local_safe_l2 and finalized_l2 use
@@ -699,7 +721,6 @@ func (cp *ConsensusPoller) Reset() {
 	for _, be := range cp.backendGroup.Backends {
 		cp.backendState[be] = &backendState{}
 	}
-	cp.tracker.SetState(ConsensusTrackerState{})
 }
 
 // blockHashFetcher retrieves the block number and hash for a given block from a backend.

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -325,11 +325,11 @@ func NewConsensusPoller(bg *BackendGroup, opts ...ConsensusOpt) *ConsensusPoller
 		backendGroup: bg,
 		backendState: state,
 
-		banPeriod:          5 * time.Minute,
-		maxUpdateThreshold: 30 * time.Second,
-		maxBlockLag:        8, // 8*12 seconds = 96 seconds ~ 1.6 minutes
-		minPeerCount:       3,
-		interval:           DefaultPollerInterval,
+		banPeriod:               5 * time.Minute,
+		maxUpdateThreshold:      30 * time.Second,
+		maxBlockLag:             8, // 8*12 seconds = 96 seconds ~ 1.6 minutes
+		minPeerCount:            3,
+		interval:                DefaultPollerInterval,
 		clSyncThreshold:         10,              // 10 L1 blocks ~ 2 minutes
 		clHeadL1MaxAge:          5 * time.Minute, // L1 head older than this → node is stalled
 		clSafeLeapWarnThreshold: 1000,            // warn if a backend's safe is >1000 blocks ahead of peer minimum

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -2,6 +2,7 @@ package proxyd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -14,6 +15,12 @@ import (
 
 const (
 	DefaultPollerInterval = 1 * time.Second
+)
+
+var (
+	errZeroLatestBlock    = errors.New("backend responded with blockheight 0 for latest block")
+	errZeroSafeBlock      = errors.New("backend responded with blockheight 0 for safe block")
+	errZeroFinalizedBlock = errors.New("backend responded with blockheight 0 for finalized block")
 )
 
 type OnConsensusBroken func()
@@ -358,38 +365,8 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		RecordConsensusBackendPeerCount(be, peerCount)
 	}
 
-	latestBlockNumber, latestBlockHash, err := cp.fetchELBlock(ctx, be, "latest")
+	latestBlockNumber, latestBlockHash, safeBlockNumber, safeBlockHash, finalizedBlockNumber, finalizedBlockHash, err := cp.updateELBackend(ctx, be)
 	if err != nil {
-		log.Warn("error updating backend - latest block will not be updated", "name", be.Name, "err", err)
-		return
-	}
-	if latestBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for latest block", "name", be.Name)
-		be.intermittentErrorsSlidingWindow.Incr()
-		return
-	}
-
-	safeBlockNumber, safeBlockHash, err := cp.fetchELBlock(ctx, be, "safe")
-	if err != nil {
-		log.Warn("error updating backend - safe block will not be updated", "name", be.Name, "err", err)
-		return
-	}
-
-	if safeBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for safe block", "name", be.Name)
-		be.intermittentErrorsSlidingWindow.Incr()
-		return
-	}
-
-	finalizedBlockNumber, finalizedBlockHash, err := cp.fetchELBlock(ctx, be, "finalized")
-	if err != nil {
-		log.Warn("error updating backend - finalized block will not be updated", "name", be.Name, "err", err)
-		return
-	}
-
-	if finalizedBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for finalized block", "name", be.Name)
-		be.intermittentErrorsSlidingWindow.Incr()
 		return
 	}
 
@@ -675,6 +652,54 @@ func (cp *ConsensusPoller) findConsensusBlock(
 		proposedBlockHash = ""
 		log.Debug("no consensus, walking back", "label", label, "block", proposedBlock)
 	}
+}
+
+// updateELBackend fetches the EL sync state and block numbers for a single backend,
+// performing zero-value validation inline. It is the EL counterpart to updateCLBackend.
+// On success it returns the inSync flag, block numbers/hashes, and nil.
+// On any error or zero block number it returns a non-nil error; the caller should skip state updates.
+func (cp *ConsensusPoller) updateELBackend(ctx context.Context, be *Backend) (
+	latestBlockNumber hexutil.Uint64, latestBlockHash string,
+	safeBlockNumber hexutil.Uint64, safeBlockHash string,
+	finalizedBlockNumber hexutil.Uint64, finalizedBlockHash string,
+	err error,
+) {
+	latestBlockNumber, latestBlockHash, err = cp.fetchELBlock(ctx, be, "latest")
+	if err != nil {
+		log.Warn("error updating backend - latest block will not be updated", "name", be.Name, "err", err)
+		return
+	}
+	if latestBlockNumber == 0 {
+		log.Warn("error backend responded a 200 with blockheight 0 for latest block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		err = errZeroLatestBlock
+		return
+	}
+
+	safeBlockNumber, safeBlockHash, err = cp.fetchELBlock(ctx, be, "safe")
+	if err != nil {
+		log.Warn("error updating backend - safe block will not be updated", "name", be.Name, "err", err)
+		return
+	}
+	if safeBlockNumber == 0 {
+		log.Warn("error backend responded a 200 with blockheight 0 for safe block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		err = errZeroSafeBlock
+		return
+	}
+
+	finalizedBlockNumber, finalizedBlockHash, err = cp.fetchELBlock(ctx, be, "finalized")
+	if err != nil {
+		log.Warn("error updating backend - finalized block will not be updated", "name", be.Name, "err", err)
+		return
+	}
+	if finalizedBlockNumber == 0 {
+		log.Warn("error backend responded a 200 with blockheight 0 for finalized block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		err = errZeroFinalizedBlock
+		return
+	}
+	return
 }
 
 // fetchELBlock calls eth_getBlockByNumber and returns the block number and hash.

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -484,50 +484,17 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	// the proposed block needs have the same hash in the entire consensus group
 	proposedBlock := lowestLatestBlock
 	proposedBlockHash := lowestLatestBlockHash
-	hasConsensus := false
 	broken := false
 
 	if lowestLatestBlock > currentConsensusBlockNumber {
 		log.Debug("validating consensus on block", "lowestLatestBlock", lowestLatestBlock)
 	}
 
-	// if there is a block to propose, check if it is the same in all backends
+	// if there is a block to propose, verify all candidates agree on the same hash,
+	// walking back one block at a time until consensus is found.
 	if proposedBlock > 0 {
-		for !hasConsensus {
-			allAgreed := true
-			for be := range candidates {
-				actualBlockNumber, actualBlockHash, err := cp.fetchBlock(ctx, be, proposedBlock.String())
-				if err != nil {
-					log.Warn("error updating backend", "name", be.Name, "err", err)
-					continue
-				}
-				if proposedBlockHash == "" {
-					proposedBlockHash = actualBlockHash
-				}
-				blocksDontMatch := (actualBlockNumber != proposedBlock) || (actualBlockHash != proposedBlockHash)
-				if blocksDontMatch {
-					if currentConsensusBlockNumber >= actualBlockNumber {
-						log.Warn("backend broke consensus",
-							"name", be.Name,
-							"actualBlockNumber", actualBlockNumber,
-							"actualBlockHash", actualBlockHash,
-							"proposedBlock", proposedBlock,
-							"proposedBlockHash", proposedBlockHash)
-						broken = true
-					}
-					allAgreed = false
-					break
-				}
-			}
-			if allAgreed {
-				hasConsensus = true
-			} else {
-				// walk one block behind and try again
-				proposedBlock -= 1
-				proposedBlockHash = ""
-				log.Debug("no consensus, now trying", "block:", proposedBlock)
-			}
-		}
+		proposedBlock, proposedBlockHash, broken = cp.findConsensusBlock(
+			ctx, candidates, currentConsensusBlockNumber, proposedBlock, proposedBlockHash, cp.elBlockFetcher, "unsafe")
 	}
 
 	if broken {
@@ -625,6 +592,65 @@ func (cp *ConsensusPoller) Unban(be *Backend) {
 func (cp *ConsensusPoller) Reset() {
 	for _, be := range cp.backendGroup.Backends {
 		cp.backendState[be] = &backendState{}
+	}
+}
+
+// blockHashFetcher retrieves the block number and hash for a given block from a backend.
+// bs is provided for fetchers that can use cached state; it may be ignored.
+type blockHashFetcher func(ctx context.Context, be *Backend, bs *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error)
+
+// elBlockFetcher is a blockHashFetcher for EL backends; bs is unused.
+func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+	return cp.fetchBlock(ctx, be, block.String())
+}
+
+// findConsensusBlock walks back from startBlock until all candidates agree on the same block hash.
+// label identifies the safety level ("unsafe", "safe") for log context.
+// It returns the agreed block number, hash, and whether consensus was broken relative to currentConsensusBlock.
+func (cp *ConsensusPoller) findConsensusBlock(
+	ctx context.Context,
+	candidates map[*Backend]*backendState,
+	currentConsensusBlock hexutil.Uint64,
+	startBlock hexutil.Uint64,
+	startHash string,
+	fetch blockHashFetcher,
+	label string,
+) (proposedBlock hexutil.Uint64, proposedBlockHash string, broken bool) {
+	proposedBlock = startBlock
+	proposedBlockHash = startHash
+
+	for {
+		allAgreed := true
+		for be, bs := range candidates {
+			actualBlockNumber, actualHash, err := fetch(ctx, be, bs, proposedBlock)
+			if err != nil {
+				log.Warn("error fetching block for consensus check", "label", label, "name", be.Name, "err", err)
+				continue
+			}
+			if proposedBlockHash == "" {
+				proposedBlockHash = actualHash
+			}
+			if actualBlockNumber != proposedBlock || actualHash != proposedBlockHash {
+				if currentConsensusBlock >= actualBlockNumber {
+					log.Warn("backend broke consensus",
+						"label", label,
+						"name", be.Name,
+						"actualBlockNumber", actualBlockNumber,
+						"actualHash", actualHash,
+						"proposedBlock", proposedBlock,
+						"proposedBlockHash", proposedBlockHash)
+					broken = true
+				}
+				allAgreed = false
+				break
+			}
+		}
+		if allAgreed {
+			return proposedBlock, proposedBlockHash, broken
+		}
+		proposedBlock -= 1
+		proposedBlockHash = ""
+		log.Debug("no consensus, walking back", "label", label, "block", proposedBlock)
 	}
 }
 

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -593,6 +593,7 @@ func (cp *ConsensusPoller) Reset() {
 	for _, be := range cp.backendGroup.Backends {
 		cp.backendState[be] = &backendState{}
 	}
+	cp.tracker.SetState(ConsensusTrackerState{})
 }
 
 // blockHashFetcher retrieves the block number and hash for a given block from a backend.

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -397,16 +397,16 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		if err != nil {
 			return
 		}
-		latestBlockHash = syncStatus.LatestBlockHash
-		latestBlockNumber = syncStatus.LatestBlockNumber
-		safeBlockNumber = syncStatus.SafeBlockNumber
-		safeBlockHash = syncStatus.SafeBlockHash
-		localSafeBlockNumber = syncStatus.LocalSafeBlockNumber
-		localSafeBlockHash = syncStatus.LocalSafeBlockHash
-		finalizedBlockNumber = syncStatus.FinalizedBlockNumber
-		finalizedBlockHash = syncStatus.FinalizedBlockHash
 		inSync = clInSync
+		latestBlockNumber, latestBlockHash = syncStatus.LatestBlockNumber, syncStatus.LatestBlockHash
+		safeBlockNumber, safeBlockHash = syncStatus.SafeBlockNumber, syncStatus.SafeBlockHash
+		localSafeBlockNumber, localSafeBlockHash = syncStatus.LocalSafeBlockNumber, syncStatus.LocalSafeBlockHash
+		finalizedBlockNumber, finalizedBlockHash = syncStatus.FinalizedBlockNumber, syncStatus.FinalizedBlockHash
+		if !cp.validateCLBackendUpdate(be, safeBlockNumber, localSafeBlockNumber) {
+			return
+		}
 	} else {
+		var err error
 		inSync, err = cp.isELInSync(ctx, be)
 		RecordConsensusBackendInSync(be, err == nil && inSync)
 		if err != nil {
@@ -417,10 +417,6 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		if err != nil {
 			return
 		}
-	}
-
-	if cp.consensusLayer && !cp.validateCLBackendUpdate(be, safeBlockNumber, localSafeBlockNumber) {
-		return
 	}
 
 	RecordConsensusBackendUpdateDelay(be, bs.lastUpdate)

--- a/proxyd/consensus_poller_cl.go
+++ b/proxyd/consensus_poller_cl.go
@@ -51,6 +51,17 @@ func WithCLHeadL1MaxAge(maxAge time.Duration) ConsensusOpt {
 	}
 }
 
+// WithCLSafeLeapWarnThreshold sets the number of blocks by which a backend's safe_l2
+// may exceed the peer minimum before a warning is logged and a metric recorded.
+// This detects the op-node premature finalization bug (https://github.com/ethereum-optimism/optimism/issues/17631)
+// where a node finishing EL sync incorrectly reports safe == finalized == unsafe == EL sync tip.
+// The minimum-safe consensus logic already protects the served value; this adds observability.
+func WithCLSafeLeapWarnThreshold(threshold uint64) ConsensusOpt {
+	return func(cp *ConsensusPoller) {
+		cp.clSafeLeapWarnThreshold = threshold
+	}
+}
+
 // updateCLBackend fetches the op-node sync status for a single backend and
 // determines whether it is considered in sync. It encapsulates the CL branch of
 // UpdateBackend, keeping all op-node logic out of the shared poller file.
@@ -153,7 +164,6 @@ func (cp *ConsensusPoller) safeBlockFetcher(ctx context.Context, be *Backend, bs
 	}
 	return cp.fetchCLBlock(ctx, be, block.String())
 }
-
 
 // fetchCLBlock calls optimism_outputAtBlock and returns the block number and hash
 // from the blockRef in the response.

--- a/proxyd/consensus_poller_cl.go
+++ b/proxyd/consensus_poller_cl.go
@@ -157,9 +157,22 @@ func (cp *ConsensusPoller) validateCLBackendUpdate(be *Backend, safeBlockNumber,
 	return true
 }
 
-// computeCLGroupMinimums extracts CL-specific per-candidate minimums that are not
-// tracked in the shared candidate loop: the finalized block hash (needed for CL
-// hash-verified consensus) and the lowest local_safe_l2 block and hash.
+// computeCLGroupMinimums resolves two group-level values that the shared candidate
+// loop does not track because they have no EL equivalent.
+//
+// Finalized block hash: the shared loop identifies the lowest finalized block number
+// across all candidates, but not the corresponding hash. The hash is required by
+// updateCLGroupConsensus to anchor the hash-verified walk-back that finds a common
+// finalized block all candidates agree on. This function finds the hash by scanning
+// candidates for the first one whose finalized block number matches the group minimum.
+//
+// Lowest local_safe_l2: in op-node, local_safe_l2 is the highest L2 block whose
+// sequencer batches have been seen on L1 by this node specifically, before any
+// cross-chain safety checks (interop). safe_l2 (cross-safe) can only advance after
+// local_safe_l2 does, so taking the minimum local_safe_l2 across backends gives a
+// conservative view of what L2 data has actually landed on L1. This is surfaced as
+// a separate metric from safe_l2 to make derivation progress visible independently
+// of interop message validation.
 func (cp *ConsensusPoller) computeCLGroupMinimums(
 	candidates map[*Backend]*backendState,
 	lowestFinalizedBlock hexutil.Uint64,
@@ -189,6 +202,7 @@ func (cp *ConsensusPoller) warnCLSafeLeap(candidates map[*Backend]*backendState,
 		leap := uint64(bs.safeBlockNumber) - uint64(lowestSafeBlock)
 		RecordCLBackendSafeLeap(be, leap)
 		if leap > cp.clSafeLeapWarnThreshold {
+			RecordCLBackendSafeLeapWarning(be)
 			log.Warn("CL backend safe head far ahead of peer minimum — possible premature finalization",
 				"backend", be.Name,
 				"safe", bs.safeBlockNumber,

--- a/proxyd/consensus_poller_cl.go
+++ b/proxyd/consensus_poller_cl.go
@@ -1,0 +1,323 @@
+package proxyd
+
+// CL (op-node / consensus layer) consensus support.
+// All op-node-specific types, RPC methods, fetchers, and option functions live here.
+// consensus_poller.go contains only shared infrastructure and the EL-specific paths.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// CLSyncStatus holds the parsed result of an optimism_syncStatus RPC call.
+type CLSyncStatus struct {
+	LatestBlockNumber    hexutil.Uint64
+	LatestBlockHash      string
+	SafeBlockNumber      hexutil.Uint64
+	SafeBlockHash        string
+	LocalSafeBlockNumber hexutil.Uint64
+	LocalSafeBlockHash   string
+	FinalizedBlockNumber hexutil.Uint64
+	FinalizedBlockHash   string
+	CurrentL1Number      uint64
+	HeadL1Number         uint64
+	HeadL1Timestamp      uint64 // Unix seconds; used to detect L1 connection staleness
+}
+
+// WithCLConsensusMode enables CL (op-node) consensus mode.
+func WithCLConsensusMode() ConsensusOpt {
+	return func(cp *ConsensusPoller) {
+		cp.consensusLayer = true
+	}
+}
+
+// WithCLSyncThreshold sets the maximum tolerated L1 block lag before a CL backend
+// is considered out of sync.
+func WithCLSyncThreshold(threshold uint64) ConsensusOpt {
+	return func(cp *ConsensusPoller) {
+		cp.clSyncThreshold = threshold
+	}
+}
+
+// WithCLHeadL1MaxAge sets the maximum age of the L1 head timestamp before a CL
+// backend is considered stale.
+func WithCLHeadL1MaxAge(maxAge time.Duration) ConsensusOpt {
+	return func(cp *ConsensusPoller) {
+		cp.clHeadL1MaxAge = maxAge
+	}
+}
+
+// updateCLBackend fetches the op-node sync status for a single backend and
+// determines whether it is considered in sync. It encapsulates the CL branch of
+// UpdateBackend, keeping all op-node logic out of the shared poller file.
+//
+// On success it returns the parsed sync status, the inSync determination, and nil.
+// On error it logs and returns a non-nil error; the caller should skip state updates.
+func (cp *ConsensusPoller) updateCLBackend(ctx context.Context, be *Backend) (*CLSyncStatus, bool, error) {
+	syncStatus, err := cp.fetchCLSyncStatus(ctx, be)
+	if err != nil {
+		log.Warn("error updating CL backend - backend will not be updated", "name", be.Name, "err", err)
+		return nil, false, err
+	}
+
+	lag := uint64(0)
+	if syncStatus.HeadL1Number > syncStatus.CurrentL1Number {
+		lag = syncStatus.HeadL1Number - syncStatus.CurrentL1Number
+	}
+	l1BlockLagOK := lag <= cp.clSyncThreshold
+	if !l1BlockLagOK {
+		log.Warn("CL backend L1 block lag too high",
+			"backend", be.Name,
+			"lag", lag,
+			"threshold", cp.clSyncThreshold,
+			"current_l1", syncStatus.CurrentL1Number,
+			"head_l1", syncStatus.HeadL1Number,
+		)
+	}
+	RecordCLBackendL1Lag(be, lag)
+
+	l1TimestampOK := true
+	if syncStatus.HeadL1Timestamp == 0 {
+		// timestamp=0 means the node hasn't synced to L1 yet (e.g. initializing after restart)
+		l1TimestampOK = false
+		log.Warn("CL backend L1 head timestamp is zero — node is initializing",
+			"backend", be.Name,
+		)
+	} else if cp.clHeadL1MaxAge > 0 {
+		l1Age := time.Since(time.Unix(int64(syncStatus.HeadL1Timestamp), 0))
+		l1TimestampOK = l1Age <= cp.clHeadL1MaxAge
+		if !l1TimestampOK {
+			log.Warn("CL backend L1 head is stale",
+				"backend", be.Name,
+				"head_l1_age", l1Age,
+				"max_age", cp.clHeadL1MaxAge,
+			)
+		}
+	}
+	RecordCLBackendL1Stale(be, !l1TimestampOK)
+
+	inSync := l1BlockLagOK && l1TimestampOK
+	RecordConsensusBackendInSync(be, inSync)
+
+	return syncStatus, inSync, nil
+}
+
+// updateCLGroupConsensus runs a hash-verified walk-back for safe_l2 in CL mode.
+// EL mode uses raw minimums; CL enforces L1-derived safety guarantees for safe.
+// local_safe_l2 and finalized_l2 use their minimum block+hash directly (no walk-back needed:
+// local_safe is L1-derived and finalized is immutable — hash divergence is a backend bug, not a fork).
+//
+// It returns the agreed (safeBlock, safeHash) after walk-back.
+func (cp *ConsensusPoller) updateCLGroupConsensus(
+	ctx context.Context,
+	candidates map[*Backend]*backendState,
+	lowestSafeBlock hexutil.Uint64, lowestSafeBlockHash string,
+) (hexutil.Uint64, string) {
+	if lowestSafeBlock > 0 {
+		var safeBroken bool
+		lowestSafeBlock, lowestSafeBlockHash, safeBroken = cp.findConsensusBlock(
+			ctx, candidates, cp.GetSafeBlockNumber(),
+			lowestSafeBlock, lowestSafeBlockHash, cp.safeBlockFetcher, "safe")
+		if safeBroken {
+			log.Warn("safe consensus broken",
+				"currentConsensusSafeBlock", cp.GetSafeBlockNumber(),
+				"proposedSafeBlock", lowestSafeBlock,
+				"proposedSafeBlockHash", lowestSafeBlockHash)
+			RecordCLGroupConsensusWalkback(cp.backendGroup, "safe")
+		}
+	}
+	return lowestSafeBlock, lowestSafeBlockHash
+}
+
+// clBlockFetcher is a blockHashFetcher for CL unsafe blocks.
+// Uses the cached latest hash when the backend is at exactly the proposed block
+// to avoid an extra RPC call; otherwise calls optimism_outputAtBlock.
+func (cp *ConsensusPoller) clBlockFetcher(ctx context.Context, be *Backend, bs *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+	if bs.latestBlockNumber == block {
+		return bs.latestBlockNumber, bs.latestBlockHash, nil
+	}
+	return cp.fetchCLBlock(ctx, be, block.String())
+}
+
+// safeBlockFetcher is a blockHashFetcher for CL safe blocks.
+// Uses the cached safe hash when the backend is at exactly the proposed block,
+// otherwise calls optimism_outputAtBlock. All candidates have safeBlockNumber >=
+// lowestSafeBlock >= proposedBlock at every walk-back step, so no abstain is needed.
+func (cp *ConsensusPoller) safeBlockFetcher(ctx context.Context, be *Backend, bs *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+	if bs.safeBlockNumber == block {
+		return bs.safeBlockNumber, bs.safeBlockHash, nil
+	}
+	return cp.fetchCLBlock(ctx, be, block.String())
+}
+
+
+// fetchCLBlock calls optimism_outputAtBlock and returns the block number and hash
+// from the blockRef in the response.
+func (cp *ConsensusPoller) fetchCLBlock(ctx context.Context, be *Backend, block string) (blockNumber hexutil.Uint64, blockHash string, err error) {
+	var rpcRes RPCRes
+	log.Trace("executing fetchCLBlock for backend",
+		"backend", be.Name,
+		"block", block,
+	)
+	err = be.ForwardRPC(ctx, &rpcRes, "67", "optimism_outputAtBlock", block)
+	if err != nil {
+		return 0, "", err
+	}
+
+	jsonMap, ok := rpcRes.Result.(map[string]interface{})
+	if !ok {
+		return 0, "", fmt.Errorf("unexpected response to optimism_outputAtBlock on backend %s", be.Name)
+	}
+	blockRef, ok := jsonMap["blockRef"].(map[string]interface{})
+	if !ok {
+		return 0, "", fmt.Errorf("missing blockRef in optimism_outputAtBlock response on backend %s", be.Name)
+	}
+	numberVal, nOk := blockRef["number"].(float64)
+	hashVal, hOk := blockRef["hash"].(string)
+	if !nOk || !hOk {
+		return 0, "", fmt.Errorf("missing or invalid number/hash in blockRef on backend %s", be.Name)
+	}
+	return hexutil.Uint64(uint64(numberVal)), hashVal, nil
+}
+
+// fetchCLSyncStatus calls optimism_syncStatus and parses the full sync status
+// for a CL (op-node) backend.
+func (cp *ConsensusPoller) fetchCLSyncStatus(ctx context.Context, be *Backend) (clSyncStatus *CLSyncStatus, err error) {
+	var rpcRes RPCRes
+	log.Trace("executing fetchCLSyncStatus for backend",
+		"backend", be.Name,
+	)
+	err = be.ForwardRPC(ctx, &rpcRes, "67", "optimism_syncStatus")
+	if err != nil {
+		return nil, err
+	}
+
+	syncStatusResult, ok := rpcRes.Result.(map[string]interface{})
+	log.Trace("syncStatus response for backend",
+		"backend", be.Name,
+		"syncStatus", syncStatusResult,
+	)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response to optimism_syncStatus on backend %s", be.Name)
+	}
+
+	latestBlockNumber, latestBlockHash, err := parseCLSyncStatusBlock(syncStatusResult, "unsafe_l2")
+	if err != nil {
+		return nil, err
+	}
+
+	safeBlockNumber, safeBlockHash, err := parseCLSyncStatusBlock(syncStatusResult, "safe_l2")
+	if err != nil {
+		return nil, err
+	}
+
+	localSafeBlockNumber, localSafeBlockHash, err := parseCLSyncStatusBlock(syncStatusResult, "local_safe_l2")
+	if err != nil {
+		return nil, err
+	}
+
+	finalizedBlockNumber, finalizedBlockHash, err := parseCLSyncStatusBlock(syncStatusResult, "finalized_l2")
+	if err != nil {
+		return nil, err
+	}
+
+	currentL1Number, _, err := parseCLSyncStatusBlock(syncStatusResult, "current_l1")
+	if err != nil {
+		return nil, err
+	}
+
+	headL1Number, _, err := parseCLSyncStatusBlock(syncStatusResult, "head_l1")
+	if err != nil {
+		return nil, err
+	}
+
+	headL1Timestamp, err := parseCLBlockTimestamp(syncStatusResult, "head_l1")
+	if err != nil {
+		return nil, err
+	}
+
+	return &CLSyncStatus{
+		LatestBlockNumber:    hexutil.Uint64(latestBlockNumber),
+		LatestBlockHash:      latestBlockHash,
+		SafeBlockNumber:      hexutil.Uint64(safeBlockNumber),
+		SafeBlockHash:        safeBlockHash,
+		LocalSafeBlockNumber: hexutil.Uint64(localSafeBlockNumber),
+		LocalSafeBlockHash:   localSafeBlockHash,
+		FinalizedBlockNumber: hexutil.Uint64(finalizedBlockNumber),
+		FinalizedBlockHash:   finalizedBlockHash,
+		CurrentL1Number:      currentL1Number,
+		HeadL1Number:         headL1Number,
+		HeadL1Timestamp:      headL1Timestamp,
+	}, nil
+}
+
+// fetchCLPeerCount calls opp2p_peerStats and returns the connected peer count.
+func (cp *ConsensusPoller) fetchCLPeerCount(ctx context.Context, be *Backend) (count uint64, err error) {
+	var rpcRes RPCRes
+	// https://docs.optimism.io/operators/node-operators/json-rpc#opp2p_peerstats
+	log.Trace("executing fetchCLPeerCount",
+		"backend", be.Name,
+	)
+	err = be.ForwardRPC(ctx, &rpcRes, "67", "opp2p_peerStats")
+	if err != nil {
+		return 0, err
+	}
+
+	jsonMap, ok := rpcRes.Result.(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("unexpected response to opp2p_peerStats on backend %s", be.Name)
+	}
+	connectedFloat, ok := jsonMap["connected"].(float64)
+	if !ok {
+		return 0, fmt.Errorf("missing or invalid 'connected' field in opp2p_peerStats response from backend %s", be.Name)
+	}
+	count = uint64(connectedFloat)
+
+	log.Trace("fetchCLPeerCount result",
+		"backend", be.Name,
+		"result", jsonMap,
+		"count", count,
+	)
+
+	return count, nil
+}
+
+// parseCLBlockTimestamp extracts the Unix timestamp from a block ref field in an
+// optimism_syncStatus response.
+func parseCLBlockTimestamp(jsonMap map[string]interface{}, key string) (uint64, error) {
+	blockMap, ok := jsonMap[key].(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("unexpected type for %s in optimism_syncStatus", key)
+	}
+	tsVal, ok := blockMap["timestamp"].(float64)
+	if !ok {
+		return 0, fmt.Errorf("missing or invalid timestamp in %s", key)
+	}
+	return uint64(tsVal), nil
+}
+
+// parseCLSyncStatusBlock parses the block number and hash from a named field
+// (e.g. "unsafe_l2", "safe_l2") within an optimism_syncStatus response map.
+func parseCLSyncStatusBlock(jsonMap map[string]interface{}, safety string) (blockNumber uint64, blockHash string, err error) {
+	safetyMap, ok := jsonMap[safety].(map[string]interface{})
+	if !ok {
+		return 0, "", fmt.Errorf("unexpected unmarshall to optimism_syncStatus on consensus layer backend safety %s", safety)
+	}
+	log.Trace("safetyMap",
+		"safetyMap", safetyMap,
+	)
+
+	numberVal, nOk := safetyMap["number"].(float64)
+	hashVal, hOk := safetyMap["hash"].(string)
+	if !nOk || !hOk {
+		return 0, "", fmt.Errorf("missing or invalid 'number' or 'hash' field in %s block", safety)
+	}
+	blockNumber = uint64(numberVal)
+	blockHash = hashVal
+
+	return blockNumber, blockHash, nil
+}

--- a/proxyd/consensus_poller_cl.go
+++ b/proxyd/consensus_poller_cl.go
@@ -114,6 +114,27 @@ func (cp *ConsensusPoller) updateCLBackend(ctx context.Context, be *Backend) (*C
 	inSync := l1BlockLagOK && l1TimestampOK
 	RecordConsensusBackendInSync(be, inSync)
 
+	if syncStatus.LatestBlockNumber == 0 {
+		log.Warn("error backend responded a 200 with blockheight 0 for latest block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		return nil, false, fmt.Errorf("latest block is 0 for backend %s", be.Name)
+	}
+	if syncStatus.SafeBlockNumber == 0 {
+		log.Warn("error backend responded a 200 with blockheight 0 for safe block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		return nil, false, fmt.Errorf("safe block is 0 for backend %s", be.Name)
+	}
+	if syncStatus.FinalizedBlockNumber == 0 {
+		log.Warn("error backend responded a 200 with blockheight 0 for finalized block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		return nil, false, fmt.Errorf("finalized block is 0 for backend %s", be.Name)
+	}
+	if syncStatus.LocalSafeBlockNumber == 0 {
+		log.Warn("error backend responded with blockheight 0 for local_safe block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		return nil, false, fmt.Errorf("local_safe block is 0 for backend %s", be.Name)
+	}
+
 	return syncStatus, inSync, nil
 }
 
@@ -121,11 +142,6 @@ func (cp *ConsensusPoller) updateCLBackend(ctx context.Context, be *Backend) (*C
 // state is written. Returns false if the backend should be excluded and the caller should
 // return early.
 func (cp *ConsensusPoller) validateCLBackendUpdate(be *Backend, safeBlockNumber, localSafeBlockNumber hexutil.Uint64) bool {
-	if localSafeBlockNumber == 0 {
-		log.Warn("error backend responded with blockheight 0 for local_safe block", "name", be.Name)
-		be.intermittentErrorsSlidingWindow.Incr()
-		return false
-	}
 	// On interop chains, cross-safe (safe_l2) always lags behind or equals local-safe.
 	// A backend reporting safe > local_safe is in an invalid state and must be excluded.
 	if safeBlockNumber > 0 && safeBlockNumber > localSafeBlockNumber {

--- a/proxyd/consensus_poller_cl.go
+++ b/proxyd/consensus_poller_cl.go
@@ -117,6 +117,73 @@ func (cp *ConsensusPoller) updateCLBackend(ctx context.Context, be *Backend) (*C
 	return syncStatus, inSync, nil
 }
 
+// validateCLBackendUpdate performs CL-specific post-fetch validation before a backend's
+// state is written. Returns false if the backend should be excluded and the caller should
+// return early.
+func (cp *ConsensusPoller) validateCLBackendUpdate(be *Backend, safeBlockNumber, localSafeBlockNumber hexutil.Uint64) bool {
+	if localSafeBlockNumber == 0 {
+		log.Warn("error backend responded with blockheight 0 for local_safe block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		return false
+	}
+	// On interop chains, cross-safe (safe_l2) always lags behind or equals local-safe.
+	// A backend reporting safe > local_safe is in an invalid state and must be excluded.
+	if safeBlockNumber > 0 && safeBlockNumber > localSafeBlockNumber {
+		log.Warn("banning CL backend: safe > local_safe (invalid interop state)",
+			"backend", be.Name,
+			"safe", safeBlockNumber,
+			"local_safe", localSafeBlockNumber,
+		)
+		RecordCLBan(be, "interop_safe_gt_local_safe")
+		cp.Ban(be)
+		return false
+	}
+	return true
+}
+
+// computeCLGroupMinimums extracts CL-specific per-candidate minimums that are not
+// tracked in the shared candidate loop: the finalized block hash (needed for CL
+// hash-verified consensus) and the lowest local_safe_l2 block and hash.
+func (cp *ConsensusPoller) computeCLGroupMinimums(
+	candidates map[*Backend]*backendState,
+	lowestFinalizedBlock hexutil.Uint64,
+) (finalizedBlockHash string, lowestLocalSafeBlock hexutil.Uint64, lowestLocalSafeBlockHash string) {
+	for _, bs := range candidates {
+		if bs.finalizedBlockNumber == lowestFinalizedBlock && finalizedBlockHash == "" {
+			finalizedBlockHash = bs.finalizedBlockHash
+		}
+		if lowestLocalSafeBlock == 0 || bs.localSafeBlockNumber < lowestLocalSafeBlock {
+			lowestLocalSafeBlock = bs.localSafeBlockNumber
+			lowestLocalSafeBlockHash = bs.localSafeBlockHash
+		}
+	}
+	return
+}
+
+// warnCLSafeLeap records a metric and logs a warning for any candidate whose safe_l2
+// is more than clSafeLeapWarnThreshold blocks ahead of the peer minimum.
+// This detects the op-node premature finalization bug (https://github.com/ethereum-optimism/optimism/issues/17631)
+// where a node finishing EL sync incorrectly reports safe == finalized == unsafe == EL sync tip.
+// The minimum-safe consensus logic already protects the served value; this is observability only.
+func (cp *ConsensusPoller) warnCLSafeLeap(candidates map[*Backend]*backendState, lowestSafeBlock hexutil.Uint64) {
+	if cp.clSafeLeapWarnThreshold == 0 || lowestSafeBlock == 0 {
+		return
+	}
+	for be, bs := range candidates {
+		leap := uint64(bs.safeBlockNumber) - uint64(lowestSafeBlock)
+		RecordCLBackendSafeLeap(be, leap)
+		if leap > cp.clSafeLeapWarnThreshold {
+			log.Warn("CL backend safe head far ahead of peer minimum — possible premature finalization",
+				"backend", be.Name,
+				"safe", bs.safeBlockNumber,
+				"peer_min_safe", lowestSafeBlock,
+				"leap", leap,
+				"threshold", cp.clSafeLeapWarnThreshold,
+			)
+		}
+	}
+}
+
 // updateCLGroupConsensus runs a hash-verified walk-back for safe_l2 in CL mode.
 // EL mode uses raw minimums; CL enforces L1-derived safety guarantees for safe.
 // local_safe_l2 and finalized_l2 use their minimum block+hash directly (no walk-back needed:

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -30,6 +30,8 @@ type ConsensusTrackerState struct {
 	Finalized     hexutil.Uint64 `json:"finalized"`
 	LatestHash    string         `json:"latest_hash"`
 	SafeHash      string         `json:"safe_hash"`
+	LocalSafe     hexutil.Uint64 `json:"local_safe"`
+	LocalSafeHash string         `json:"local_safe_hash"`
 	FinalizedHash string         `json:"finalized_hash"`
 }
 
@@ -42,6 +44,8 @@ func (ct *InMemoryConsensusTracker) update(o *ConsensusTrackerState) {
 	ct.state.Finalized = o.Finalized
 	ct.state.LatestHash = o.LatestHash
 	ct.state.SafeHash = o.SafeHash
+	ct.state.LocalSafe = o.LocalSafe
+	ct.state.LocalSafeHash = o.LocalSafeHash
 	ct.state.FinalizedHash = o.FinalizedHash
 }
 
@@ -66,9 +70,13 @@ func (ct *InMemoryConsensusTracker) Valid() bool {
 func (ct *InMemoryConsensusTracker) Behind(other *InMemoryConsensusTracker) bool {
 	local := ct.GetState()
 	remote := other.GetState()
+	// LocalSafe is only non-zero in CL mode; in EL mode both sides are always 0
+	// so this condition never fires for EL deployments.
+	localSafeBehind := local.LocalSafe > 0 && local.LocalSafe < remote.LocalSafe
 	return local.Latest < remote.Latest ||
 		local.Safe < remote.Safe ||
-		local.Finalized < remote.Finalized
+		local.Finalized < remote.Finalized ||
+		localSafeBehind
 }
 
 func (ct *InMemoryConsensusTracker) GetState() ConsensusTrackerState {

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -25,9 +25,12 @@ type ConsensusTracker interface {
 // ConsensusTrackerState holds the full consensus state in one snapshot.
 // Adding a new field only requires changing this struct and update().
 type ConsensusTrackerState struct {
-	Latest    hexutil.Uint64 `json:"latest"`
-	Safe      hexutil.Uint64 `json:"safe"`
-	Finalized hexutil.Uint64 `json:"finalized"`
+	Latest        hexutil.Uint64 `json:"latest"`
+	Safe          hexutil.Uint64 `json:"safe"`
+	Finalized     hexutil.Uint64 `json:"finalized"`
+	LatestHash    string         `json:"latest_hash"`
+	SafeHash      string         `json:"safe_hash"`
+	FinalizedHash string         `json:"finalized_hash"`
 }
 
 func (ct *InMemoryConsensusTracker) update(o *ConsensusTrackerState) {
@@ -37,6 +40,9 @@ func (ct *InMemoryConsensusTracker) update(o *ConsensusTrackerState) {
 	ct.state.Latest = o.Latest
 	ct.state.Safe = o.Safe
 	ct.state.Finalized = o.Finalized
+	ct.state.LatestHash = o.LatestHash
+	ct.state.SafeHash = o.SafeHash
+	ct.state.FinalizedHash = o.FinalizedHash
 }
 
 // InMemoryConsensusTracker store and retrieve in memory, async-safe

--- a/proxyd/integration_tests/block_height_zero_and_network_errors_test.go
+++ b/proxyd/integration_tests/block_height_zero_and_network_errors_test.go
@@ -328,13 +328,17 @@ func TestBlockHeightZero(t *testing.T) {
 		require.Equal(t, nodes["node2"].intermittentNetErrorWindow.Count(), uint(0))
 	})
 
-	// TODO: this test assumes isInSync is called before getPeerCount in UpdateBackend,
-	// giving 2 network requests per poll cycle so the error-rate threshold (min 10 requests)
-	// fires after 5 iterations. The CL refactor moved isELInSync inside the else branch
-	// (after the getPeerCount early-return), halving the request count and delaying the ban.
-	// The test needs to be updated to account for the new call order.
+	// isELInSync is now called after getPeerCount (inside the else branch), so failing
+	// cycles contribute one fewer network request than before. With max_error_rate_threshold=0.25
+	// the ban fires after 3 failing cycles instead of 5.
+	//
+	// Per-cycle accounting (initial successful update: 6 network requests):
+	//   cycles 1-2: getPeerCount(500) [+1 network, +1 error] + findConsensusBlock [+1 network] = +2/+1
+	//   cycle  3:   getPeerCount(500) [+1 network, +1 error]; node1 IsHealthy=false → excluded from
+	//               findConsensusBlock candidates → no extra network request
+	// After cycle 3: network=11, errors=3, rate=3/11≈0.27 ≥ 0.25 → IsHealthy=false
+	// Cycle 4: UpdateBackend sees !IsHealthy → bans; getPeerCount is never called → count stays at 3.
 	t.Run("Test that if it breaches the network error threshold the node will be banned", func(t *testing.T) {
-		t.Skip("TODO: update test to account for new UpdateBackend call order (isELInSync now after getPeerCount)")
 		reset()
 		update()
 		overrideBlock("node1", "latest", "0x0", 500)
@@ -342,12 +346,12 @@ func TestBlockHeightZero(t *testing.T) {
 		overrideBlock("node1", "finalized", "0x0", 403)
 		overridePeerCount("node1", 0, 500)
 
-		for i := 1; i < 7; i++ {
+		for i := 1; i < 5; i++ {
 			require.False(t, bg.Consensus.IsBanned(nodes["node1"].backend), "Execpted node 1 to be not banned on iteration ", i)
 			require.False(t, bg.Consensus.IsBanned(nodes["node2"].backend), "Execpted node 2 to be not banned on iteration ", i)
 			update()
-			// On the 5th update (i=6), node 1 will be banned due to error rate and not increment window
-			if i < 6 {
+			// On the 4th update (i=4), node1 will be banned due to error rate and will not increment window
+			if i < 4 {
 				require.Equal(t, nodes["node1"].intermittentNetErrorWindow.Count(), uint(i))
 			}
 			require.Equal(t, nodes["node2"].intermittentNetErrorWindow.Count(), uint(0))

--- a/proxyd/integration_tests/block_height_zero_and_network_errors_test.go
+++ b/proxyd/integration_tests/block_height_zero_and_network_errors_test.go
@@ -328,7 +328,13 @@ func TestBlockHeightZero(t *testing.T) {
 		require.Equal(t, nodes["node2"].intermittentNetErrorWindow.Count(), uint(0))
 	})
 
+	// TODO: this test assumes isInSync is called before getPeerCount in UpdateBackend,
+	// giving 2 network requests per poll cycle so the error-rate threshold (min 10 requests)
+	// fires after 5 iterations. The CL refactor moved isELInSync inside the else branch
+	// (after the getPeerCount early-return), halving the request count and delaying the ban.
+	// The test needs to be updated to account for the new call order.
 	t.Run("Test that if it breaches the network error threshold the node will be banned", func(t *testing.T) {
+		t.Skip("TODO: update test to account for new UpdateBackend call order (isELInSync now after getPeerCount)")
 		reset()
 		update()
 		overrideBlock("node1", "latest", "0x0", 500)

--- a/proxyd/integration_tests/consensus_cl_test.go
+++ b/proxyd/integration_tests/consensus_cl_test.go
@@ -1,0 +1,794 @@
+package integration_tests
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/infra/proxyd"
+	ms "github.com/ethereum-optimism/infra/proxyd/tools/mockserver/handler"
+	"github.com/stretchr/testify/require"
+)
+
+func setupCL(t *testing.T) (map[string]nodeContext, *proxyd.BackendGroup, *ProxydHTTPClient, func()) {
+	node1 := NewMockBackend(nil)
+	node2 := NewMockBackend(nil)
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	responses := path.Join(dir, "testdata/consensus_cl_responses.yml")
+
+	h1 := ms.MockedHandler{
+		Overrides:    []*ms.MethodTemplate{},
+		Autoload:     true,
+		AutoloadFile: responses,
+	}
+	h2 := ms.MockedHandler{
+		Overrides:    []*ms.MethodTemplate{},
+		Autoload:     true,
+		AutoloadFile: responses,
+	}
+
+	require.NoError(t, os.Setenv("NODE1_URL", node1.URL()))
+	require.NoError(t, os.Setenv("NODE2_URL", node2.URL()))
+
+	node1.SetHandler(http.HandlerFunc(h1.Handler))
+	node2.SetHandler(http.HandlerFunc(h2.Handler))
+
+	config := ReadConfig("consensus_cl")
+	svr, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+
+	bg := svr.BackendGroups["node"]
+	require.NotNil(t, bg)
+	require.NotNil(t, bg.Consensus)
+	require.Equal(t, 2, len(bg.Backends))
+
+	nodes := map[string]nodeContext{
+		"node1": {
+			mockBackend: node1,
+			backend:     bg.Backends[0],
+			handler:     &h1,
+		},
+		"node2": {
+			mockBackend: node2,
+			backend:     bg.Backends[1],
+			handler:     &h2,
+		},
+	}
+
+	return nodes, bg, client, shutdown
+}
+
+// clSyncStatus builds a full optimism_syncStatus result map with the given unsafe_l2 values.
+// safe/finalized/L1 fields use the default test values.
+// local_safe_l2 defaults to the same values as safe_l2 (non-interop behaviour).
+func clSyncStatus(unsafeNum float64, unsafeHash string) map[string]interface{} {
+	return map[string]interface{}{
+		"unsafe_l2": map[string]interface{}{
+			"hash":   unsafeHash,
+			"number": unsafeNum,
+		},
+		"safe_l2": map[string]interface{}{
+			"hash":   "hash_0xe1",
+			"number": float64(225),
+		},
+		"local_safe_l2": map[string]interface{}{
+			"hash":   "hash_0xe1",
+			"number": float64(225),
+		},
+		"finalized_l2": map[string]interface{}{
+			"hash":   "hash_0xc1",
+			"number": float64(193),
+		},
+		"current_l1": map[string]interface{}{
+			"hash":      "hash_l1_100",
+			"number":    float64(100),
+			"timestamp": float64(9999999999),
+		},
+		"head_l1": map[string]interface{}{
+			"hash":      "hash_l1_100",
+			"number":    float64(100),
+			"timestamp": float64(9999999999),
+		},
+	}
+}
+
+// clSyncStatusOutOfSync builds a syncStatus where L1 lag exceeds the default threshold (10).
+func clSyncStatusOutOfSync(unsafeNum float64, unsafeHash string) map[string]interface{} {
+	s := clSyncStatus(unsafeNum, unsafeHash)
+	s["head_l1"] = map[string]interface{}{
+		"hash":      "hash_l1_111",
+		"number":    float64(111), // lag = 111 - 100 = 11 > 10 (default threshold)
+		"timestamp": float64(9999999999),
+	}
+	return s
+}
+
+// clSyncStatusStaleL1 builds a syncStatus where head_l1 timestamp is very old, triggering staleness check.
+func clSyncStatusStaleL1(unsafeNum float64, unsafeHash string) map[string]interface{} {
+	s := clSyncStatus(unsafeNum, unsafeHash)
+	s["head_l1"] = map[string]interface{}{
+		"hash":      "hash_l1_100",
+		"number":    float64(100),
+		"timestamp": float64(1000), // Unix timestamp far in the past → stale
+	}
+	return s
+}
+
+// clSyncStatusInitializing builds a syncStatus where all fields are zero,
+// as returned by an op-node that has just restarted and hasn't connected to L1 yet.
+func clSyncStatusInitializing() map[string]interface{} {
+	zero := map[string]interface{}{"hash": "0x0000000000000000000000000000000000000000000000000000000000000000", "number": float64(0), "timestamp": float64(0)}
+	return map[string]interface{}{
+		"unsafe_l2":     zero,
+		"safe_l2":       zero,
+		"local_safe_l2": zero,
+		"finalized_l2":  zero,
+		"current_l1":    zero,
+		"head_l1":       zero,
+	}
+}
+
+func TestConsensusCL(t *testing.T) {
+	nodes, bg, client, shutdown := setupCL(t)
+	defer nodes["node1"].mockBackend.Close()
+	defer nodes["node2"].mockBackend.Close()
+	defer shutdown()
+
+	ctx := context.Background()
+
+	update := func() {
+		for _, be := range bg.Backends {
+			bg.Consensus.UpdateBackend(ctx, be)
+		}
+		bg.Consensus.UpdateBackendGroupConsensus(ctx)
+	}
+
+	reset := func() {
+		for _, node := range nodes {
+			node.handler.ResetOverrides()
+			node.mockBackend.Reset()
+			node.backend.ClearSlidingWindows()
+		}
+		bg.Consensus.ClearListeners()
+		bg.Consensus.Reset()
+	}
+
+	override := func(node string, method string, block string, response string) {
+		if _, ok := nodes[node]; !ok {
+			t.Fatalf("node %s does not exist in the nodes map", node)
+		}
+		nodes[node].handler.AddOverride(&ms.MethodTemplate{
+			Method:   method,
+			Block:    block,
+			Response: response,
+		})
+	}
+
+	overrideSyncStatus := func(node string, unsafeNum float64, unsafeHash string) {
+		override(node, "optimism_syncStatus", "", buildResponse(clSyncStatus(unsafeNum, unsafeHash)))
+	}
+
+	overridePeerCount := func(node string, count int) {
+		override(node, "opp2p_peerStats", "", buildResponse(map[string]interface{}{
+			"connected": float64(count),
+		}))
+	}
+
+	overrideNotInSync := func(node string) {
+		nodes[node].handler.AddOverride(&ms.MethodTemplate{
+			Method:   "optimism_syncStatus",
+			Block:    "",
+			Response: buildResponse(clSyncStatusOutOfSync(257, "hash_0x101")),
+		})
+	}
+
+	overrideNotInSyncByTimestamp := func(node string) {
+		nodes[node].handler.AddOverride(&ms.MethodTemplate{
+			Method:   "optimism_syncStatus",
+			Block:    "",
+			Response: buildResponse(clSyncStatusStaleL1(257, "hash_0x101")),
+		})
+	}
+
+	// overrideSyncStatusFull overrides safe_l2, local_safe_l2, and finalized_l2 numbers in addition to unsafe_l2.
+	// local_safe_l2 defaults to the same values as safe_l2 (non-interop behaviour).
+	overrideSyncStatusFull := func(node string, unsafeNum float64, unsafeHash string, safeNum float64, finalizedNum float64) {
+		s := clSyncStatus(unsafeNum, unsafeHash)
+		s["safe_l2"] = map[string]interface{}{
+			"hash":   "hash_safe",
+			"number": safeNum,
+		}
+		s["local_safe_l2"] = map[string]interface{}{
+			"hash":   "hash_safe",
+			"number": safeNum,
+		}
+		s["finalized_l2"] = map[string]interface{}{
+			"hash":   "hash_finalized",
+			"number": finalizedNum,
+		}
+		override(node, "optimism_syncStatus", "", buildResponse(s))
+	}
+
+	// outputAtBlock builds the JSON response for an optimism_outputAtBlock call.
+	outputAtBlock := func(num float64, hash string) string {
+		return buildResponse(map[string]interface{}{
+			"blockRef": map[string]interface{}{"number": num, "hash": hash},
+		})
+	}
+
+	t.Run("initial consensus", func(t *testing.T) {
+		reset()
+
+		require.Equal(t, "0x0", bg.Consensus.GetLatestBlockNumber().String())
+
+		update()
+
+		// Default responses: unsafe_l2 at 0x101 (257), safe 0xe1, finalized 0xc1
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+		require.Equal(t, "0xe1", bg.Consensus.GetSafeBlockNumber().String())
+		require.Equal(t, "0xc1", bg.Consensus.GetFinalizedBlockNumber().String())
+		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
+	})
+
+	t.Run("prevent using a backend with low peer count", func(t *testing.T) {
+		reset()
+		overridePeerCount("node1", 0)
+		update()
+
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.NotContains(t, consensusGroup, nodes["node1"].backend)
+		require.False(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		require.Equal(t, 1, len(consensusGroup))
+	})
+
+	t.Run("prevent using a backend not in sync", func(t *testing.T) {
+		reset()
+		overrideNotInSync("node1")
+		update()
+
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.NotContains(t, consensusGroup, nodes["node1"].backend)
+		require.False(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		require.Equal(t, 1, len(consensusGroup))
+	})
+
+	t.Run("prevent using a backend with stale L1 head", func(t *testing.T) {
+		reset()
+		overrideNotInSyncByTimestamp("node1")
+		update()
+
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.NotContains(t, consensusGroup, nodes["node1"].backend)
+		require.False(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		require.Equal(t, 1, len(consensusGroup))
+	})
+
+	t.Run("prevent using a backend that is initializing (all-zero syncStatus)", func(t *testing.T) {
+		reset()
+		// Simulate a node that just restarted: all block numbers and timestamps are zero.
+		// The backend should be excluded from consensus (not banned) and the metric
+		// should reflect out-of-sync, not in-sync.
+		override("node1", "optimism_syncStatus", "", buildResponse(clSyncStatusInitializing()))
+		update()
+
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.NotContains(t, consensusGroup, nodes["node1"].backend)
+		require.False(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		require.Equal(t, 1, len(consensusGroup))
+		// node2 still healthy; consensus at default values
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+	})
+
+	t.Run("one node ahead - consensus resolves to lower", func(t *testing.T) {
+		reset()
+
+		// node2 one block ahead; lowest is node1 at 0x101
+		overrideSyncStatus("node2", 258, "hash_0x102")
+		update()
+
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
+	})
+
+	t.Run("lagging backend excluded", func(t *testing.T) {
+		reset()
+
+		// node2 is maxBlockLag+1 (9) blocks ahead of node1 at 0x101 → 0x10a (266)
+		overrideSyncStatus("node2", 266, "hash_0x10a")
+		update()
+
+		// node1 is lagging, excluded
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.NotContains(t, consensusGroup, nodes["node1"].backend)
+		require.False(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		require.Equal(t, 1, len(consensusGroup))
+
+		// consensus is at node2's block since node1 is excluded
+		require.Equal(t, "0x10a", bg.Consensus.GetLatestBlockNumber().String())
+	})
+
+	t.Run("lagging backend not excluded when within maxBlockLag", func(t *testing.T) {
+		reset()
+
+		// node2 is exactly maxBlockLag (8) blocks ahead: 0x101 + 8 = 0x109 (265)
+		overrideSyncStatus("node2", 265, "hash_0x109")
+		update()
+
+		// both should be in the consensus group since lag = 8 = maxBlockLag (not exceeded)
+		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
+		// consensus at node1's block (lowest)
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+	})
+
+	t.Run("broken consensus - hash divergence walks back to agreeable block", func(t *testing.T) {
+		reset()
+		listenerCalled := false
+		bg.Consensus.AddListener(func() {
+			listenerCalled = true
+		})
+
+		update()
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+
+		// advance both nodes to 0x102
+		overrideSyncStatus("node1", 258, "hash_0x102")
+		overrideSyncStatus("node2", 258, "hash_0x102")
+		// provide outputAtBlock for 0x101 so walk-back can verify agreement there
+		override("node1", "optimism_outputAtBlock", "0x102", buildResponse(map[string]interface{}{
+			"blockRef": map[string]interface{}{"number": float64(258), "hash": "hash_0x102"},
+		}))
+		override("node2", "optimism_outputAtBlock", "0x102", buildResponse(map[string]interface{}{
+			"blockRef": map[string]interface{}{"number": float64(258), "hash": "hash_0x102"},
+		}))
+		update()
+		require.Equal(t, "0x102", bg.Consensus.GetLatestBlockNumber().String())
+
+		// node2 diverges: same block number but different hash
+		overrideSyncStatus("node2", 258, "wrong_hash_0x102")
+		// walk-back will query optimism_outputAtBlock("0x101") on both nodes;
+		// the default YAML response returns "hash_0x101" — so both agree at 0x101
+		update()
+
+		// consensus walks back to 0x101 where hashes agree
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+		require.True(t, listenerCalled)
+
+		// both backends still in the consensus group (no ban for hash divergence)
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.Equal(t, 2, len(consensusGroup))
+	})
+
+	t.Run("rewrite response of optimism_syncStatus", func(t *testing.T) {
+		reset()
+		update()
+
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+		require.Equal(t, "hash_0x101", bg.Consensus.GetLatestBlockHash())
+		require.Equal(t, "0xe1", bg.Consensus.GetSafeBlockNumber().String())
+		require.Equal(t, "hash_0xe1", bg.Consensus.GetSafeBlockHash())
+
+		resRaw, statusCode, err := client.SendRPC("optimism_syncStatus", nil)
+		require.NoError(t, err)
+		require.Equal(t, 200, statusCode)
+
+		var jsonMap map[string]interface{}
+		err = json.Unmarshal(resRaw, &jsonMap)
+		require.NoError(t, err)
+
+		result, ok := jsonMap["result"].(map[string]interface{})
+		require.True(t, ok, "result should be an object")
+
+		unsafeL2, ok := result["unsafe_l2"].(map[string]interface{})
+		require.True(t, ok, "unsafe_l2 should be an object")
+		require.Equal(t, hexutil.Uint64(257).String(), hexutil.Uint64(uint64(unsafeL2["number"].(float64))).String())
+		require.Equal(t, "hash_0x101", unsafeL2["hash"])
+
+		safeL2, ok := result["safe_l2"].(map[string]interface{})
+		require.True(t, ok, "safe_l2 should be an object")
+		require.Equal(t, hexutil.Uint64(225).String(), hexutil.Uint64(uint64(safeL2["number"].(float64))).String())
+		require.Equal(t, "hash_0xe1", safeL2["hash"])
+
+		localSafeL2, ok := result["local_safe_l2"].(map[string]interface{})
+		require.True(t, ok, "local_safe_l2 should be an object")
+		require.Equal(t, hexutil.Uint64(225).String(), hexutil.Uint64(uint64(localSafeL2["number"].(float64))).String())
+		require.Equal(t, "hash_0xe1", localSafeL2["hash"])
+
+		finalizedL2, ok := result["finalized_l2"].(map[string]interface{})
+		require.True(t, ok, "finalized_l2 should be an object")
+		require.Equal(t, hexutil.Uint64(193).String(), hexutil.Uint64(uint64(finalizedL2["number"].(float64))).String())
+		require.Equal(t, "hash_0xc1", finalizedL2["hash"])
+
+		// L1 refs pass through from backend
+		require.NotNil(t, result["current_l1"])
+		require.NotNil(t, result["head_l1"])
+	})
+
+	t.Run("rewrite uses consensus values even when individual backends differ", func(t *testing.T) {
+		reset()
+
+		// node2 is one block ahead at 0x102
+		overrideSyncStatus("node2", 258, "hash_0x102")
+		update()
+
+		// consensus is at 0x101 (the lower of the two)
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+
+		// optimism_syncStatus response should reflect consensus (0x101), not individual backend value
+		resRaw, statusCode, err := client.SendRPC("optimism_syncStatus", nil)
+		require.NoError(t, err)
+		require.Equal(t, 200, statusCode)
+
+		var jsonMap map[string]interface{}
+		err = json.Unmarshal(resRaw, &jsonMap)
+		require.NoError(t, err)
+
+		result := jsonMap["result"].(map[string]interface{})
+		unsafeL2 := result["unsafe_l2"].(map[string]interface{})
+		require.Equal(t, hexutil.Uint64(257).String(), hexutil.Uint64(uint64(unsafeL2["number"].(float64))).String())
+		require.Equal(t, "hash_0x101", unsafeL2["hash"])
+
+		safeL2 := result["safe_l2"].(map[string]interface{})
+		require.Equal(t, hexutil.Uint64(225).String(), hexutil.Uint64(uint64(safeL2["number"].(float64))).String())
+		require.Equal(t, "hash_0xe1", safeL2["hash"])
+	})
+
+	t.Run("advance consensus", func(t *testing.T) {
+		reset()
+		update()
+
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+
+		// node2 advances one block; consensus holds at node1's lower block
+		overrideSyncStatus("node2", 258, "hash_0x102")
+		update()
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
+
+		// node1 also advances; both agree at 0x102
+		overrideSyncStatus("node1", 258, "hash_0x102")
+		update()
+		require.Equal(t, "0x102", bg.Consensus.GetLatestBlockNumber().String())
+		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
+	})
+
+	t.Run("should use lowest safe and finalized", func(t *testing.T) {
+		reset()
+		// node2 has higher safe/finalized; consensus uses node1's lower values
+		overrideSyncStatusFull("node2", 257, "hash_0x101", 241, 209) // safe=0xf1, finalized=0xd1
+		update()
+
+		require.Equal(t, "0xe1", bg.Consensus.GetSafeBlockNumber().String())
+		require.Equal(t, "0xc1", bg.Consensus.GetFinalizedBlockNumber().String())
+	})
+
+	t.Run("advance safe and finalized", func(t *testing.T) {
+		reset()
+		// both nodes advance safe and finalized to higher values
+		overrideSyncStatusFull("node1", 257, "hash_0x101", 241, 209) // safe=0xf1, finalized=0xd1
+		overrideSyncStatusFull("node2", 257, "hash_0x101", 241, 209)
+		update()
+
+		require.Equal(t, "0xf1", bg.Consensus.GetSafeBlockNumber().String())
+		require.Equal(t, "0xd1", bg.Consensus.GetFinalizedBlockNumber().String())
+	})
+
+	t.Run("ban backend if tags are messed - safe < finalized", func(t *testing.T) {
+		reset()
+		// node1 reports safe (0xa1=161) < finalized (0xc1=193) — ordering violation
+		overrideSyncStatusFull("node1", 257, "hash_0x101", 161, 193)
+		update()
+
+		require.True(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.NotContains(t, consensusGroup, nodes["node1"].backend)
+		require.Equal(t, 1, len(consensusGroup))
+	})
+
+	t.Run("ban backend if tags are messed - latest < safe", func(t *testing.T) {
+		reset()
+		// node1 reports latest (0xa1=161) < safe (0xe1=225) — ordering violation
+		overrideSyncStatusFull("node1", 161, "hash_0xa1", 225, 193)
+		update()
+
+		require.True(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.NotContains(t, consensusGroup, nodes["node1"].backend)
+		require.Equal(t, 1, len(consensusGroup))
+	})
+
+	t.Run("ban backend if safe dropped", func(t *testing.T) {
+		reset()
+		update() // establishes safe baseline at 0xe1 (225)
+
+		// safe drops from 0xe1 (225) to 0xb1 (177)
+		overrideSyncStatusFull("node1", 257, "hash_0x101", 177, 193)
+		update()
+
+		require.True(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.NotContains(t, consensusGroup, nodes["node1"].backend)
+		require.Equal(t, 1, len(consensusGroup))
+		// node2 still healthy; consensus safe unchanged
+		require.Equal(t, "0xe1", bg.Consensus.GetSafeBlockNumber().String())
+	})
+
+	t.Run("ban backend if finalized dropped", func(t *testing.T) {
+		reset()
+		update() // establishes finalized baseline at 0xc1 (193)
+
+		// finalized drops from 0xc1 (193) to 0xa1 (161)
+		overrideSyncStatusFull("node1", 257, "hash_0x101", 225, 161)
+		update()
+
+		require.True(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.NotContains(t, consensusGroup, nodes["node1"].backend)
+		require.Equal(t, 1, len(consensusGroup))
+		require.Equal(t, "0xc1", bg.Consensus.GetFinalizedBlockNumber().String())
+	})
+
+	t.Run("recover after ban", func(t *testing.T) {
+		reset()
+		update() // establish baseline
+
+		// cause node1 to be banned via finalized drop
+		overrideSyncStatusFull("node1", 257, "hash_0x101", 225, 161)
+		update()
+		require.True(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		require.Equal(t, 1, len(bg.Consensus.GetConsensusGroup()))
+
+		// unban and restore node1 to healthy state
+		bg.Consensus.Unban(nodes["node1"].backend)
+		nodes["node1"].handler.ResetOverrides()
+		update()
+
+		require.False(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
+	})
+
+	t.Run("stays banned if unhealthy state persists after unban", func(t *testing.T) {
+		reset()
+
+		// safe (161) < finalized (193): static ordering violation — always fails
+		// regardless of prior state, so re-banning works even after Ban() clears block state.
+		overrideSyncStatusFull("node1", 257, "hash_0x101", 161, 193)
+		update()
+		require.True(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+
+		// unban but leave the bad state in place
+		bg.Consensus.Unban(nodes["node1"].backend)
+		update()
+
+		// should be immediately re-banned
+		require.True(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		require.Equal(t, 1, len(bg.Consensus.GetConsensusGroup()))
+	})
+
+	t.Run("broken consensus with depth 2", func(t *testing.T) {
+		reset()
+		listenerCalled := false
+		bg.Consensus.AddListener(func() { listenerCalled = true })
+
+		update()
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+
+		// both advance to 0x103
+		overrideSyncStatus("node1", 259, "hash_0x103")
+		overrideSyncStatus("node2", 259, "hash_0x103")
+		override("node1", "optimism_outputAtBlock", "0x101", outputAtBlock(257, "hash_0x101"))
+		override("node2", "optimism_outputAtBlock", "0x101", outputAtBlock(257, "hash_0x101"))
+		update()
+		require.Equal(t, "0x103", bg.Consensus.GetLatestBlockNumber().String())
+
+		// node2 diverges at both 0x103 and 0x102; 0x101 still agrees (YAML default)
+		overrideSyncStatus("node2", 259, "wrong_hash_0x103")
+		override("node1", "optimism_outputAtBlock", "0x103", outputAtBlock(259, "hash_0x103"))
+		override("node2", "optimism_outputAtBlock", "0x103", outputAtBlock(259, "wrong_hash_0x103"))
+		override("node1", "optimism_outputAtBlock", "0x102", outputAtBlock(258, "hash_0x102"))
+		override("node2", "optimism_outputAtBlock", "0x102", outputAtBlock(258, "wrong_hash_0x102"))
+		update()
+
+		// walk-back finds agreement at 0x101
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+		require.True(t, listenerCalled)
+		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
+	})
+
+	t.Run("fork in advanced block - no prior consensus at new height", func(t *testing.T) {
+		reset()
+		listenerCalled := false
+		bg.Consensus.AddListener(func() { listenerCalled = true })
+		update()
+
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+
+		// both nodes jump to 0x103 but on different forks (never agreed at 0x102 or 0x103)
+		overrideSyncStatus("node1", 259, "node1_hash_0x103")
+		overrideSyncStatus("node2", 259, "node2_hash_0x103")
+		override("node1", "optimism_outputAtBlock", "0x103", outputAtBlock(259, "node1_hash_0x103"))
+		override("node2", "optimism_outputAtBlock", "0x103", outputAtBlock(259, "node2_hash_0x103"))
+		override("node1", "optimism_outputAtBlock", "0x102", outputAtBlock(258, "node1_hash_0x102"))
+		override("node2", "optimism_outputAtBlock", "0x102", outputAtBlock(258, "node2_hash_0x102"))
+		// 0x101 uses YAML default — both agree
+		update()
+
+		// resolves to last common ancestor (0x101)
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
+		// listener NOT fired: we never had prior consensus at 0x103 or 0x102
+		require.False(t, listenerCalled)
+	})
+
+	t.Run("safe hash divergence - walks back to agreed safe block", func(t *testing.T) {
+		reset()
+
+		// node2 reports a different hash at safe block 0xe1 (225)
+		s2 := clSyncStatus(257, "hash_0x101")
+		s2["safe_l2"] = map[string]interface{}{
+			"hash":   "wrong_safe_hash",
+			"number": float64(225),
+		}
+		override("node2", "optimism_syncStatus", "", buildResponse(s2))
+
+		// both agree at 0xe0 (224) one block back
+		override("node1", "optimism_outputAtBlock", "0xe0", outputAtBlock(224, "agreed_safe_hash"))
+		override("node2", "optimism_outputAtBlock", "0xe0", outputAtBlock(224, "agreed_safe_hash"))
+
+		update()
+
+		// safe walks back to last agreed block
+		require.Equal(t, "0xe0", bg.Consensus.GetSafeBlockNumber().String())
+		require.Equal(t, "agreed_safe_hash", bg.Consensus.GetSafeBlockHash())
+		// unsafe consensus unaffected
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
+	})
+
+	t.Run("finalized below consensus - lagging backend excluded from candidates", func(t *testing.T) {
+		reset()
+		update() // establishes finalized consensus at 0xc1 (193)
+
+		// node1 drops to finalized 0xc0 (192), below the established consensus of 0xc1 (193).
+		// FilterCandidates excludes node1 to prevent dragging consensus backward,
+		// which would cause unnecessary EL sync cycles on downstream light nodes.
+		s1 := clSyncStatus(257, "hash_0x101")
+		s1["finalized_l2"] = map[string]interface{}{"hash": "hash_0xc0", "number": float64(192)}
+		override("node1", "optimism_syncStatus", "", buildResponse(s1))
+
+		update()
+
+		// node1 excluded; consensus finalized holds at 0xc1 backed by node2 alone
+		require.Equal(t, "0xc1", bg.Consensus.GetFinalizedBlockNumber().String())
+		require.Equal(t, "hash_0xc1", bg.Consensus.GetFinalizedBlockHash())
+		require.Equal(t, 1, len(bg.Consensus.GetConsensusGroup()))
+		require.NotContains(t, bg.Consensus.GetConsensusGroup(), nodes["node1"].backend)
+		// unsafe and safe consensus unaffected
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+		require.Equal(t, "0xe1", bg.Consensus.GetSafeBlockNumber().String())
+	})
+
+	t.Run("local_safe below consensus - lagging backend excluded from candidates", func(t *testing.T) {
+		reset()
+		update() // establishes local_safe consensus at 0xe1 (225)
+
+		// node1 drops to local_safe 0xe0 (224), below the established consensus of 0xe1 (225).
+		// FilterCandidates excludes node1 to prevent local_safe from going backward,
+		// which would trigger unnecessary EL sync cycles in downstream light nodes via FollowSource.
+		s1 := clSyncStatus(257, "hash_0x101")
+		s1["local_safe_l2"] = map[string]interface{}{"hash": "hash_0xe0", "number": float64(224)}
+		override("node1", "optimism_syncStatus", "", buildResponse(s1))
+
+		update()
+
+		// node1 excluded; consensus local_safe holds at 0xe1 backed by node2 alone
+		require.Equal(t, "0xe1", bg.Consensus.GetLocalSafeBlockNumber().String())
+		require.Equal(t, "hash_0xe1", bg.Consensus.GetLocalSafeBlockHash())
+		require.Equal(t, 1, len(bg.Consensus.GetConsensusGroup()))
+		require.NotContains(t, bg.Consensus.GetConsensusGroup(), nodes["node1"].backend)
+		// unsafe and safe consensus unaffected
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+		require.Equal(t, "0xe1", bg.Consensus.GetSafeBlockNumber().String())
+	})
+
+	t.Run("no consensus when both backends are out of sync", func(t *testing.T) {
+		reset()
+		overrideNotInSync("node1")
+		overrideNotInSync("node2")
+		update()
+
+		require.Equal(t, 0, len(bg.Consensus.GetConsensusGroup()))
+	})
+
+	t.Run("backend recovers from out-of-sync and re-enters consensus", func(t *testing.T) {
+		reset()
+		overrideNotInSync("node1")
+		update()
+
+		require.Equal(t, 1, len(bg.Consensus.GetConsensusGroup()))
+		require.NotContains(t, bg.Consensus.GetConsensusGroup(), nodes["node1"].backend)
+
+		// node1 catches up: clear the override, L1 lag is gone
+		nodes["node1"].handler.ResetOverrides()
+		update()
+
+		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
+		require.Contains(t, bg.Consensus.GetConsensusGroup(), nodes["node1"].backend)
+	})
+
+	t.Run("ban backend if safe > local_safe (invalid interop state)", func(t *testing.T) {
+		reset()
+		// node1 reports safe (0xf1=241) > local_safe (0xe1=225) — invalid on interop chains
+		s := clSyncStatus(257, "hash_0x101")
+		s["safe_l2"] = map[string]interface{}{"hash": "hash_safe", "number": float64(241)}
+		s["local_safe_l2"] = map[string]interface{}{"hash": "hash_local_safe", "number": float64(225)}
+		override("node1", "optimism_syncStatus", "", buildResponse(s))
+		update()
+
+		require.True(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.NotContains(t, consensusGroup, nodes["node1"].backend)
+		require.Equal(t, 1, len(consensusGroup))
+	})
+
+	t.Run("rewrite local_safe_l2 uses consensus values", func(t *testing.T) {
+		reset()
+		// node2 has a higher local_safe; consensus picks the lower (node1's) value
+		s2 := clSyncStatus(257, "hash_0x101")
+		s2["local_safe_l2"] = map[string]interface{}{"hash": "hash_local_safe_high", "number": float64(240)}
+		override("node2", "optimism_syncStatus", "", buildResponse(s2))
+		update()
+
+		require.Equal(t, "0xe1", bg.Consensus.GetLocalSafeBlockNumber().String())
+		require.Equal(t, "hash_0xe1", bg.Consensus.GetLocalSafeBlockHash())
+
+		resRaw, statusCode, err := client.SendRPC("optimism_syncStatus", nil)
+		require.NoError(t, err)
+		require.Equal(t, 200, statusCode)
+
+		var jsonMap map[string]interface{}
+		err = json.Unmarshal(resRaw, &jsonMap)
+		require.NoError(t, err)
+
+		result := jsonMap["result"].(map[string]interface{})
+		localSafeL2, ok := result["local_safe_l2"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, hexutil.Uint64(225).String(), hexutil.Uint64(uint64(localSafeL2["number"].(float64))).String())
+		require.Equal(t, "hash_0xe1", localSafeL2["hash"])
+	})
+
+	t.Run("rewrite finalized_l2 uses consensus values", func(t *testing.T) {
+		reset()
+		// node2 has a higher finalized; consensus picks node1's lower value
+		s2 := clSyncStatus(257, "hash_0x101")
+		s2["finalized_l2"] = map[string]interface{}{"hash": "hash_finalized_high", "number": float64(210)}
+		override("node2", "optimism_syncStatus", "", buildResponse(s2))
+		update()
+
+		require.Equal(t, "0xc1", bg.Consensus.GetFinalizedBlockNumber().String())
+		require.Equal(t, "hash_0xc1", bg.Consensus.GetFinalizedBlockHash())
+
+		resRaw, statusCode, err := client.SendRPC("optimism_syncStatus", nil)
+		require.NoError(t, err)
+		require.Equal(t, 200, statusCode)
+
+		var jsonMap map[string]interface{}
+		err = json.Unmarshal(resRaw, &jsonMap)
+		require.NoError(t, err)
+
+		result := jsonMap["result"].(map[string]interface{})
+		finalizedL2, ok := result["finalized_l2"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, hexutil.Uint64(193).String(), hexutil.Uint64(uint64(finalizedL2["number"].(float64))).String())
+		require.Equal(t, "hash_0xc1", finalizedL2["hash"])
+	})
+}

--- a/proxyd/integration_tests/consensus_cl_test.go
+++ b/proxyd/integration_tests/consensus_cl_test.go
@@ -793,4 +793,72 @@ func TestConsensusCL(t *testing.T) {
 		require.Equal(t, hexutil.Uint64(193).String(), hexutil.Uint64(uint64(finalizedL2["number"].(float64))).String())
 		require.Equal(t, "hash_0xc1", finalizedL2["hash"])
 	})
+
+	t.Run("malformed optimism_syncStatus response triggers ErrBackendBadResponse", func(t *testing.T) {
+		reset()
+		update() // establish consensus so all hashes are non-empty
+
+		// Override both backends to return optimism_syncStatus where unsafe_l2 is a
+		// string instead of an object. RewriteConsensusBackendResponse should fail the
+		// type assertion and set ErrBackendBadResponse rather than silently returning
+		// partially-rewritten or raw data.
+		malformed := clSyncStatus(257, "hash_0x101")
+		malformed["unsafe_l2"] = "bad"
+		override("node1", "optimism_syncStatus", "", buildResponse(malformed))
+		override("node2", "optimism_syncStatus", "", buildResponse(malformed))
+
+		resRaw, _, err := client.SendRPC("optimism_syncStatus", nil)
+		require.NoError(t, err)
+
+		var jsonMap map[string]interface{}
+		err = json.Unmarshal(resRaw, &jsonMap)
+		require.NoError(t, err)
+
+		require.Nil(t, jsonMap["result"])
+		require.NotNil(t, jsonMap["error"])
+		errObj, ok := jsonMap["error"].(map[string]interface{})
+		require.True(t, ok, "error should be a JSON object")
+		require.Equal(t, float64(proxyd.ErrBackendBadResponse.Code), errObj["code"])
+	})
+
+	t.Run("batch optimism_syncStatus requests all rewritten to consensus values", func(t *testing.T) {
+		reset()
+		update() // consensus at 0x101 / hash_0x101
+
+		// Override backends to return unsafe_l2 at 0x102 — but do NOT call update() again.
+		// Consensus stays at 0x101. The rewrite should override 0x102 → 0x101 for
+		// every response in the batch, validating ApplyConsensusLayerRewrites iterates
+		// the full rpcReqs slice rather than stopping after the first entry.
+		overrideSyncStatus("node1", 258, "hash_0x102")
+		overrideSyncStatus("node2", 258, "hash_0x102")
+
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+		require.Equal(t, "hash_0x101", bg.Consensus.GetLatestBlockHash())
+
+		req1 := NewRPCReq("1", "optimism_syncStatus", nil)
+		req2 := NewRPCReq("2", "optimism_syncStatus", nil)
+		resRaw, statusCode, err := client.SendBatchRPC(req1, req2)
+		require.NoError(t, err)
+		require.Equal(t, 200, statusCode)
+
+		var batchRes []map[string]interface{}
+		err = json.Unmarshal(resRaw, &batchRes)
+		require.NoError(t, err)
+		require.Len(t, batchRes, 2)
+
+		for i, r := range batchRes {
+			result, ok := r["result"].(map[string]interface{})
+			require.True(t, ok, "response %d result should be a map", i)
+
+			unsafeL2, ok := result["unsafe_l2"].(map[string]interface{})
+			require.True(t, ok, "response %d unsafe_l2 should be a map", i)
+			// Backend returned 0x102; consensus rewrites it to 0x101.
+			require.Equal(t, hexutil.Uint64(257).String(), hexutil.Uint64(uint64(unsafeL2["number"].(float64))).String(), "response %d unsafe_l2 number", i)
+			require.Equal(t, "hash_0x101", unsafeL2["hash"], "response %d unsafe_l2 hash", i)
+
+			// L1 fields pass through from the backend (confirming these are real responses).
+			require.NotNil(t, result["current_l1"], "response %d current_l1", i)
+			require.NotNil(t, result["head_l1"], "response %d head_l1", i)
+		}
+	})
 }

--- a/proxyd/integration_tests/consensus_cl_test.go
+++ b/proxyd/integration_tests/consensus_cl_test.go
@@ -484,6 +484,7 @@ func TestConsensusCL(t *testing.T) {
 
 	t.Run("ban backend if tags are messed - safe < finalized", func(t *testing.T) {
 		reset()
+		update() // establish baseline at finalized=193
 		// node1 reports safe (0xa1=161) < finalized (0xc1=193) — ordering violation
 		overrideSyncStatusFull("node1", 257, "hash_0x101", 161, 193)
 		update()
@@ -496,6 +497,7 @@ func TestConsensusCL(t *testing.T) {
 
 	t.Run("ban backend if tags are messed - latest < safe", func(t *testing.T) {
 		reset()
+		update() // establish baseline at finalized=193
 		// node1 reports latest (0xa1=161) < safe (0xe1=225) — ordering violation
 		overrideSyncStatusFull("node1", 161, "hash_0xa1", 225, 193)
 		update()

--- a/proxyd/integration_tests/testdata/consensus_cl.toml
+++ b/proxyd/integration_tests/testdata/consensus_cl.toml
@@ -1,0 +1,28 @@
+[server]
+
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 1
+max_degraded_latency_threshold = "30ms"
+
+[backends]
+[backends.node1]
+rpc_url = "$NODE1_URL"
+
+[backends.node2]
+rpc_url = "$NODE2_URL"
+
+[backend_groups]
+[backend_groups.node]
+backends = ["node1", "node2"]
+routing_strategy = "consensus_aware_consensus_layer"
+consensus_handler = "noop" # allow more control over the consensus poller for tests
+consensus_ban_period = "1m"
+consensus_poller_interval = "5s"
+consensus_max_update_threshold = "2m"
+consensus_max_block_lag = 8
+consensus_min_peer_count = 4
+
+[rpc_method_mappings]
+optimism_syncStatus = "node"

--- a/proxyd/integration_tests/testdata/consensus_cl_responses.yml
+++ b/proxyd/integration_tests/testdata/consensus_cl_responses.yml
@@ -1,0 +1,56 @@
+- method: opp2p_peerStats
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "connected": 10
+      }
+    }
+- method: optimism_outputAtBlock
+  block: "0x101"
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "blockRef": {
+          "hash": "hash_0x101",
+          "number": 257
+        }
+      }
+    }
+- method: optimism_syncStatus
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "unsafe_l2": {
+          "hash": "hash_0x101",
+          "number": 257
+        },
+        "safe_l2": {
+          "hash": "hash_0xe1",
+          "number": 225
+        },
+        "local_safe_l2": {
+          "hash": "hash_0xe1",
+          "number": 225
+        },
+        "finalized_l2": {
+          "hash": "hash_0xc1",
+          "number": 193
+        },
+        "current_l1": {
+          "hash": "hash_l1_100",
+          "number": 100,
+          "timestamp": 9999999999
+        },
+        "head_l1": {
+          "hash": "hash_l1_100",
+          "number": 100,
+          "timestamp": 9999999999
+        }
+      }
+    }

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -78,6 +78,7 @@ var WithSkipOnNoSupervisorBackend = func(skipOnNoSupervisorBackend bool) commonS
 var WithChainID = func(chainID uint64) commonStrategyOpt {
 	return func(s *commonInteropStrategy) {
 		s.chainID = eth.ChainIDFromUInt64(chainID)
+		log.Info("interop strategy configured with chain ID", "chain_id", chainID)
 	}
 }
 
@@ -145,6 +146,14 @@ func (s *firstSupervisorStrategyImpl) ValidateAccessList(ctx context.Context, in
 	firstSupervisorUrl := s.urls[0]
 
 	ctx = context.WithValue(ctx, ContextKeyInteropValidationStrategy, FirstSupervisorStrategy) // nolint:staticcheck
+	log.Debug(
+		"performing interop access list check",
+		"strategy", FirstSupervisorStrategy,
+		"req_id", GetReqID(ctx),
+		"chain_id", s.chainID,
+		"supervisor_url", firstSupervisorUrl,
+		"access_list_size", len(accessListToValidate),
+	)
 	_, _, err = performCheckAccessListOp(ctx, accessListToValidate, firstSupervisorUrl, s.chainID)
 	return err
 }
@@ -169,6 +178,14 @@ func (s *multicallStrategyImpl) ValidateAccessList(ctx context.Context, interopA
 		return nil
 	}
 
+	log.Debug(
+		"performing interop access list check",
+		"strategy", MulticallStrategy,
+		"req_id", GetReqID(ctx),
+		"chain_id", s.chainID,
+		"supervisor_count", len(s.urls),
+		"access_list_size", len(accessListToValidate),
+	)
 	resultChan := make(chan error, len(s.urls))
 	// concurrently broadcast the checkAccessList operation to all the validating backends
 	var wg sync.WaitGroup
@@ -237,6 +254,15 @@ func (s *healthAwareLoadBalancingStrategyImpl) ValidateAccessList(ctx context.Co
 	// retry only in case of encountering unhealthy backends
 	// retries prevents an infinite loop in case all backends are unhealthy
 	maxRetries := s.backends.Size()
+
+	log.Debug(
+		"performing interop access list check",
+		"strategy", HealthAwareLoadBalancingStrategy,
+		"req_id", GetReqID(ctx),
+		"chain_id", s.chainID,
+		"supervisor_count", s.backends.Size(),
+		"access_list_size", len(accessListToValidate),
+	)
 
 	// NOTE: races can still happen between the backend selection and the validation, yet they're are harmless
 	// The harmeless races are just a trade-off against avoiding lock contention for the duration of the entire request
@@ -308,9 +334,18 @@ func (b *healthAwareBackend) Validate(ctx context.Context, accessList []common.H
 }
 
 func performCheckAccessListOp(ctx context.Context, accessList []common.Hash, url string, chainID eth.ChainID) (int, string, error) {
+	chainIDUint256 := uint256.Int(chainID)
+	log.Debug(
+		"calling CheckAccessList on supervisor",
+		"supervisor_url", url,
+		"req_id", GetReqID(ctx),
+		"chain_id", chainID,
+		"chain_id_uint256", chainIDUint256.Dec(),
+		"access_list_size", len(accessList),
+	)
 	validatingBackend := interop.NewInteropClient(url)
 	err := validatingBackend.CheckAccessList(ctx, accessList, interoptypes.CrossUnsafe, interoptypes.ExecutingDescriptor{
-		ChainID:   uint256.Int(chainID),
+		ChainID:   chainIDUint256,
 		Timestamp: getInteropExecutingDescriptorTimestamp(),
 	})
 
@@ -338,6 +373,9 @@ func performCheckAccessListOp(ctx context.Context, accessList []common.Hash, url
 		"strategy", strategy,
 		"req_id", GetReqID(ctx),
 		"method", "eth_sendRawTransaction",
+		"chain_id", chainID,
+		"http_code", httpCode,
+		"rpc_error_code", rpcErrorCode,
 		"error", err,
 	)
 

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -78,7 +78,6 @@ var WithSkipOnNoSupervisorBackend = func(skipOnNoSupervisorBackend bool) commonS
 var WithChainID = func(chainID uint64) commonStrategyOpt {
 	return func(s *commonInteropStrategy) {
 		s.chainID = eth.ChainIDFromUInt64(chainID)
-		log.Info("interop strategy configured with chain ID", "chain_id", chainID)
 	}
 }
 
@@ -146,14 +145,6 @@ func (s *firstSupervisorStrategyImpl) ValidateAccessList(ctx context.Context, in
 	firstSupervisorUrl := s.urls[0]
 
 	ctx = context.WithValue(ctx, ContextKeyInteropValidationStrategy, FirstSupervisorStrategy) // nolint:staticcheck
-	log.Debug(
-		"performing interop access list check",
-		"strategy", FirstSupervisorStrategy,
-		"req_id", GetReqID(ctx),
-		"chain_id", s.chainID,
-		"supervisor_url", firstSupervisorUrl,
-		"access_list_size", len(accessListToValidate),
-	)
 	_, _, err = performCheckAccessListOp(ctx, accessListToValidate, firstSupervisorUrl, s.chainID)
 	return err
 }
@@ -178,14 +169,6 @@ func (s *multicallStrategyImpl) ValidateAccessList(ctx context.Context, interopA
 		return nil
 	}
 
-	log.Debug(
-		"performing interop access list check",
-		"strategy", MulticallStrategy,
-		"req_id", GetReqID(ctx),
-		"chain_id", s.chainID,
-		"supervisor_count", len(s.urls),
-		"access_list_size", len(accessListToValidate),
-	)
 	resultChan := make(chan error, len(s.urls))
 	// concurrently broadcast the checkAccessList operation to all the validating backends
 	var wg sync.WaitGroup
@@ -254,15 +237,6 @@ func (s *healthAwareLoadBalancingStrategyImpl) ValidateAccessList(ctx context.Co
 	// retry only in case of encountering unhealthy backends
 	// retries prevents an infinite loop in case all backends are unhealthy
 	maxRetries := s.backends.Size()
-
-	log.Debug(
-		"performing interop access list check",
-		"strategy", HealthAwareLoadBalancingStrategy,
-		"req_id", GetReqID(ctx),
-		"chain_id", s.chainID,
-		"supervisor_count", s.backends.Size(),
-		"access_list_size", len(accessListToValidate),
-	)
 
 	// NOTE: races can still happen between the backend selection and the validation, yet they're are harmless
 	// The harmeless races are just a trade-off against avoiding lock contention for the duration of the entire request
@@ -334,18 +308,9 @@ func (b *healthAwareBackend) Validate(ctx context.Context, accessList []common.H
 }
 
 func performCheckAccessListOp(ctx context.Context, accessList []common.Hash, url string, chainID eth.ChainID) (int, string, error) {
-	chainIDUint256 := uint256.Int(chainID)
-	log.Debug(
-		"calling CheckAccessList on supervisor",
-		"supervisor_url", url,
-		"req_id", GetReqID(ctx),
-		"chain_id", chainID,
-		"chain_id_uint256", chainIDUint256.Dec(),
-		"access_list_size", len(accessList),
-	)
 	validatingBackend := interop.NewInteropClient(url)
 	err := validatingBackend.CheckAccessList(ctx, accessList, interoptypes.CrossUnsafe, interoptypes.ExecutingDescriptor{
-		ChainID:   chainIDUint256,
+		ChainID:   uint256.Int(chainID),
 		Timestamp: getInteropExecutingDescriptorTimestamp(),
 	})
 
@@ -373,9 +338,6 @@ func performCheckAccessListOp(ctx context.Context, accessList []common.Hash, url
 		"strategy", strategy,
 		"req_id", GetReqID(ctx),
 		"method", "eth_sendRawTransaction",
-		"chain_id", chainID,
-		"http_code", httpCode,
-		"rpc_error_code", rpcErrorCode,
 		"error", err,
 	)
 

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -461,6 +461,14 @@ var (
 		"backend_name",
 	})
 
+	consensusCLBackendSafeLeapTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "consensus_cl_backend_safe_leap_total",
+		Help:      "Number of polling cycles in which a CL backend's safe_l2 exceeded the safe-leap warning threshold, indicating possible premature finalization",
+	}, []string{
+		"backend_name",
+	})
+
 	consensusCLBanTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "consensus_cl_ban_total",
@@ -730,6 +738,10 @@ func RecordCLGroupLocalSafeBlock(group *BackendGroup, blockNumber hexutil.Uint64
 
 func RecordCLBackendSafeLeap(b *Backend, leap uint64) {
 	consensusCLBackendSafeLeap.WithLabelValues(b.Name).Set(float64(leap))
+}
+
+func RecordCLBackendSafeLeapWarning(b *Backend) {
+	consensusCLBackendSafeLeapTotal.WithLabelValues(b.Name).Inc()
 }
 
 func RecordCLBan(b *Backend, reason string) {

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -403,6 +403,65 @@ var (
 		"backend_name",
 	})
 
+	consensusCLBackendL1Lag = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "consensus_cl_backend_l1_lag",
+		Help:      "L1 block lag for CL (op-node) backends (head_l1 - current_l1)",
+	}, []string{
+		"backend_name",
+	})
+
+	consensusCLBackendL1LagHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: MetricsNamespace,
+		Name:      "consensus_cl_backend_l1_lag_histogram",
+		Help:      "Distribution of L1 block lag across CL (op-node) backends (head_l1 - current_l1)",
+		Buckets:   []float64{0, 1, 2, 5, 10, 20, 50, 100},
+	}, []string{
+		"backend_name",
+	})
+
+	consensusCLBackendL1Stale = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "consensus_cl_backend_l1_stale",
+		Help:      "Bool gauge for CL backends with a stale L1 head timestamp",
+	}, []string{
+		"backend_name",
+	})
+
+	consensusCLGroupWalkbackTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "consensus_cl_group_walkback_total",
+		Help:      "Count of CL consensus walk-back events where the proposed block had divergent hashes",
+	}, []string{
+		"backend_group_name",
+		"safety",
+	})
+
+	consensusCLBackendLocalSafeBlock = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "consensus_cl_backend_local_safe_block",
+		Help:      "Current local_safe_l2 block observed per CL (op-node) backend",
+	}, []string{
+		"backend_name",
+	})
+
+	consensusCLGroupLocalSafeBlock = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "consensus_cl_group_local_safe_block",
+		Help:      "Consensus local_safe_l2 block for the CL (op-node) backend group",
+	}, []string{
+		"backend_group_name",
+	})
+
+	consensusCLBanTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "consensus_cl_ban_total",
+		Help:      "Count of CL backend ban events, labelled by reason",
+	}, []string{
+		"backend_name",
+		"reason",
+	})
+
 	consensusUpdateDelayBackend = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
 		Name:      "consensus_backend_update_delay",
@@ -638,6 +697,31 @@ func RecordConsensusBackendPeerCount(b *Backend, peerCount uint64) {
 
 func RecordConsensusBackendInSync(b *Backend, inSync bool) {
 	consensusInSyncBackend.WithLabelValues(b.Name).Set(boolToFloat64(inSync))
+}
+
+func RecordCLBackendL1Lag(b *Backend, lag uint64) {
+	consensusCLBackendL1Lag.WithLabelValues(b.Name).Set(float64(lag))
+	consensusCLBackendL1LagHistogram.WithLabelValues(b.Name).Observe(float64(lag))
+}
+
+func RecordCLBackendL1Stale(b *Backend, stale bool) {
+	consensusCLBackendL1Stale.WithLabelValues(b.Name).Set(boolToFloat64(stale))
+}
+
+func RecordCLGroupConsensusWalkback(group *BackendGroup, safety string) {
+	consensusCLGroupWalkbackTotal.WithLabelValues(group.Name, safety).Inc()
+}
+
+func RecordCLBackendLocalSafeBlock(b *Backend, blockNumber hexutil.Uint64) {
+	consensusCLBackendLocalSafeBlock.WithLabelValues(b.Name).Set(float64(blockNumber))
+}
+
+func RecordCLGroupLocalSafeBlock(group *BackendGroup, blockNumber hexutil.Uint64) {
+	consensusCLGroupLocalSafeBlock.WithLabelValues(group.Name).Set(float64(blockNumber))
+}
+
+func RecordCLBan(b *Backend, reason string) {
+	consensusCLBanTotal.WithLabelValues(b.Name, reason).Inc()
 }
 
 func RecordConsensusBackendUpdateDelay(b *Backend, lastUpdate time.Time) {

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -453,6 +453,14 @@ var (
 		"backend_group_name",
 	})
 
+	consensusCLBackendSafeLeap = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "consensus_cl_backend_safe_leap",
+		Help:      "Blocks by which a CL backend's safe_l2 exceeds the peer minimum safe (non-zero indicates possible premature finalization)",
+	}, []string{
+		"backend_name",
+	})
+
 	consensusCLBanTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "consensus_cl_ban_total",
@@ -718,6 +726,10 @@ func RecordCLBackendLocalSafeBlock(b *Backend, blockNumber hexutil.Uint64) {
 
 func RecordCLGroupLocalSafeBlock(group *BackendGroup, blockNumber hexutil.Uint64) {
 	consensusCLGroupLocalSafeBlock.WithLabelValues(group.Name).Set(float64(blockNumber))
+}
+
+func RecordCLBackendSafeLeap(b *Backend, leap uint64) {
+	consensusCLBackendSafeLeap.WithLabelValues(b.Name).Set(float64(leap))
 }
 
 func RecordCLBan(b *Backend, reason string) {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -567,16 +567,22 @@ func Start(config *Config) (*Server, func(), error) {
 		bgcfg := config.BackendGroups[bgName]
 
 		if !bgcfg.ValidateRoutingStrategy(bgName) {
-			log.Crit("Invalid routing strategy provided. Valid options: fallback, multicall, consensus_aware, \"\"", "name", bgName)
+			log.Crit("Invalid routing strategy provided. Valid options: fallback, multicall, consensus_aware, consensus_aware_consensus_layer \"\"", "name", bgName)
 		}
 
 		log.Info("configuring routing strategy for backend_group", "name", bgName, "routing_strategy", bgcfg.RoutingStrategy)
 
-		if bgcfg.RoutingStrategy == ConsensusAwareRoutingStrategy {
-			log.Info("creating poller for consensus aware backend_group", "name", bgName)
+		if bgcfg.RoutingStrategy == ConsensusAwareRoutingStrategy || bgcfg.RoutingStrategy == ConsensusAwareCLRoutingStrategy {
+			log.Info("creating poller for consensus aware backend_group",
+				"name", bgName,
+				"routing_strategy", bgcfg.RoutingStrategy,
+			)
 
 			copts := make([]ConsensusOpt, 0)
 
+			if bgcfg.RoutingStrategy == ConsensusAwareCLRoutingStrategy {
+				copts = append(copts, WithCLConsensusMode())
+			}
 			if bgcfg.ConsensusAsyncHandler == "noop" {
 				copts = append(copts, WithAsyncHandler(NewNoopAsyncHandler()))
 			}
@@ -597,6 +603,12 @@ func Start(config *Config) (*Server, func(), error) {
 			}
 			if bgcfg.ConsensusPollerInterval > 0 {
 				copts = append(copts, WithPollerInterval(time.Duration(bgcfg.ConsensusPollerInterval)))
+			}
+			if bgcfg.ConsensusCLSyncThreshold > 0 {
+				copts = append(copts, WithCLSyncThreshold(bgcfg.ConsensusCLSyncThreshold))
+			}
+			if bgcfg.ConsensusCLHeadL1MaxAge > 0 {
+				copts = append(copts, WithCLHeadL1MaxAge(time.Duration(bgcfg.ConsensusCLHeadL1MaxAge)))
 			}
 
 			for _, be := range bgcfg.Backends {

--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -52,10 +52,13 @@ func RewriteTags(rctx RewriteContext, req *RPCReq, res *RPCRes) (RewriteResult, 
 	return RewriteRequest(rctx, req, res)
 }
 
-// RewriteResponse modifies the response object to comply with the rewrite context
-// before the backend is called (pre-processing). For synthetic responses that skip
-// the backend entirely (e.g. eth_blockNumber returning the consensus value).
+// RewriteResponse synthesizes responses from consensus state before the backend is called.
+// This is EL-only: CL mode always needs the real backend response (for passthrough fields
+// like current_l1 / head_l1) and rewrites specific fields post-fetch instead.
 func RewriteResponse(rctx RewriteContext, req *RPCReq, res *RPCRes) (RewriteResult, error) {
+	if rctx.consensusLayer {
+		return RewriteNone, nil
+	}
 	switch req.Method {
 	case "eth_blockNumber":
 		res.Result = rctx.latest
@@ -65,48 +68,54 @@ func RewriteResponse(rctx RewriteContext, req *RPCReq, res *RPCRes) (RewriteResu
 }
 
 // RewriteConsensusBackendResponse rewrites an actual backend response to enforce
-// consensus values. Unlike RewriteResponse, this is called post-backend with a
-// populated res.Result and only applies in CL (consensusLayer) mode.
-func RewriteConsensusBackendResponse(rctx RewriteContext, req *RPCReq, res *RPCRes) bool {
-	if !rctx.consensusLayer || rctx.latestHash == "" || res == nil || res.Error != nil || res.Result == nil {
-		return false
+// consensus values. It operates on the real backend response rather than synthesizing
+// one pre-flight because optimism_syncStatus contains passthrough fields (current_l1,
+// head_l1, timestamps) that the consensus poller does not track — those must come from
+// the backend. Only the four L2 block fields are overwritten with consensus values.
+//
+// All four consensus hashes must be present before any field is written. A partial
+// rewrite — unsafe_l2 consensus but raw safe_l2 — is more dangerous than a no-op:
+// the client would see finality fields from a divergent or lagging backend.
+// If any hash is missing the poller hasn't completed its first cycle; the response is
+// passed through unchanged.
+//
+// On a malformed backend response (field missing or wrong type), res.Error is set to
+// ErrBackendBadResponse and res.Result is cleared, so no raw data reaches the client.
+func RewriteConsensusBackendResponse(rctx RewriteContext, req *RPCReq, res *RPCRes) {
+	if !rctx.consensusLayer || rctx.latestHash == "" || rctx.safeHash == "" ||
+		rctx.localSafeHash == "" || rctx.finalizedHash == "" ||
+		res == nil || res.Error != nil || res.Result == nil {
+		return
 	}
-	switch req.Method {
-	case "optimism_syncStatus":
-		result, ok := res.Result.(map[string]interface{})
-		if !ok {
-			return false
-		}
-		unsafeL2, ok := result["unsafe_l2"].(map[string]interface{})
-		if !ok {
-			return false
-		}
-		unsafeL2["number"] = float64(rctx.latest)
-		unsafeL2["hash"] = rctx.latestHash
-		if rctx.safeHash != "" {
-			safeL2, ok := result["safe_l2"].(map[string]interface{})
-			if ok {
-				safeL2["number"] = float64(rctx.safe)
-				safeL2["hash"] = rctx.safeHash
-			}
-		}
-		if rctx.localSafeHash != "" {
-			localSafeL2, ok := result["local_safe_l2"].(map[string]interface{})
-			if ok {
-				localSafeL2["number"] = float64(rctx.localSafe)
-				localSafeL2["hash"] = rctx.localSafeHash
-			}
-		}
-		if rctx.finalizedHash != "" {
-			finalizedL2, ok := result["finalized_l2"].(map[string]interface{})
-			if ok {
-				finalizedL2["number"] = float64(rctx.finalized)
-				finalizedL2["hash"] = rctx.finalizedHash
-			}
-		}
-		return true
+	if req.Method != "optimism_syncStatus" {
+		return
 	}
-	return false
+	result, ok := res.Result.(map[string]interface{})
+	if !ok {
+		res.Result = nil
+		res.Error = ErrBackendBadResponse
+		return
+	}
+	fields := []struct {
+		key    string
+		number hexutil.Uint64
+		hash   string
+	}{
+		{"unsafe_l2", rctx.latest, rctx.latestHash},
+		{"safe_l2", rctx.safe, rctx.safeHash},
+		{"local_safe_l2", rctx.localSafe, rctx.localSafeHash},
+		{"finalized_l2", rctx.finalized, rctx.finalizedHash},
+	}
+	for _, f := range fields {
+		block, ok := result[f.key].(map[string]interface{})
+		if !ok {
+			res.Result = nil
+			res.Error = ErrBackendBadResponse
+			return
+		}
+		block["number"] = float64(f.number)
+		block["hash"] = f.hash
+	}
 }
 
 // RewriteRequest modifies the request object to comply with the rewrite context

--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -9,11 +9,17 @@ import (
 )
 
 type RewriteContext struct {
-	latest        hexutil.Uint64
-	safe          hexutil.Uint64
-	finalized     hexutil.Uint64
-	maxBlockRange uint64
-	consensusMode bool
+	latest         hexutil.Uint64
+	safe           hexutil.Uint64
+	finalized      hexutil.Uint64
+	maxBlockRange  uint64
+	consensusMode  bool
+	latestHash     string
+	safeHash       string
+	localSafe      hexutil.Uint64
+	localSafeHash  string
+	finalizedHash  string
+	consensusLayer bool
 }
 
 type RewriteResult uint8
@@ -47,8 +53,8 @@ func RewriteTags(rctx RewriteContext, req *RPCReq, res *RPCRes) (RewriteResult, 
 }
 
 // RewriteResponse modifies the response object to comply with the rewrite context
-// after the method has been called at the backend
-// RewriteResult informs the decision of the rewrite
+// before the backend is called (pre-processing). For synthetic responses that skip
+// the backend entirely (e.g. eth_blockNumber returning the consensus value).
 func RewriteResponse(rctx RewriteContext, req *RPCReq, res *RPCRes) (RewriteResult, error) {
 	switch req.Method {
 	case "eth_blockNumber":
@@ -56,6 +62,51 @@ func RewriteResponse(rctx RewriteContext, req *RPCReq, res *RPCRes) (RewriteResu
 		return RewriteOverrideResponse, nil
 	}
 	return RewriteNone, nil
+}
+
+// RewriteConsensusBackendResponse rewrites an actual backend response to enforce
+// consensus values. Unlike RewriteResponse, this is called post-backend with a
+// populated res.Result and only applies in CL (consensusLayer) mode.
+func RewriteConsensusBackendResponse(rctx RewriteContext, req *RPCReq, res *RPCRes) bool {
+	if !rctx.consensusLayer || rctx.latestHash == "" || res == nil || res.Error != nil || res.Result == nil {
+		return false
+	}
+	switch req.Method {
+	case "optimism_syncStatus":
+		result, ok := res.Result.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		unsafeL2, ok := result["unsafe_l2"].(map[string]interface{})
+		if !ok {
+			return false
+		}
+		unsafeL2["number"] = float64(rctx.latest)
+		unsafeL2["hash"] = rctx.latestHash
+		if rctx.safeHash != "" {
+			safeL2, ok := result["safe_l2"].(map[string]interface{})
+			if ok {
+				safeL2["number"] = float64(rctx.safe)
+				safeL2["hash"] = rctx.safeHash
+			}
+		}
+		if rctx.localSafeHash != "" {
+			localSafeL2, ok := result["local_safe_l2"].(map[string]interface{})
+			if ok {
+				localSafeL2["number"] = float64(rctx.localSafe)
+				localSafeL2["hash"] = rctx.localSafeHash
+			}
+		}
+		if rctx.finalizedHash != "" {
+			finalizedL2, ok := result["finalized_l2"].(map[string]interface{})
+			if ok {
+				finalizedL2["number"] = float64(rctx.finalized)
+				finalizedL2["hash"] = rctx.finalizedHash
+			}
+		}
+		return true
+	}
+	return false
 }
 
 // RewriteRequest modifies the request object to comply with the rewrite context

--- a/proxyd/rewriter_test.go
+++ b/proxyd/rewriter_test.go
@@ -692,7 +692,7 @@ func TestRewriteResponse(t *testing.T) {
 		check    func(*testing.T, args)
 	}{
 		{
-			name: "eth_blockNumber latest",
+			name: "eth_blockNumber in EL mode returns consensus latest",
 			args: args{
 				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true},
 				req:  &RPCReq{Method: "eth_blockNumber"},
@@ -701,6 +701,18 @@ func TestRewriteResponse(t *testing.T) {
 			expected: RewriteOverrideResponse,
 			check: func(t *testing.T, args args) {
 				require.Equal(t, args.res.Result, hexutil.Uint64(100))
+			},
+		},
+		{
+			name: "eth_blockNumber in CL mode is not synthesized — CL rewrites post-fetch instead",
+			args: args{
+				rctx: RewriteContext{latest: hexutil.Uint64(100), consensusMode: true, consensusLayer: true},
+				req:  &RPCReq{Method: "eth_blockNumber"},
+				res:  &RPCRes{Result: hexutil.Uint64(200)},
+			},
+			expected: RewriteNone,
+			check: func(t *testing.T, args args) {
+				require.Equal(t, args.res.Result, hexutil.Uint64(200)) // unchanged
 			},
 		},
 	}
@@ -803,6 +815,211 @@ func TestRewriteRequest_NonConsensusMode(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 			if tt.check != nil {
 				tt.check(t, tt.args)
+			}
+		})
+	}
+}
+
+// syncStatusResult builds a well-formed optimism_syncStatus result map for use in
+// RewriteConsensusBackendResponse tests.
+func syncStatusResult(unsafeNum, safeNum, localSafeNum, finalizedNum float64) map[string]interface{} {
+	block := func(n float64, h string) map[string]interface{} {
+		return map[string]interface{}{"number": n, "hash": h}
+	}
+	return map[string]interface{}{
+		"unsafe_l2":     block(unsafeNum, "0xold_unsafe"),
+		"safe_l2":       block(safeNum, "0xold_safe"),
+		"local_safe_l2": block(localSafeNum, "0xold_local_safe"),
+		"finalized_l2":  block(finalizedNum, "0xold_finalized"),
+	}
+}
+
+// fullCLRewriteContext returns a RewriteContext with all CL consensus fields populated.
+func fullCLRewriteContext() RewriteContext {
+	return RewriteContext{
+		consensusLayer: true,
+		latest:         hexutil.Uint64(100),
+		latestHash:     "0xnew_unsafe",
+		safe:           hexutil.Uint64(90),
+		safeHash:       "0xnew_safe",
+		localSafe:      hexutil.Uint64(95),
+		localSafeHash:  "0xnew_local_safe",
+		finalized:      hexutil.Uint64(80),
+		finalizedHash:  "0xnew_finalized",
+	}
+}
+
+func TestRewriteConsensusBackendResponse(t *testing.T) {
+	syncStatusReq := &RPCReq{Method: "optimism_syncStatus"}
+
+	tests := []struct {
+		name       string
+		rctx       RewriteContext
+		req        *RPCReq
+		res        *RPCRes
+		wantErrSet bool
+		check      func(*testing.T, *RPCRes)
+	}{
+		// --- no-op / early-exit conditions: result must be untouched ---
+		{
+			name: "non-CL mode: no rewrite",
+			rctx: RewriteContext{consensusLayer: false},
+			req:  syncStatusReq,
+			res:  &RPCRes{Result: syncStatusResult(99, 89, 94, 79)},
+		},
+		{
+			name: "empty latestHash: no rewrite",
+			rctx: RewriteContext{consensusLayer: true, latestHash: ""},
+			req:  syncStatusReq,
+			res:  &RPCRes{Result: syncStatusResult(99, 89, 94, 79)},
+		},
+		{
+			name: "nil res: no panic",
+			rctx: fullCLRewriteContext(),
+			req:  syncStatusReq,
+			res:  nil,
+		},
+		{
+			name: "res already has error: no rewrite",
+			rctx: fullCLRewriteContext(),
+			req:  syncStatusReq,
+			res:  &RPCRes{Error: ErrInternal},
+		},
+		{
+			name: "nil result: no rewrite",
+			rctx: fullCLRewriteContext(),
+			req:  syncStatusReq,
+			res:  &RPCRes{Result: nil},
+		},
+		{
+			name: "non-syncStatus method: no rewrite",
+			rctx: fullCLRewriteContext(),
+			req:  &RPCReq{Method: "eth_blockNumber"},
+			res:  &RPCRes{Result: syncStatusResult(99, 89, 94, 79)},
+		},
+		// poller hasn't completed first cycle — all four hashes required, partial is a no-op
+		{
+			name: "missing safeHash: no rewrite, result untouched",
+			rctx: RewriteContext{
+				consensusLayer: true,
+				latest:         hexutil.Uint64(100),
+				latestHash:     "0xnew_unsafe",
+				// safeHash, localSafeHash, finalizedHash empty
+			},
+			req: syncStatusReq,
+			res: &RPCRes{Result: syncStatusResult(99, 89, 94, 79)},
+			check: func(t *testing.T, res *RPCRes) {
+				result := res.Result.(map[string]interface{})
+				unsafe := result["unsafe_l2"].(map[string]interface{})
+				require.Equal(t, float64(99), unsafe["number"])
+				require.Equal(t, "0xold_unsafe", unsafe["hash"])
+			},
+		},
+
+		// --- successful rewrite: all four L2 fields overwritten ---
+		{
+			name:  "all fields rewritten",
+			rctx:  fullCLRewriteContext(),
+			req:   syncStatusReq,
+			res:   &RPCRes{Result: syncStatusResult(99, 89, 94, 79)},
+			check: func(t *testing.T, res *RPCRes) {
+				result := res.Result.(map[string]interface{})
+				unsafe := result["unsafe_l2"].(map[string]interface{})
+				require.Equal(t, float64(100), unsafe["number"])
+				require.Equal(t, "0xnew_unsafe", unsafe["hash"])
+
+				safe := result["safe_l2"].(map[string]interface{})
+				require.Equal(t, float64(90), safe["number"])
+				require.Equal(t, "0xnew_safe", safe["hash"])
+
+				localSafe := result["local_safe_l2"].(map[string]interface{})
+				require.Equal(t, float64(95), localSafe["number"])
+				require.Equal(t, "0xnew_local_safe", localSafe["hash"])
+
+				finalized := result["finalized_l2"].(map[string]interface{})
+				require.Equal(t, float64(80), finalized["number"])
+				require.Equal(t, "0xnew_finalized", finalized["hash"])
+			},
+		},
+
+		// --- malformed backend response: res.Error set, res.Result cleared ---
+		{
+			name:       "result is not a map: sets ErrBackendBadResponse and clears result",
+			rctx:       fullCLRewriteContext(),
+			req:        syncStatusReq,
+			res:        &RPCRes{Result: "not-a-map"},
+			wantErrSet: true,
+			check: func(t *testing.T, res *RPCRes) {
+				require.Equal(t, ErrBackendBadResponse, res.Error)
+			},
+		},
+		{
+			name: "unsafe_l2 missing: sets error",
+			rctx: fullCLRewriteContext(),
+			req:  syncStatusReq,
+			res: &RPCRes{Result: map[string]interface{}{
+				"safe_l2":       map[string]interface{}{"number": float64(89), "hash": "0xold_safe"},
+				"local_safe_l2": map[string]interface{}{"number": float64(94), "hash": "0xold_local_safe"},
+				"finalized_l2":  map[string]interface{}{"number": float64(79), "hash": "0xold_finalized"},
+			}},
+			wantErrSet: true,
+		},
+		{
+			name: "unsafe_l2 wrong type: sets error",
+			rctx: fullCLRewriteContext(),
+			req:  syncStatusReq,
+			res: &RPCRes{Result: map[string]interface{}{
+				"unsafe_l2":     "not-a-map",
+				"safe_l2":       map[string]interface{}{"number": float64(89), "hash": "0xold_safe"},
+				"local_safe_l2": map[string]interface{}{"number": float64(94), "hash": "0xold_local_safe"},
+				"finalized_l2":  map[string]interface{}{"number": float64(79), "hash": "0xold_finalized"},
+			}},
+			wantErrSet: true,
+		},
+		{
+			name: "safe_l2 missing: sets error",
+			rctx: fullCLRewriteContext(),
+			req:  syncStatusReq,
+			res: &RPCRes{Result: map[string]interface{}{
+				"unsafe_l2":     map[string]interface{}{"number": float64(99), "hash": "0xold_unsafe"},
+				"local_safe_l2": map[string]interface{}{"number": float64(94), "hash": "0xold_local_safe"},
+				"finalized_l2":  map[string]interface{}{"number": float64(79), "hash": "0xold_finalized"},
+			}},
+			wantErrSet: true,
+		},
+		{
+			name: "local_safe_l2 missing: sets error",
+			rctx: fullCLRewriteContext(),
+			req:  syncStatusReq,
+			res: &RPCRes{Result: map[string]interface{}{
+				"unsafe_l2":    map[string]interface{}{"number": float64(99), "hash": "0xold_unsafe"},
+				"safe_l2":      map[string]interface{}{"number": float64(89), "hash": "0xold_safe"},
+				"finalized_l2": map[string]interface{}{"number": float64(79), "hash": "0xold_finalized"},
+			}},
+			wantErrSet: true,
+		},
+		{
+			name: "finalized_l2 missing: sets error",
+			rctx: fullCLRewriteContext(),
+			req:  syncStatusReq,
+			res: &RPCRes{Result: map[string]interface{}{
+				"unsafe_l2":     map[string]interface{}{"number": float64(99), "hash": "0xold_unsafe"},
+				"safe_l2":       map[string]interface{}{"number": float64(89), "hash": "0xold_safe"},
+				"local_safe_l2": map[string]interface{}{"number": float64(94), "hash": "0xold_local_safe"},
+			}},
+			wantErrSet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RewriteConsensusBackendResponse(tt.rctx, tt.req, tt.res)
+			if tt.wantErrSet {
+				require.NotNil(t, tt.res.Error)
+				require.Nil(t, tt.res.Result)
+			}
+			if tt.check != nil {
+				tt.check(t, tt.res)
 			}
 		})
 	}

--- a/proxyd/tools/mockserver/handler/handler.go
+++ b/proxyd/tools/mockserver/handler/handler.go
@@ -76,9 +76,10 @@ func (mh *MockedHandler) Handler(w http.ResponseWriter, req *http.Request) {
 
 	var responses []string
 	for _, r := range requests {
-		method := r["method"]
+		method, _ := r["method"].(string)
 		block := ""
-		if method == "eth_getBlockByNumber" || method == "debug_getRawReceipts" || method == "optimism_outputAtBlock" {
+		switch method {
+		case "eth_getBlockByNumber", "debug_getRawReceipts", "optimism_outputAtBlock":
 			if params, ok := r["params"].([]interface{}); ok && len(params) > 0 {
 				if s, ok := params[0].(string); ok {
 					block = s

--- a/proxyd/tools/mockserver/handler/handler.go
+++ b/proxyd/tools/mockserver/handler/handler.go
@@ -78,8 +78,12 @@ func (mh *MockedHandler) Handler(w http.ResponseWriter, req *http.Request) {
 	for _, r := range requests {
 		method := r["method"]
 		block := ""
-		if method == "eth_getBlockByNumber" || method == "debug_getRawReceipts" {
-			block = (r["params"].([]interface{})[0]).(string)
+		if method == "eth_getBlockByNumber" || method == "debug_getRawReceipts" || method == "optimism_outputAtBlock" {
+			if params, ok := r["params"].([]interface{}); ok && len(params) > 0 {
+				if s, ok := params[0].(string); ok {
+					block = s
+				}
+			}
 		}
 
 		var selectedResponse string


### PR DESCRIPTION
This pull request introduces support for consensus-layer (CL) aware routing and consensus mechanisms in `proxyd`, alongside several improvements to Docker and Makefile workflows. The main changes add new configuration options and logic for CL routing, update consensus tracking to handle CL-specific fields, and enhance Docker image building for different environments.

**Consensus-layer (CL) routing and consensus enhancements:**

* Added support for a new routing strategy, `consensus_aware_consensus_layer`, with associated configuration options `consensus_cl_sync_threshold` and `consensus_cl_head_l1_max_age` in `BackendGroupConfig`. These options help determine CL backend health and participation in consensus. [[1]](diffhunk://#diff-c4f5668393f48eb742c6cb60d21ae205f38e10e24b45ac344398ffcad2cd8551R180) [[2]](diffhunk://#diff-c4f5668393f48eb742c6cb60d21ae205f38e10e24b45ac344398ffcad2cd8551R210-R223)
* Updated `ConsensusPoller` and related logic to track and compute CL-specific consensus fields, including `local_safe` and finalized block hashes, and to apply CL-specific backend validation and group consensus aggregation. [[1]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07R50-R56) [[2]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07R66-R67) [[3]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07R137-R156) [[4]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07R333-R335) [[5]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07L342-R377) [[6]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07L368-R420) [[7]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07R431-R442) [[8]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07R475-R477) [[9]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07R519-R527) [[10]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07R541-R543) [[11]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07L494-R575) [[12]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07R596-R598) [[13]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07R622-R624) [[14]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07L591-R696)
* Added post-processing of consensus responses in `BackendGroup.Forward` to allow CL-specific response rewriting after backend calls.
* Extended consensus response overwrite logic to include CL fields and detection.

**Build and deployment improvements:**

* Modified the `Dockerfile` to use build arguments for the builder and runtime images, improving flexibility for different environments. [[1]](diffhunk://#diff-a6e0ab6d48b0c21ecf33de5604acba1d9ef62a172d1bd9c16933da2d1a577cc2L1-R4) [[2]](diffhunk://#diff-a6e0ab6d48b0c21ecf33de5604acba1d9ef62a172d1bd9c16933da2d1a577cc2L15-R18)
* Enhanced the `Makefile` with new variables and targets (`docker`, `docker-dev`) to support building Docker images with either production or development images. [[1]](diffhunk://#diff-45b9970e328c8a396588e6fb3009f57c54133b6e195201c6db1b4f9488ba918fR6-R14) [[2]](diffhunk://#diff-45b9970e328c8a396588e6fb3009f57c54133b6e195201c6db1b4f9488ba918fR36-R53)

**Other improvements:**

* Improved error messages and peer count fetching logic to support CL mode. [[1]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07L723-R815) [[2]](diffhunk://#diff-e6ca976401daaa2104307da62149af125391c58fee6a55a73e703ee87972bf07R825-R827)
* Allowed the new routing strategy in config validation.

These changes collectively enable proxyd to route and aggregate consensus across both execution and consensus layer backends, while also making the build process more flexible for different deployment scenarios.<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A clear and concise description of the features you're adding in this pull request.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
