### PR TITLE
ci: migrate Docker build matrix to images.json

### DIFF
--- a/.github/images.json
+++ b/.github/images.json
@@ -1,0 +1,59 @@
+{
+  "shared_paths": [
+    ".github/workflows/branches.yaml",
+    ".github/images.json",
+    "go.mod"
+  ],
+  "images": {
+    "cci-stats": {
+      "context": ".",
+      "dockerfile": "cci-stats/Dockerfile",
+      "paths": ["cci-stats/**"]
+    },
+    "op-acceptor": {
+      "context": ".",
+      "dockerfile": "op-acceptor/Dockerfile",
+      "paths": ["op-acceptor/**"]
+    },
+    "op-conductor-mon": {
+      "context": ".",
+      "dockerfile": "op-conductor-mon/Dockerfile",
+      "paths": ["op-conductor-mon/**"]
+    },
+    "op-conductor-ops": {
+      "context": ".",
+      "dockerfile": "op-conductor-ops/Dockerfile",
+      "paths": ["op-conductor-ops/**"]
+    },
+    "op-signer": {
+      "context": ".",
+      "dockerfile": "op-signer/Dockerfile",
+      "paths": ["op-signer/**"]
+    },
+    "op-txproxy": {
+      "context": ".",
+      "dockerfile": "op-txproxy/Dockerfile",
+      "paths": ["op-txproxy/**"]
+    },
+    "op-ufm": {
+      "context": ".",
+      "dockerfile": "op-ufm/Dockerfile",
+      "paths": ["op-ufm/**"]
+    },
+    "peer-mgmt-service": {
+      "context": ".",
+      "dockerfile": "peer-mgmt-service/Dockerfile",
+      "paths": ["peer-mgmt-service/**"]
+    },
+    "proxyd": {
+      "context": ".",
+      "dockerfile": "proxyd/Dockerfile",
+      "paths": ["proxyd/**"]
+    },
+    "replica-healthcheck": {
+      "context": ".",
+      "dockerfile": "replica-healthcheck/Dockerfile",
+      "paths": ["replica-healthcheck/**"]
+    }
+  }
+}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -9,28 +9,34 @@ on:
       - 'main'
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix_json: ${{ steps.detect.outputs.matrix_json }}
+      has_images: ${{ steps.detect.outputs.has_images }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6
+        with:
+          fetch-depth: 0
+      - name: Detect affected images
+        id: detect
+        uses: ethereum-optimism/factory/actions/detect-changes@e2dc072bfb0492f579dfab8d0dc9938a35739a9c
+
   local:
-    # only build if the push is to a local branch, or if the PR is to main from a local branch
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.has_images == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
     strategy:
       fail-fast: false
       matrix:
-        image_name:
-          - cci-stats
-          - op-acceptor
-          - op-conductor-mon
-          - op-conductor-ops
-          - op-signer
-          - op-txproxy
-          - op-ufm
-          - peer-mgmt-service
-          - proxyd
-          - replica-healthcheck
+        include: ${{ fromJson(needs.detect-changes.outputs.matrix_json) }}
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@612b1cbbd0d9c659bb6cf90dc6492f8a39288fc5
     with:
       image_name: ${{ matrix.image_name }}
-      context: .
-      dockerfile: ${{ matrix.image_name }}/Dockerfile
+      context: ${{ matrix.context || '.' }}
+      dockerfile: ${{ matrix.dockerfile || 'Dockerfile' }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
     permissions:
@@ -39,27 +45,17 @@ jobs:
       attestations: write
 
   fork:
-    # only build if the PR is from a fork
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.has_images == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
-        image_name:
-          - cci-stats
-          - op-acceptor
-          - op-conductor-mon
-          - op-conductor-ops
-          - op-signer
-          - op-txproxy
-          - op-ufm
-          - peer-mgmt-service
-          - proxyd
-          - replica-healthcheck
+        include: ${{ fromJson(needs.detect-changes.outputs.matrix_json) }}
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@612b1cbbd0d9c659bb6cf90dc6492f8a39288fc5
     with:
       image_name: ${{ matrix.image_name }}
-      context: .
-      dockerfile: ${{ matrix.image_name }}/Dockerfile
+      context: ${{ matrix.context || '.' }}
+      dockerfile: ${{ matrix.dockerfile || 'Dockerfile' }}
       registry: ttl.sh/${{ github.sha }}
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Extract hardcoded Docker build matrix into `.github/images.json`
- Update `branches.yaml` to use the `detect-changes` composite action from factory
- Image definitions (names, dockerfiles, paths) are now managed in `images.json` independently of the workflow file
- Preserves the existing local/fork PR split behavior

No functional change to what gets built. All 10 images continue to build with the same configuration. On PRs, only images affected by changed files will build.

Closes #602

## Test plan

- [ ] Verify CI passes on this PR (only affected images should build)
- [ ] Merge and confirm all 10 images build successfully on push to main