### PR TITLE
feat(proxyd): track block hashes in consensus state

### DIFF
--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -48,7 +48,9 @@ type backendState struct {
 	latestBlockNumber    hexutil.Uint64
 	latestBlockHash      string
 	safeBlockNumber      hexutil.Uint64
+	safeBlockHash        string
 	finalizedBlockNumber hexutil.Uint64
+	finalizedBlockHash   string
 
 	peerCount uint64
 	inSync    bool
@@ -104,6 +106,21 @@ func (cp *ConsensusPoller) GetSafeBlockNumber() hexutil.Uint64 {
 // GetFinalizedBlockNumber returns the `finalized` agreed block number in a consensus
 func (cp *ConsensusPoller) GetFinalizedBlockNumber() hexutil.Uint64 {
 	return cp.tracker.GetState().Finalized
+}
+
+// GetLatestBlockHash returns the hash of the `latest` agreed block in a consensus
+func (cp *ConsensusPoller) GetLatestBlockHash() string {
+	return cp.tracker.GetState().LatestHash
+}
+
+// GetSafeBlockHash returns the hash of the `safe` agreed block in a consensus
+func (cp *ConsensusPoller) GetSafeBlockHash() string {
+	return cp.tracker.GetState().SafeHash
+}
+
+// GetFinalizedBlockHash returns the hash of the `finalized` agreed block in a consensus
+func (cp *ConsensusPoller) GetFinalizedBlockHash() string {
+	return cp.tracker.GetState().FinalizedHash
 }
 
 func (cp *ConsensusPoller) Shutdown() {
@@ -352,7 +369,7 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		return
 	}
 
-	safeBlockNumber, _, err := cp.fetchBlock(ctx, be, "safe")
+	safeBlockNumber, safeBlockHash, err := cp.fetchBlock(ctx, be, "safe")
 	if err != nil {
 		log.Warn("error updating backend - safe block will not be updated", "name", be.Name, "err", err)
 		return
@@ -364,7 +381,7 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		return
 	}
 
-	finalizedBlockNumber, _, err := cp.fetchBlock(ctx, be, "finalized")
+	finalizedBlockNumber, finalizedBlockHash, err := cp.fetchBlock(ctx, be, "finalized")
 	if err != nil {
 		log.Warn("error updating backend - finalized block will not be updated", "name", be.Name, "err", err)
 		return
@@ -384,7 +401,9 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		latestBlockNumber:    latestBlockNumber,
 		latestBlockHash:      latestBlockHash,
 		safeBlockNumber:      safeBlockNumber,
+		safeBlockHash:        safeBlockHash,
 		finalizedBlockNumber: finalizedBlockNumber,
+		finalizedBlockHash:   finalizedBlockHash,
 	})
 
 	RecordBackendLatestBlock(be, latestBlockNumber)
@@ -461,11 +480,12 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	candidates := cp.getConsensusCandidates()
 
 	// update the lowest latest block number and hash
-	//        the lowest safe block number
+	//        the lowest safe block number and hash
 	//        the lowest finalized block number
 	var lowestLatestBlock hexutil.Uint64
 	var lowestLatestBlockHash string
 	var lowestFinalizedBlock hexutil.Uint64
+	var lowestSafeBlockHash string
 	var lowestSafeBlock hexutil.Uint64
 	for _, bs := range candidates {
 		if lowestLatestBlock == 0 || bs.latestBlockNumber < lowestLatestBlock {
@@ -477,6 +497,7 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 		}
 		if lowestSafeBlock == 0 || bs.safeBlockNumber < lowestSafeBlock {
 			lowestSafeBlock = bs.safeBlockNumber
+			lowestSafeBlockHash = bs.safeBlockHash
 		}
 	}
 
@@ -510,9 +531,11 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 
 	// update tracker
 	cp.tracker.SetState(ConsensusTrackerState{
-		Latest:    proposedBlock,
-		Safe:      lowestSafeBlock,
-		Finalized: lowestFinalizedBlock,
+		Latest:     proposedBlock,
+		Safe:       lowestSafeBlock,
+		Finalized:  lowestFinalizedBlock,
+		LatestHash: proposedBlockHash,
+		SafeHash:   lowestSafeBlockHash,
 	})
 
 	// update consensus group
@@ -727,7 +750,9 @@ func (cp *ConsensusPoller) GetBackendState(be *Backend) *backendState {
 		latestBlockNumber:    bs.latestBlockNumber,
 		latestBlockHash:      bs.latestBlockHash,
 		safeBlockNumber:      bs.safeBlockNumber,
+		safeBlockHash:        bs.safeBlockHash,
 		finalizedBlockNumber: bs.finalizedBlockNumber,
+		finalizedBlockHash:   bs.finalizedBlockHash,
 		peerCount:            bs.peerCount,
 		inSync:               bs.inSync,
 		lastUpdate:           bs.lastUpdate,
@@ -750,7 +775,9 @@ type backendStateUpdate struct {
 	latestBlockNumber    hexutil.Uint64
 	latestBlockHash      string
 	safeBlockNumber      hexutil.Uint64
+	safeBlockHash        string
 	finalizedBlockNumber hexutil.Uint64
+	finalizedBlockHash   string
 }
 
 func (cp *ConsensusPoller) setBackendState(be *Backend, upd backendStateUpdate) bool {
@@ -761,8 +788,10 @@ func (cp *ConsensusPoller) setBackendState(be *Backend, upd backendStateUpdate) 
 	bs.inSync = upd.inSync
 	bs.latestBlockNumber = upd.latestBlockNumber
 	bs.latestBlockHash = upd.latestBlockHash
-	bs.finalizedBlockNumber = upd.finalizedBlockNumber
 	bs.safeBlockNumber = upd.safeBlockNumber
+	bs.safeBlockHash = upd.safeBlockHash
+	bs.finalizedBlockNumber = upd.finalizedBlockNumber
+	bs.finalizedBlockHash = upd.finalizedBlockHash
 	bs.lastUpdate = time.Now()
 	bs.backendStateMux.Unlock()
 	return changed

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -418,7 +418,9 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 			"latestBlockNumber", latestBlockNumber,
 			"latestBlockHash", latestBlockHash,
 			"safeBlockNumber", safeBlockNumber,
+			"safeBlockHash", safeBlockHash,
 			"finalizedBlockNumber", finalizedBlockNumber,
+			"finalizedBlockHash", finalizedBlockHash,
 			"lastUpdate", bs.lastUpdate)
 	}
 

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -484,50 +484,17 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	// the proposed block needs have the same hash in the entire consensus group
 	proposedBlock := lowestLatestBlock
 	proposedBlockHash := lowestLatestBlockHash
-	hasConsensus := false
 	broken := false
 
 	if lowestLatestBlock > currentConsensusBlockNumber {
 		log.Debug("validating consensus on block", "lowestLatestBlock", lowestLatestBlock)
 	}
 
-	// if there is a block to propose, check if it is the same in all backends
+	// if there is a block to propose, verify all candidates agree on the same hash,
+	// walking back one block at a time until consensus is found.
 	if proposedBlock > 0 {
-		for !hasConsensus {
-			allAgreed := true
-			for be := range candidates {
-				actualBlockNumber, actualBlockHash, err := cp.fetchBlock(ctx, be, proposedBlock.String())
-				if err != nil {
-					log.Warn("error updating backend", "name", be.Name, "err", err)
-					continue
-				}
-				if proposedBlockHash == "" {
-					proposedBlockHash = actualBlockHash
-				}
-				blocksDontMatch := (actualBlockNumber != proposedBlock) || (actualBlockHash != proposedBlockHash)
-				if blocksDontMatch {
-					if currentConsensusBlockNumber >= actualBlockNumber {
-						log.Warn("backend broke consensus",
-							"name", be.Name,
-							"actualBlockNumber", actualBlockNumber,
-							"actualBlockHash", actualBlockHash,
-							"proposedBlock", proposedBlock,
-							"proposedBlockHash", proposedBlockHash)
-						broken = true
-					}
-					allAgreed = false
-					break
-				}
-			}
-			if allAgreed {
-				hasConsensus = true
-			} else {
-				// walk one block behind and try again
-				proposedBlock -= 1
-				proposedBlockHash = ""
-				log.Debug("no consensus, now trying", "block:", proposedBlock)
-			}
-		}
+		proposedBlock, proposedBlockHash, broken = cp.findConsensusBlock(
+			ctx, candidates, currentConsensusBlockNumber, proposedBlock, proposedBlockHash, cp.elBlockFetcher, "unsafe")
 	}
 
 	if broken {
@@ -625,6 +592,65 @@ func (cp *ConsensusPoller) Unban(be *Backend) {
 func (cp *ConsensusPoller) Reset() {
 	for _, be := range cp.backendGroup.Backends {
 		cp.backendState[be] = &backendState{}
+	}
+}
+
+// blockHashFetcher retrieves the block number and hash for a given block from a backend.
+// bs is provided for fetchers that can use cached state; it may be ignored.
+type blockHashFetcher func(ctx context.Context, be *Backend, bs *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error)
+
+// elBlockFetcher is a blockHashFetcher for EL backends; bs is unused.
+func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+	return cp.fetchBlock(ctx, be, block.String())
+}
+
+// findConsensusBlock walks back from startBlock until all candidates agree on the same block hash.
+// label identifies the safety level ("unsafe", "safe") for log context.
+// It returns the agreed block number, hash, and whether consensus was broken relative to currentConsensusBlock.
+func (cp *ConsensusPoller) findConsensusBlock(
+	ctx context.Context,
+	candidates map[*Backend]*backendState,
+	currentConsensusBlock hexutil.Uint64,
+	startBlock hexutil.Uint64,
+	startHash string,
+	fetch blockHashFetcher,
+	label string,
+) (proposedBlock hexutil.Uint64, proposedBlockHash string, broken bool) {
+	proposedBlock = startBlock
+	proposedBlockHash = startHash
+
+	for {
+		allAgreed := true
+		for be, bs := range candidates {
+			actualBlockNumber, actualHash, err := fetch(ctx, be, bs, proposedBlock)
+			if err != nil {
+				log.Warn("error fetching block for consensus check", "label", label, "name", be.Name, "err", err)
+				continue
+			}
+			if proposedBlockHash == "" {
+				proposedBlockHash = actualHash
+			}
+			if actualBlockNumber != proposedBlock || actualHash != proposedBlockHash {
+				if currentConsensusBlock >= actualBlockNumber {
+					log.Warn("backend broke consensus",
+						"label", label,
+						"name", be.Name,
+						"actualBlockNumber", actualBlockNumber,
+						"actualHash", actualHash,
+						"proposedBlock", proposedBlock,
+						"proposedBlockHash", proposedBlockHash)
+					broken = true
+				}
+				allAgreed = false
+				break
+			}
+		}
+		if allAgreed {
+			return proposedBlock, proposedBlockHash, broken
+		}
+		proposedBlock -= 1
+		proposedBlockHash = ""
+		log.Debug("no consensus, walking back", "label", label, "block", proposedBlock)
 	}
 }
 

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -25,9 +25,12 @@ type ConsensusTracker interface {
 // ConsensusTrackerState holds the full consensus state in one snapshot.
 // Adding a new field only requires changing this struct and update().
 type ConsensusTrackerState struct {
-	Latest    hexutil.Uint64 `json:"latest"`
-	Safe      hexutil.Uint64 `json:"safe"`
-	Finalized hexutil.Uint64 `json:"finalized"`
+	Latest        hexutil.Uint64 `json:"latest"`
+	Safe          hexutil.Uint64 `json:"safe"`
+	Finalized     hexutil.Uint64 `json:"finalized"`
+	LatestHash    string         `json:"latest_hash"`
+	SafeHash      string         `json:"safe_hash"`
+	FinalizedHash string         `json:"finalized_hash"`
 }
 
 func (ct *InMemoryConsensusTracker) update(o *ConsensusTrackerState) {
@@ -37,6 +40,9 @@ func (ct *InMemoryConsensusTracker) update(o *ConsensusTrackerState) {
 	ct.state.Latest = o.Latest
 	ct.state.Safe = o.Safe
 	ct.state.Finalized = o.Finalized
+	ct.state.LatestHash = o.LatestHash
+	ct.state.SafeHash = o.SafeHash
+	ct.state.FinalizedHash = o.FinalizedHash
 }
 
 // InMemoryConsensusTracker store and retrieve in memory, async-safe


### PR DESCRIPTION
**Description**
EL already fetches block hashes from eth_getBlockByNumber for latest, safe, and finalized — this change stores them instead of discarding safe/finalized.

- Add safeBlockHash, finalizedBlockHash to backendState and backendStateUpdate
- Add LatestHash, SafeHash, FinalizedHash to ConsensusTrackerState
- Expose GetLatestBlockHash/GetSafeBlockHash/GetFinalizedBlockHash on ConsensusPoller
- Track lowestSafeBlockHash in UpdateBackendGroupConsensus and persist to tracker

CL mode will use these fields (and add FinalizedHash) in the next PR.
**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
