### PR TITLE
refactor(proxyd): extract findConsensusBlock walk-back into reusable function

### DIFF
--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -596,11 +596,10 @@ func (cp *ConsensusPoller) Reset() {
 }
 
 // blockHashFetcher retrieves the block number and hash for a given block from a backend.
-// bs is provided for fetchers that can use cached state; it may be ignored.
-type blockHashFetcher func(ctx context.Context, be *Backend, bs *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error)
+type blockHashFetcher func(ctx context.Context, be *Backend, block hexutil.Uint64) (hexutil.Uint64, string, error)
 
-// elBlockFetcher is a blockHashFetcher for EL backends; bs is unused.
-func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+// elBlockFetcher is a blockHashFetcher for EL backends.
+func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, block hexutil.Uint64) (hexutil.Uint64, string, error) {
 	return cp.fetchBlock(ctx, be, block.String())
 }
 
@@ -622,8 +621,8 @@ func (cp *ConsensusPoller) findConsensusBlock(
 
 	for {
 		allAgreed := true
-		for be, bs := range candidates {
-			actualBlockNumber, actualHash, err := fetch(ctx, be, bs, proposedBlock)
+		for be := range candidates {
+			actualBlockNumber, actualHash, err := fetch(ctx, be, proposedBlock)
 			if err != nil {
 				log.Warn("error fetching block for consensus check", "label", label, "name", be.Name, "err", err)
 				continue

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -607,6 +607,7 @@ func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, _ *b
 // findConsensusBlock walks back from startBlock until all candidates agree on the same block hash.
 // label identifies the safety level ("unsafe", "safe") for log context.
 // It returns the agreed block number, hash, and whether consensus was broken relative to currentConsensusBlock.
+// If agreement cannot be reached down to genesis, it returns 0, "", true.
 func (cp *ConsensusPoller) findConsensusBlock(
 	ctx context.Context,
 	candidates map[*Backend]*backendState,
@@ -647,6 +648,9 @@ func (cp *ConsensusPoller) findConsensusBlock(
 		}
 		if allAgreed {
 			return proposedBlock, proposedBlockHash, broken
+		}
+		if proposedBlock == 0 {
+			return 0, "", true
 		}
 		proposedBlock -= 1
 		proposedBlockHash = ""

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -484,50 +484,17 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	// the proposed block needs have the same hash in the entire consensus group
 	proposedBlock := lowestLatestBlock
 	proposedBlockHash := lowestLatestBlockHash
-	hasConsensus := false
 	broken := false
 
 	if lowestLatestBlock > currentConsensusBlockNumber {
 		log.Debug("validating consensus on block", "lowestLatestBlock", lowestLatestBlock)
 	}
 
-	// if there is a block to propose, check if it is the same in all backends
+	// if there is a block to propose, verify all candidates agree on the same hash,
+	// walking back one block at a time until consensus is found.
 	if proposedBlock > 0 {
-		for !hasConsensus {
-			allAgreed := true
-			for be := range candidates {
-				actualBlockNumber, actualBlockHash, err := cp.fetchBlock(ctx, be, proposedBlock.String())
-				if err != nil {
-					log.Warn("error updating backend", "name", be.Name, "err", err)
-					continue
-				}
-				if proposedBlockHash == "" {
-					proposedBlockHash = actualBlockHash
-				}
-				blocksDontMatch := (actualBlockNumber != proposedBlock) || (actualBlockHash != proposedBlockHash)
-				if blocksDontMatch {
-					if currentConsensusBlockNumber >= actualBlockNumber {
-						log.Warn("backend broke consensus",
-							"name", be.Name,
-							"actualBlockNumber", actualBlockNumber,
-							"actualBlockHash", actualBlockHash,
-							"proposedBlock", proposedBlock,
-							"proposedBlockHash", proposedBlockHash)
-						broken = true
-					}
-					allAgreed = false
-					break
-				}
-			}
-			if allAgreed {
-				hasConsensus = true
-			} else {
-				// walk one block behind and try again
-				proposedBlock -= 1
-				proposedBlockHash = ""
-				log.Debug("no consensus, now trying", "block:", proposedBlock)
-			}
-		}
+		proposedBlock, proposedBlockHash, broken = cp.findConsensusBlock(
+			ctx, candidates, currentConsensusBlockNumber, proposedBlock, proposedBlockHash, cp.elBlockFetcher, "unsafe")
 	}
 
 	if broken {
@@ -625,6 +592,65 @@ func (cp *ConsensusPoller) Unban(be *Backend) {
 func (cp *ConsensusPoller) Reset() {
 	for _, be := range cp.backendGroup.Backends {
 		cp.backendState[be] = &backendState{}
+	}
+}
+
+// blockHashFetcher retrieves the block number and hash for a given block from a backend.
+// bs is provided for fetchers that can use cached state; it may be ignored.
+type blockHashFetcher func(ctx context.Context, be *Backend, bs *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error)
+
+// elBlockFetcher is a blockHashFetcher for EL backends; bs is unused.
+func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+	return cp.fetchBlock(ctx, be, block.String())
+}
+
+// findConsensusBlock walks back from startBlock until all candidates agree on the same block hash.
+// label identifies the safety level ("unsafe", "safe") for log context.
+// It returns the agreed block number, hash, and whether consensus was broken relative to currentConsensusBlock.
+func (cp *ConsensusPoller) findConsensusBlock(
+	ctx context.Context,
+	candidates map[*Backend]*backendState,
+	currentConsensusBlock hexutil.Uint64,
+	startBlock hexutil.Uint64,
+	startHash string,
+	fetch blockHashFetcher,
+	label string,
+) (proposedBlock hexutil.Uint64, proposedBlockHash string, broken bool) {
+	proposedBlock = startBlock
+	proposedBlockHash = startHash
+
+	for {
+		allAgreed := true
+		for be, bs := range candidates {
+			actualBlockNumber, actualHash, err := fetch(ctx, be, bs, proposedBlock)
+			if err != nil {
+				log.Warn("error fetching block for consensus check", "label", label, "name", be.Name, "err", err)
+				continue
+			}
+			if proposedBlockHash == "" {
+				proposedBlockHash = actualHash
+			}
+			if actualBlockNumber != proposedBlock || actualHash != proposedBlockHash {
+				if currentConsensusBlock >= actualBlockNumber {
+					log.Warn("backend broke consensus",
+						"label", label,
+						"name", be.Name,
+						"actualBlockNumber", actualBlockNumber,
+						"actualHash", actualHash,
+						"proposedBlock", proposedBlock,
+						"proposedBlockHash", proposedBlockHash)
+					broken = true
+				}
+				allAgreed = false
+				break
+			}
+		}
+		if allAgreed {
+			return proposedBlock, proposedBlockHash, broken
+		}
+		proposedBlock -= 1
+		proposedBlockHash = ""
+		log.Debug("no consensus, walking back", "label", label, "block", proposedBlock)
 	}
 }
 

--- a/proxyd/consensus_poller_test.go
+++ b/proxyd/consensus_poller_test.go
@@ -1,0 +1,64 @@
+package proxyd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindConsensusBlock_exhaustsAtGenesis(t *testing.T) {
+	ctx := context.Background()
+	cp := &ConsensusPoller{}
+
+	be1 := &Backend{Name: "node-a"}
+	be2 := &Backend{Name: "node-b"}
+	candidates := map[*Backend]*backendState{
+		be1: {},
+		be2: {},
+	}
+
+	fetch := func(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+		if be == be1 {
+			return block, "hash-a", nil
+		}
+		return block, "hash-b", nil
+	}
+
+	num, hash, broken := cp.findConsensusBlock(ctx, candidates, 0, 2, "hash-a", fetch, "test")
+	require.Equal(t, hexutil.Uint64(0), num)
+	require.Equal(t, "", hash)
+	require.True(t, broken)
+}
+
+func TestFindConsensusBlock_agreesAtBlockZero(t *testing.T) {
+	ctx := context.Background()
+	cp := &ConsensusPoller{}
+
+	be1 := &Backend{Name: "node-a"}
+	be2 := &Backend{Name: "node-b"}
+	candidates := map[*Backend]*backendState{
+		be1: {},
+		be2: {},
+	}
+
+	fetch := func(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+		switch uint64(block) {
+		case 1:
+			if be == be1 {
+				return block, "hash-a-at-1", nil
+			}
+			return block, "hash-b-at-1", nil
+		case 0:
+			return block, "genesis-shared", nil
+		default:
+			return block, "unused", nil
+		}
+	}
+
+	num, hash, broken := cp.findConsensusBlock(ctx, candidates, 0, 1, "hash-a-at-1", fetch, "test")
+	require.Equal(t, hexutil.Uint64(0), num)
+	require.Equal(t, "genesis-shared", hash)
+	require.False(t, broken)
+}

--- a/proxyd/consensus_poller_test.go
+++ b/proxyd/consensus_poller_test.go
@@ -19,7 +19,7 @@ func TestFindConsensusBlock_exhaustsAtGenesis(t *testing.T) {
 		be2: {},
 	}
 
-	fetch := func(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+	fetch := func(ctx context.Context, be *Backend, block hexutil.Uint64) (hexutil.Uint64, string, error) {
 		if be == be1 {
 			return block, "hash-a", nil
 		}
@@ -43,7 +43,7 @@ func TestFindConsensusBlock_agreesAtBlockZero(t *testing.T) {
 		be2: {},
 	}
 
-	fetch := func(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+	fetch := func(ctx context.Context, be *Backend, block hexutil.Uint64) (hexutil.Uint64, string, error) {
 		switch uint64(block) {
 		case 1:
 			if be == be1 {


### PR DESCRIPTION

**Description**

The hash-verification walk-back loop in UpdateBackendGroupConsensus is duplicated by the upcoming CL mode which needs the same logic for safe_l2. Extract it into findConsensusBlock with a blockHashFetcher callback, so CL can reuse it with a different fetcher without duplicating the loop.

No behavior change for EL — elBlockFetcher wraps the existing fetchBlock.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
