### PR TITLE
refactor(proxyd): collapse ConsensusTracker interface and introduce backendState

### DIFF
--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -626,7 +626,6 @@ func (cp *ConsensusPoller) Reset() {
 	for _, be := range cp.backendGroup.Backends {
 		cp.backendState[be] = &backendState{}
 	}
-	cp.tracker.SetState(ConsensusTrackerState{})
 }
 
 // fetchBlock is a convenient wrapper to make a request to get a block directly from the backend

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -92,18 +92,18 @@ func (cp *ConsensusPoller) GetConsensusGroup() []*Backend {
 }
 
 // GetLatestBlockNumber returns the `latest` agreed block number in a consensus
-func (ct *ConsensusPoller) GetLatestBlockNumber() hexutil.Uint64 {
-	return ct.tracker.GetState().Latest
+func (cp *ConsensusPoller) GetLatestBlockNumber() hexutil.Uint64 {
+	return cp.tracker.GetState().Latest
 }
 
 // GetSafeBlockNumber returns the `safe` agreed block number in a consensus
-func (ct *ConsensusPoller) GetSafeBlockNumber() hexutil.Uint64 {
-	return ct.tracker.GetState().Safe
+func (cp *ConsensusPoller) GetSafeBlockNumber() hexutil.Uint64 {
+	return cp.tracker.GetState().Safe
 }
 
 // GetFinalizedBlockNumber returns the `finalized` agreed block number in a consensus
-func (ct *ConsensusPoller) GetFinalizedBlockNumber() hexutil.Uint64 {
-	return ct.tracker.GetState().Finalized
+func (cp *ConsensusPoller) GetFinalizedBlockNumber() hexutil.Uint64 {
+	return cp.tracker.GetState().Finalized
 }
 
 func (cp *ConsensusPoller) Shutdown() {

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -93,17 +93,17 @@ func (cp *ConsensusPoller) GetConsensusGroup() []*Backend {
 
 // GetLatestBlockNumber returns the `latest` agreed block number in a consensus
 func (ct *ConsensusPoller) GetLatestBlockNumber() hexutil.Uint64 {
-	return ct.tracker.GetLatestBlockNumber()
+	return ct.tracker.GetState().Latest
 }
 
 // GetSafeBlockNumber returns the `safe` agreed block number in a consensus
 func (ct *ConsensusPoller) GetSafeBlockNumber() hexutil.Uint64 {
-	return ct.tracker.GetSafeBlockNumber()
+	return ct.tracker.GetState().Safe
 }
 
 // GetFinalizedBlockNumber returns the `finalized` agreed block number in a consensus
 func (ct *ConsensusPoller) GetFinalizedBlockNumber() hexutil.Uint64 {
-	return ct.tracker.GetFinalizedBlockNumber()
+	return ct.tracker.GetState().Finalized
 }
 
 func (cp *ConsensusPoller) Shutdown() {
@@ -378,9 +378,14 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 
 	RecordConsensusBackendUpdateDelay(be, bs.lastUpdate)
 
-	changed := cp.setBackendState(be, peerCount, inSync,
-		latestBlockNumber, latestBlockHash,
-		safeBlockNumber, finalizedBlockNumber)
+	changed := cp.setBackendState(be, backendStateUpdate{
+		peerCount:            peerCount,
+		inSync:               inSync,
+		latestBlockNumber:    latestBlockNumber,
+		latestBlockHash:      latestBlockHash,
+		safeBlockNumber:      safeBlockNumber,
+		finalizedBlockNumber: finalizedBlockNumber,
+	})
 
 	RecordBackendLatestBlock(be, latestBlockNumber)
 	RecordBackendSafeBlock(be, safeBlockNumber)
@@ -537,9 +542,11 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	}
 
 	// update tracker
-	cp.tracker.SetLatestBlockNumber(proposedBlock)
-	cp.tracker.SetSafeBlockNumber(lowestSafeBlock)
-	cp.tracker.SetFinalizedBlockNumber(lowestFinalizedBlock)
+	cp.tracker.SetState(ConsensusTrackerState{
+		Latest:    proposedBlock,
+		Safe:      lowestSafeBlock,
+		Finalized: lowestFinalizedBlock,
+	})
 
 	// update consensus group
 	group := make([]*Backend, 0, len(candidates))
@@ -619,6 +626,7 @@ func (cp *ConsensusPoller) Reset() {
 	for _, be := range cp.backendGroup.Backends {
 		cp.backendState[be] = &backendState{}
 	}
+	cp.tracker.SetState(ConsensusTrackerState{})
 }
 
 // fetchBlock is a convenient wrapper to make a request to get a block directly from the backend
@@ -709,19 +717,27 @@ func (cp *ConsensusPoller) GetLastUpdate(be *Backend) time.Time {
 	return bs.lastUpdate
 }
 
-func (cp *ConsensusPoller) setBackendState(be *Backend, peerCount uint64, inSync bool,
-	latestBlockNumber hexutil.Uint64, latestBlockHash string,
-	safeBlockNumber hexutil.Uint64,
-	finalizedBlockNumber hexutil.Uint64) bool {
+// backendStateUpdate is a value object passed to setBackendState to avoid
+// transposition bugs with same-typed arguments.
+type backendStateUpdate struct {
+	peerCount            uint64
+	inSync               bool
+	latestBlockNumber    hexutil.Uint64
+	latestBlockHash      string
+	safeBlockNumber      hexutil.Uint64
+	finalizedBlockNumber hexutil.Uint64
+}
+
+func (cp *ConsensusPoller) setBackendState(be *Backend, upd backendStateUpdate) bool {
 	bs := cp.backendState[be]
 	bs.backendStateMux.Lock()
-	changed := bs.latestBlockHash != latestBlockHash
-	bs.peerCount = peerCount
-	bs.inSync = inSync
-	bs.latestBlockNumber = latestBlockNumber
-	bs.latestBlockHash = latestBlockHash
-	bs.finalizedBlockNumber = finalizedBlockNumber
-	bs.safeBlockNumber = safeBlockNumber
+	changed := bs.latestBlockHash != upd.latestBlockHash
+	bs.peerCount = upd.peerCount
+	bs.inSync = upd.inSync
+	bs.latestBlockNumber = upd.latestBlockNumber
+	bs.latestBlockHash = upd.latestBlockHash
+	bs.finalizedBlockNumber = upd.finalizedBlockNumber
+	bs.safeBlockNumber = upd.safeBlockNumber
 	bs.lastUpdate = time.Now()
 	bs.backendStateMux.Unlock()
 	return changed

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -18,15 +18,12 @@ import (
 // ConsensusTracker abstracts how we store and retrieve the current consensus
 // allowing it to be stored locally in-memory or in a shared Redis cluster
 type ConsensusTracker interface {
-	GetLatestBlockNumber() hexutil.Uint64
-	SetLatestBlockNumber(blockNumber hexutil.Uint64)
-	GetSafeBlockNumber() hexutil.Uint64
-	SetSafeBlockNumber(blockNumber hexutil.Uint64)
-	GetFinalizedBlockNumber() hexutil.Uint64
-	SetFinalizedBlockNumber(blockNumber hexutil.Uint64)
+	GetState() ConsensusTrackerState
+	SetState(state ConsensusTrackerState)
 }
 
-// DTO to hold the current consensus state
+// ConsensusTrackerState holds the full consensus state in one snapshot.
+// Adding a new field only requires changing this struct and update().
 type ConsensusTrackerState struct {
 	Latest    hexutil.Uint64 `json:"latest"`
 	Safe      hexutil.Uint64 `json:"safe"`
@@ -56,57 +53,26 @@ func NewInMemoryConsensusTracker() ConsensusTracker {
 }
 
 func (ct *InMemoryConsensusTracker) Valid() bool {
-	return ct.GetLatestBlockNumber() > 0 &&
-		ct.GetSafeBlockNumber() > 0 &&
-		ct.GetFinalizedBlockNumber() > 0
+	s := ct.GetState()
+	return s.Latest > 0 && s.Safe > 0 && s.Finalized > 0
 }
 
 func (ct *InMemoryConsensusTracker) Behind(other *InMemoryConsensusTracker) bool {
-	return ct.GetLatestBlockNumber() < other.GetLatestBlockNumber() ||
-		ct.GetSafeBlockNumber() < other.GetSafeBlockNumber() ||
-		ct.GetFinalizedBlockNumber() < other.GetFinalizedBlockNumber()
+	local := ct.GetState()
+	remote := other.GetState()
+	return local.Latest < remote.Latest ||
+		local.Safe < remote.Safe ||
+		local.Finalized < remote.Finalized
 }
 
-func (ct *InMemoryConsensusTracker) GetLatestBlockNumber() hexutil.Uint64 {
-	defer ct.mutex.Unlock()
+func (ct *InMemoryConsensusTracker) GetState() ConsensusTrackerState {
 	ct.mutex.Lock()
-
-	return ct.state.Latest
+	defer ct.mutex.Unlock()
+	return *ct.state
 }
 
-func (ct *InMemoryConsensusTracker) SetLatestBlockNumber(blockNumber hexutil.Uint64) {
-	defer ct.mutex.Unlock()
-	ct.mutex.Lock()
-
-	ct.state.Latest = blockNumber
-}
-
-func (ct *InMemoryConsensusTracker) GetSafeBlockNumber() hexutil.Uint64 {
-	defer ct.mutex.Unlock()
-	ct.mutex.Lock()
-
-	return ct.state.Safe
-}
-
-func (ct *InMemoryConsensusTracker) SetSafeBlockNumber(blockNumber hexutil.Uint64) {
-	defer ct.mutex.Unlock()
-	ct.mutex.Lock()
-
-	ct.state.Safe = blockNumber
-}
-
-func (ct *InMemoryConsensusTracker) GetFinalizedBlockNumber() hexutil.Uint64 {
-	defer ct.mutex.Unlock()
-	ct.mutex.Lock()
-
-	return ct.state.Finalized
-}
-
-func (ct *InMemoryConsensusTracker) SetFinalizedBlockNumber(blockNumber hexutil.Uint64) {
-	defer ct.mutex.Unlock()
-	ct.mutex.Lock()
-
-	ct.state.Finalized = blockNumber
+func (ct *InMemoryConsensusTracker) SetState(state ConsensusTrackerState) {
+	ct.update(&state)
 }
 
 // RedisConsensusTracker store and retrieve in a shared Redis cluster, with leader election
@@ -256,9 +222,10 @@ func (ct *RedisConsensusTracker) stateHeartbeat() {
 			ct.remote.update(state)
 			log.Debug("updated state from remote", "state", val, "leader", leaderName)
 
-			RecordGroupConsensusHALatestBlock(ct.backendGroup, leaderName, ct.remote.state.Latest)
-			RecordGroupConsensusHASafeBlock(ct.backendGroup, leaderName, ct.remote.state.Safe)
-			RecordGroupConsensusHAFinalizedBlock(ct.backendGroup, leaderName, ct.remote.state.Finalized)
+			remoteState := ct.remote.GetState()
+			RecordGroupConsensusHALatestBlock(ct.backendGroup, leaderName, remoteState.Latest)
+			RecordGroupConsensusHASafeBlock(ct.backendGroup, leaderName, remoteState.Safe)
+			RecordGroupConsensusHAFinalizedBlock(ct.backendGroup, leaderName, remoteState.Finalized)
 		}
 	} else {
 		if !ct.local.Valid() {
@@ -296,32 +263,17 @@ func (ct *RedisConsensusTracker) key(tag string) string {
 	return fmt.Sprintf("consensus:%s:%s", ct.namespace, tag)
 }
 
-func (ct *RedisConsensusTracker) GetLatestBlockNumber() hexutil.Uint64 {
-	return ct.remote.GetLatestBlockNumber()
+func (ct *RedisConsensusTracker) GetState() ConsensusTrackerState {
+	return ct.remote.GetState()
 }
 
-func (ct *RedisConsensusTracker) SetLatestBlockNumber(blockNumber hexutil.Uint64) {
-	ct.local.SetLatestBlockNumber(blockNumber)
-}
-
-func (ct *RedisConsensusTracker) GetSafeBlockNumber() hexutil.Uint64 {
-	return ct.remote.GetSafeBlockNumber()
-}
-
-func (ct *RedisConsensusTracker) SetSafeBlockNumber(blockNumber hexutil.Uint64) {
-	ct.local.SetSafeBlockNumber(blockNumber)
-}
-
-func (ct *RedisConsensusTracker) GetFinalizedBlockNumber() hexutil.Uint64 {
-	return ct.remote.GetFinalizedBlockNumber()
-}
-
-func (ct *RedisConsensusTracker) SetFinalizedBlockNumber(blockNumber hexutil.Uint64) {
-	ct.local.SetFinalizedBlockNumber(blockNumber)
+func (ct *RedisConsensusTracker) SetState(state ConsensusTrackerState) {
+	ct.local.SetState(state)
 }
 
 func (ct *RedisConsensusTracker) postPayload(mutexVal string) {
-	jsonState, err := json.Marshal(ct.local.state)
+	state := ct.local.GetState()
+	jsonState, err := json.Marshal(state)
 	if err != nil {
 		log.Error("failed to marshal local", "err", err)
 		RecordGroupConsensusError(ct.backendGroup, "leader_marshal_local_state", err)
@@ -348,9 +300,10 @@ func (ct *RedisConsensusTracker) postPayload(mutexVal string) {
 	log.Debug("posted state", "state", string(jsonState), "leader", leader)
 
 	ct.leaderName = leader
-	ct.remote.update(ct.local.state)
+	ct.remote.update(&state)
 
-	RecordGroupConsensusHALatestBlock(ct.backendGroup, leader, ct.remote.state.Latest)
-	RecordGroupConsensusHASafeBlock(ct.backendGroup, leader, ct.remote.state.Safe)
-	RecordGroupConsensusHAFinalizedBlock(ct.backendGroup, leader, ct.remote.state.Finalized)
+	remoteState := ct.remote.GetState()
+	RecordGroupConsensusHALatestBlock(ct.backendGroup, leader, remoteState.Latest)
+	RecordGroupConsensusHASafeBlock(ct.backendGroup, leader, remoteState.Safe)
+	RecordGroupConsensusHAFinalizedBlock(ct.backendGroup, leader, remoteState.Finalized)
 }


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
- Replace 6-method ConsensusTracker interface (individual getters/setters) with GetState()/SetState(ConsensusTrackerState) — adding a new consensus field now only requires changing the struct, not the interface
- Introduce backendStateUpdate value struct for setBackendState to eliminate transposition risk with same-typed positional arguments
- ConsensusPoller getters delegate through GetState() rather than individual tracker methods
- postPayload uses GetState() snapshot instead of direct field access

Zero behavior change — all existing consensus tests pass.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
