### PR TITLE
ci: bump factory workflow to node24-compatible version

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - name: Detect affected images
         id: detect
-        uses: ethereum-optimism/factory/actions/detect-changes@cc1794a8e99695971560f5354076fbe2ddca9f2e
+        uses: ethereum-optimism/factory/actions/detect-changes@0df70b9f043d552377e641951fe72ca292086e85
 
   local:
     needs: [detect-changes]
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.detect-changes.outputs.matrix_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@0df70b9f043d552377e641951fe72ca292086e85
     with:
       image_name: ${{ matrix.image_name }}
       context: ${{ matrix.context || '.' }}
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.detect-changes.outputs.matrix_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@0df70b9f043d552377e641951fe72ca292086e85
     with:
       image_name: ${{ matrix.image_name }}
       context: ${{ matrix.context || '.' }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - name: Detect affected images
         id: detect
-        uses: ethereum-optimism/factory/actions/detect-changes@e2dc072bfb0492f579dfab8d0dc9938a35739a9c
+        uses: ethereum-optimism/factory/actions/detect-changes@cc1794a8e99695971560f5354076fbe2ddca9f2e
 
   local:
     needs: [detect-changes]
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.detect-changes.outputs.matrix_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@612b1cbbd0d9c659bb6cf90dc6492f8a39288fc5
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
     with:
       image_name: ${{ matrix.image_name }}
       context: ${{ matrix.context || '.' }}
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.detect-changes.outputs.matrix_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@612b1cbbd0d9c659bb6cf90dc6492f8a39288fc5
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
     with:
       image_name: ${{ matrix.image_name }}
       context: ${{ matrix.context || '.' }}

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -12,11 +12,11 @@ jobs:
       image_name: ${{ steps.parse-tag.outputs.image_name }}
       version: ${{ steps.parse-tag.outputs.version }}
     steps:
-      - uses: ethereum-optimism/factory/actions/parse-tag@cc1794a8e99695971560f5354076fbe2ddca9f2e
+      - uses: ethereum-optimism/factory/actions/parse-tag@0df70b9f043d552377e641951fe72ca292086e85
         id: parse-tag
   tag:
     needs: prep
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@0df70b9f043d552377e641951fe72ca292086e85
     with:
       image_name: ${{ needs.prep.outputs.image_name }}
       context: .

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -12,11 +12,11 @@ jobs:
       image_name: ${{ steps.parse-tag.outputs.image_name }}
       version: ${{ steps.parse-tag.outputs.version }}
     steps:
-      - uses: ethereum-optimism/factory/actions/parse-tag@f8f3cb4800e538003134fb5f50cc734c2c98d762
+      - uses: ethereum-optimism/factory/actions/parse-tag@cc1794a8e99695971560f5354076fbe2ddca9f2e
         id: parse-tag
   tag:
     needs: prep
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
     with:
       image_name: ${{ needs.prep.outputs.image_name }}
       context: .


### PR DESCRIPTION
## Summary

- Bumps all `ethereum-optimism/factory` workflow and action references to `cc1794a8e99695971560f5354076fbe2ddca9f2e`
- Picks up Node.js 24 compatible action updates ahead of the June 2 deprecation deadline

## Test plan

- [ ] CI passes on this PR (branch build workflow runs successfully)
- [ ] Tag build workflow syntax is valid