### PR TITLE
refactor(proxyd): extract updateELBackend from UpdateBackend

### DIFF
--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -365,7 +365,7 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		RecordConsensusBackendPeerCount(be, peerCount)
 	}
 
-	latestBlockNumber, latestBlockHash, safeBlockNumber, safeBlockHash, finalizedBlockNumber, finalizedBlockHash, err := cp.updateELBackend(ctx, be)
+	els, err := cp.fetchELState(ctx, be)
 	if err != nil {
 		return
 	}
@@ -375,29 +375,29 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 	changed := cp.setBackendState(be, backendStateUpdate{
 		peerCount:            peerCount,
 		inSync:               inSync,
-		latestBlockNumber:    latestBlockNumber,
-		latestBlockHash:      latestBlockHash,
-		safeBlockNumber:      safeBlockNumber,
-		safeBlockHash:        safeBlockHash,
-		finalizedBlockNumber: finalizedBlockNumber,
-		finalizedBlockHash:   finalizedBlockHash,
+		latestBlockNumber:    els.LatestBlockNumber,
+		latestBlockHash:      els.LatestBlockHash,
+		safeBlockNumber:      els.SafeBlockNumber,
+		safeBlockHash:        els.SafeBlockHash,
+		finalizedBlockNumber: els.FinalizedBlockNumber,
+		finalizedBlockHash:   els.FinalizedBlockHash,
 	})
 
-	RecordBackendLatestBlock(be, latestBlockNumber)
-	RecordBackendSafeBlock(be, safeBlockNumber)
-	RecordBackendFinalizedBlock(be, finalizedBlockNumber)
+	RecordBackendLatestBlock(be, els.LatestBlockNumber)
+	RecordBackendSafeBlock(be, els.SafeBlockNumber)
+	RecordBackendFinalizedBlock(be, els.FinalizedBlockNumber)
 
 	if changed {
 		log.Debug("backend state updated",
 			"name", be.Name,
 			"peerCount", peerCount,
 			"inSync", inSync,
-			"latestBlockNumber", latestBlockNumber,
-			"latestBlockHash", latestBlockHash,
-			"safeBlockNumber", safeBlockNumber,
-			"safeBlockHash", safeBlockHash,
-			"finalizedBlockNumber", finalizedBlockNumber,
-			"finalizedBlockHash", finalizedBlockHash,
+			"latestBlockNumber", els.LatestBlockNumber,
+			"latestBlockHash", els.LatestBlockHash,
+			"safeBlockNumber", els.SafeBlockNumber,
+			"safeBlockHash", els.SafeBlockHash,
+			"finalizedBlockNumber", els.FinalizedBlockNumber,
+			"finalizedBlockHash", els.FinalizedBlockHash,
 			"lastUpdate", bs.lastUpdate)
 	}
 
@@ -405,9 +405,9 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 	expectedBlockTags := cp.checkExpectedBlockTags(
 		be.safeBlockDriftThreshold,
 		be.finalizedBlockDriftThreshold,
-		latestBlockNumber,
-		bs.safeBlockNumber, safeBlockNumber,
-		bs.finalizedBlockNumber, finalizedBlockNumber)
+		els.LatestBlockNumber,
+		bs.safeBlockNumber, els.SafeBlockNumber,
+		bs.finalizedBlockNumber, els.FinalizedBlockNumber)
 
 	RecordBackendUnexpectedBlockTags(be, !expectedBlockTags)
 
@@ -415,10 +415,10 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		log.Warn("backend banned - unexpected block tags",
 			"backend", be.Name,
 			"oldFinalized", bs.finalizedBlockNumber,
-			"finalizedBlockNumber", finalizedBlockNumber,
+			"finalizedBlockNumber", els.FinalizedBlockNumber,
 			"oldSafe", bs.safeBlockNumber,
-			"safeBlockNumber", safeBlockNumber,
-			"latestBlockNumber", latestBlockNumber,
+			"safeBlockNumber", els.SafeBlockNumber,
+			"latestBlockNumber", els.LatestBlockNumber,
 		)
 		cp.Ban(be)
 	}
@@ -659,52 +659,48 @@ func (cp *ConsensusPoller) findConsensusBlock(
 	}
 }
 
-// updateELBackend fetches the EL sync state and block numbers for a single backend,
-// performing zero-value validation inline. It is the EL counterpart to updateCLBackend.
-// On success it returns the inSync flag, block numbers/hashes, and nil.
+// fetchELState fetches the block numbers and hashes for the latest, safe, and finalized
+// tags from a single EL backend, performing zero-value validation inline.
+// It is the EL counterpart to updateCLBackend.
 // On any error or zero block number it returns a non-nil error; the caller should skip state updates.
-func (cp *ConsensusPoller) updateELBackend(ctx context.Context, be *Backend) (
-	latestBlockNumber hexutil.Uint64, latestBlockHash string,
-	safeBlockNumber hexutil.Uint64, safeBlockHash string,
-	finalizedBlockNumber hexutil.Uint64, finalizedBlockHash string,
-	err error,
-) {
-	latestBlockNumber, latestBlockHash, err = cp.fetchELBlock(ctx, be, "latest")
+func (cp *ConsensusPoller) fetchELState(ctx context.Context, be *Backend) (ELBlockState, error) {
+	var s ELBlockState
+	var err error
+
+	s.LatestBlockNumber, s.LatestBlockHash, err = cp.fetchELBlock(ctx, be, "latest")
 	if err != nil {
 		log.Warn("error updating backend - latest block will not be updated", "name", be.Name, "err", err)
-		return
+		return ELBlockState{}, err
 	}
-	if latestBlockNumber == 0 {
+	if s.LatestBlockNumber == 0 {
 		log.Warn("error backend responded a 200 with blockheight 0 for latest block", "name", be.Name)
 		be.intermittentErrorsSlidingWindow.Incr()
-		err = errZeroLatestBlock
-		return
+		return ELBlockState{}, errZeroLatestBlock
 	}
 
-	safeBlockNumber, safeBlockHash, err = cp.fetchELBlock(ctx, be, "safe")
+	s.SafeBlockNumber, s.SafeBlockHash, err = cp.fetchELBlock(ctx, be, "safe")
 	if err != nil {
 		log.Warn("error updating backend - safe block will not be updated", "name", be.Name, "err", err)
-		return
+		return ELBlockState{}, err
 	}
-	if safeBlockNumber == 0 {
+	if s.SafeBlockNumber == 0 {
 		log.Warn("error backend responded a 200 with blockheight 0 for safe block", "name", be.Name)
 		be.intermittentErrorsSlidingWindow.Incr()
-		err = errZeroSafeBlock
-		return
+		return ELBlockState{}, errZeroSafeBlock
 	}
 
-	finalizedBlockNumber, finalizedBlockHash, err = cp.fetchELBlock(ctx, be, "finalized")
+	s.FinalizedBlockNumber, s.FinalizedBlockHash, err = cp.fetchELBlock(ctx, be, "finalized")
 	if err != nil {
 		log.Warn("error updating backend - finalized block will not be updated", "name", be.Name, "err", err)
-		return
+		return ELBlockState{}, err
 	}
-	if finalizedBlockNumber == 0 {
+	if s.FinalizedBlockNumber == 0 {
 		log.Warn("error backend responded a 200 with blockheight 0 for finalized block", "name", be.Name)
 		be.intermittentErrorsSlidingWindow.Incr()
-		err = errZeroFinalizedBlock
-		return
+		return ELBlockState{}, errZeroFinalizedBlock
 	}
-	return
+
+	return s, nil
 }
 
 // fetchELBlock calls eth_getBlockByNumber and returns the block number and hash.
@@ -812,6 +808,17 @@ func (cp *ConsensusPoller) GetLastUpdate(be *Backend) time.Time {
 	defer bs.backendStateMux.Unlock()
 	bs.backendStateMux.Lock()
 	return bs.lastUpdate
+}
+
+// ELBlockState holds the latest, safe, and finalized block number and hash
+// fetched from an EL backend in a single polling cycle.
+type ELBlockState struct {
+	LatestBlockNumber    hexutil.Uint64
+	LatestBlockHash      string
+	SafeBlockNumber      hexutil.Uint64
+	SafeBlockHash        string
+	FinalizedBlockNumber hexutil.Uint64
+	FinalizedBlockHash   string
 }
 
 // backendStateUpdate is a value object passed to setBackendState to avoid

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -623,8 +623,13 @@ func (cp *ConsensusPoller) Reset() {
 // blockHashFetcher retrieves the block number and hash for a given block from a backend.
 type blockHashFetcher func(ctx context.Context, be *Backend, block hexutil.Uint64) (hexutil.Uint64, string, error)
 
+<<<<<<< HEAD
 // elBlockFetcher is a blockHashFetcher for EL backends.
 func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+=======
+// elBlockFetcher is a blockHashFetcher for EL backends; bs is unused.
+func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
+>>>>>>> feb08d5 (refactor(proxyd): rename EL-specific functions and fix type assertion panics)
 	return cp.fetchELBlock(ctx, be, block.String())
 }
 

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -2,6 +2,7 @@ package proxyd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -14,6 +15,12 @@ import (
 
 const (
 	DefaultPollerInterval = 1 * time.Second
+)
+
+var (
+	errZeroLatestBlock    = errors.New("backend responded with blockheight 0 for latest block")
+	errZeroSafeBlock      = errors.New("backend responded with blockheight 0 for safe block")
+	errZeroFinalizedBlock = errors.New("backend responded with blockheight 0 for finalized block")
 )
 
 type OnConsensusBroken func()
@@ -358,38 +365,8 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		RecordConsensusBackendPeerCount(be, peerCount)
 	}
 
-	latestBlockNumber, latestBlockHash, err := cp.fetchELBlock(ctx, be, "latest")
+	latestBlockNumber, latestBlockHash, safeBlockNumber, safeBlockHash, finalizedBlockNumber, finalizedBlockHash, err := cp.updateELBackend(ctx, be)
 	if err != nil {
-		log.Warn("error updating backend - latest block will not be updated", "name", be.Name, "err", err)
-		return
-	}
-	if latestBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for latest block", "name", be.Name)
-		be.intermittentErrorsSlidingWindow.Incr()
-		return
-	}
-
-	safeBlockNumber, safeBlockHash, err := cp.fetchELBlock(ctx, be, "safe")
-	if err != nil {
-		log.Warn("error updating backend - safe block will not be updated", "name", be.Name, "err", err)
-		return
-	}
-
-	if safeBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for safe block", "name", be.Name)
-		be.intermittentErrorsSlidingWindow.Incr()
-		return
-	}
-
-	finalizedBlockNumber, finalizedBlockHash, err := cp.fetchELBlock(ctx, be, "finalized")
-	if err != nil {
-		log.Warn("error updating backend - finalized block will not be updated", "name", be.Name, "err", err)
-		return
-	}
-
-	if finalizedBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for finalized block", "name", be.Name)
-		be.intermittentErrorsSlidingWindow.Incr()
 		return
 	}
 
@@ -623,13 +600,8 @@ func (cp *ConsensusPoller) Reset() {
 // blockHashFetcher retrieves the block number and hash for a given block from a backend.
 type blockHashFetcher func(ctx context.Context, be *Backend, block hexutil.Uint64) (hexutil.Uint64, string, error)
 
-<<<<<<< HEAD
 // elBlockFetcher is a blockHashFetcher for EL backends.
 func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, block hexutil.Uint64) (hexutil.Uint64, string, error) {
-=======
-// elBlockFetcher is a blockHashFetcher for EL backends; bs is unused.
-func (cp *ConsensusPoller) elBlockFetcher(ctx context.Context, be *Backend, _ *backendState, block hexutil.Uint64) (hexutil.Uint64, string, error) {
->>>>>>> feb08d5 (refactor(proxyd): rename EL-specific functions and fix type assertion panics)
 	return cp.fetchELBlock(ctx, be, block.String())
 }
 
@@ -685,6 +657,54 @@ func (cp *ConsensusPoller) findConsensusBlock(
 		proposedBlockHash = ""
 		log.Debug("no consensus, walking back", "label", label, "block", proposedBlock)
 	}
+}
+
+// updateELBackend fetches the EL sync state and block numbers for a single backend,
+// performing zero-value validation inline. It is the EL counterpart to updateCLBackend.
+// On success it returns the inSync flag, block numbers/hashes, and nil.
+// On any error or zero block number it returns a non-nil error; the caller should skip state updates.
+func (cp *ConsensusPoller) updateELBackend(ctx context.Context, be *Backend) (
+	latestBlockNumber hexutil.Uint64, latestBlockHash string,
+	safeBlockNumber hexutil.Uint64, safeBlockHash string,
+	finalizedBlockNumber hexutil.Uint64, finalizedBlockHash string,
+	err error,
+) {
+	latestBlockNumber, latestBlockHash, err = cp.fetchELBlock(ctx, be, "latest")
+	if err != nil {
+		log.Warn("error updating backend - latest block will not be updated", "name", be.Name, "err", err)
+		return
+	}
+	if latestBlockNumber == 0 {
+		log.Warn("error backend responded a 200 with blockheight 0 for latest block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		err = errZeroLatestBlock
+		return
+	}
+
+	safeBlockNumber, safeBlockHash, err = cp.fetchELBlock(ctx, be, "safe")
+	if err != nil {
+		log.Warn("error updating backend - safe block will not be updated", "name", be.Name, "err", err)
+		return
+	}
+	if safeBlockNumber == 0 {
+		log.Warn("error backend responded a 200 with blockheight 0 for safe block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		err = errZeroSafeBlock
+		return
+	}
+
+	finalizedBlockNumber, finalizedBlockHash, err = cp.fetchELBlock(ctx, be, "finalized")
+	if err != nil {
+		log.Warn("error updating backend - finalized block will not be updated", "name", be.Name, "err", err)
+		return
+	}
+	if finalizedBlockNumber == 0 {
+		log.Warn("error backend responded a 200 with blockheight 0 for finalized block", "name", be.Name)
+		be.intermittentErrorsSlidingWindow.Incr()
+		err = errZeroFinalizedBlock
+		return
+	}
+	return
 }
 
 // fetchELBlock calls eth_getBlockByNumber and returns the block number and hash.


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
This pull request refactors how the consensus poller fetches and validates execution layer (EL) block state in the `proxyd` package. The main improvement is consolidating the fetching and validation of the latest, safe, and finalized blocks into a single method, which simplifies error handling and reduces code duplication. Additionally, the changes introduce a new struct to encapsulate EL block state and improve error reporting for zero block numbers.

Key changes:

**New Helper and Structs:**
- Added the `fetchELState` helper function, which retrieves and validates the latest, safe, and finalized block numbers and hashes from an EL backend, returning an error if any are invalid or zero.
- Introduced the `ELBlockState` struct to encapsulate the block numbers and hashes for the three block tags, improving code clarity and reducing argument transposition bugs.

**Error Handling Improvements:**
- Defined specific error variables for zero block number responses for each block tag, improving error reporting and making it easier to handle these cases consistently.
- Improved logging and error incrementing for zero block number responses, now handled centrally in `fetchELState`.

**Minor:**
- Added the `errors` import to support the new error variables.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
