### PR TITLE
proxyd: cap latest at cross-unsafe block

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -23,6 +23,7 @@ import (
 	supervisorBackend "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend"
 	supervisorTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/gorilla/websocket"
@@ -1000,6 +1001,8 @@ type BackendGroup struct {
 	routingStrategy        RoutingStrategy
 	multicallRPCErrorCheck bool
 	maxBlockRange          uint64
+	crossUnsafeLatest      *CrossUnsafeLatestPoller
+	crossUnsafeBypassAuth  *StringSet
 }
 
 func (bg *BackendGroup) GetRoutingStrategy() RoutingStrategy {
@@ -1042,7 +1045,7 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 	// serving traffic from any backend that agrees in the consensus group
 	// We also rewrite block tags to enforce compliance with consensus
 	if bg.Consensus != nil {
-		rpcReqs, overriddenResponses = bg.OverwriteConsensusResponses(rpcReqs, overriddenResponses, rewrittenReqs)
+		rpcReqs, overriddenResponses = bg.OverwriteConsensusResponses(ctx, rpcReqs, overriddenResponses, rewrittenReqs)
 	} else if bg.maxBlockRange > 0 {
 		rpcReqs, overriddenResponses = bg.OverwriteNonConsensusRequests(rpcReqs, overriddenResponses)
 	}
@@ -1333,6 +1336,9 @@ func (bg *BackendGroup) loadBalancedConsensusGroup() []*Backend {
 func (bg *BackendGroup) Shutdown() {
 	if bg.Consensus != nil {
 		bg.Consensus.Shutdown()
+	}
+	if bg.crossUnsafeLatest != nil {
+		bg.crossUnsafeLatest.Shutdown()
 	}
 }
 
@@ -1780,9 +1786,20 @@ func OverrideResponses(res []*RPCRes, overriddenResponses []*indexedReqRes) []*R
 	return res
 }
 
-func (bg *BackendGroup) OverwriteConsensusResponses(rpcReqs []*RPCReq, overriddenResponses []*indexedReqRes, rewrittenReqs []*RPCReq) ([]*RPCReq, []*indexedReqRes) {
+func (bg *BackendGroup) OverwriteConsensusResponses(ctx context.Context, rpcReqs []*RPCReq, overriddenResponses []*indexedReqRes, rewrittenReqs []*RPCReq) ([]*RPCReq, []*indexedReqRes) {
+	latest := bg.Consensus.GetLatestBlockNumber()
+	if bg.crossUnsafeLatest != nil && !bg.bypassesCrossUnsafeLatest(ctx) {
+		if block, ok := bg.crossUnsafeLatest.LatestBlock(); ok {
+			if block.Number < uint64(latest) {
+				latest = hexutil.Uint64(block.Number)
+			}
+		} else {
+			latest = 0
+		}
+	}
+
 	rctx := RewriteContext{
-		latest:         bg.Consensus.GetLatestBlockNumber(),
+		latest:         latest,
 		safe:           bg.Consensus.GetSafeBlockNumber(),
 		finalized:      bg.Consensus.GetFinalizedBlockNumber(),
 		maxBlockRange:  bg.Consensus.maxBlockRange,
@@ -1874,6 +1891,13 @@ func (bg *BackendGroup) OverwriteConsensusResponses(rpcReqs []*RPCReq, overridde
 		}
 	}
 	return rewrittenReqs, overriddenResponses
+}
+
+func (bg *BackendGroup) bypassesCrossUnsafeLatest(ctx context.Context) bool {
+	if bg.crossUnsafeBypassAuth == nil {
+		return false
+	}
+	return bg.crossUnsafeBypassAuth.Has(GetAuthCtx(ctx))
 }
 
 func (bg *BackendGroup) OverwriteNonConsensusRequests(rpcReqs []*RPCReq, overriddenResponses []*indexedReqRes) ([]*RPCReq, []*indexedReqRes) {

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -2,12 +2,16 @@ package proxyd
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,6 +31,79 @@ func TestStripXFF(t *testing.T) {
 		actual := stripXFF(test.in)
 		assert.Equal(t, test.out, actual)
 	}
+}
+
+func TestOverwriteConsensusResponsesCrossUnsafeLatestCap(t *testing.T) {
+	tracker := NewInMemoryConsensusTracker()
+	tracker.SetState(ConsensusTrackerState{
+		Latest:    hexutil.Uint64(100),
+		Safe:      hexutil.Uint64(90),
+		Finalized: hexutil.Uint64(80),
+	})
+	cap := NewCrossUnsafeLatestPoller(nil, 900, time.Second)
+	cap.SetLatestBlock(eth.BlockID{Hash: common.HexToHash("0x01"), Number: 95})
+
+	bg := &BackendGroup{
+		Consensus:         &ConsensusPoller{tracker: tracker},
+		crossUnsafeLatest: cap,
+	}
+
+	t.Run("eth_blockNumber uses cross-unsafe cap", func(t *testing.T) {
+		req := &RPCReq{
+			JSONRPC: JSONRPCVersion,
+			Method:  "eth_blockNumber",
+			ID:      json.RawMessage("1"),
+		}
+		rewritten, overridden := bg.OverwriteConsensusResponses(context.Background(), []*RPCReq{req}, nil, nil)
+
+		require.Empty(t, rewritten)
+		require.Len(t, overridden, 1)
+		require.Equal(t, hexutil.Uint64(95), overridden[0].res.Result)
+	})
+
+	t.Run("latest tag uses cross-unsafe cap", func(t *testing.T) {
+		req := &RPCReq{
+			JSONRPC: JSONRPCVersion,
+			Method:  "eth_getBlockByNumber",
+			Params:  mustMarshalJSON([]interface{}{"latest", false}),
+			ID:      json.RawMessage("1"),
+		}
+		rewritten, overridden := bg.OverwriteConsensusResponses(context.Background(), []*RPCReq{req}, nil, nil)
+
+		require.Empty(t, overridden)
+		require.Len(t, rewritten, 1)
+		require.JSONEq(t, `["0x5f",false]`, string(req.Params))
+	})
+
+	t.Run("missing cap fails closed", func(t *testing.T) {
+		bg.crossUnsafeLatest = NewCrossUnsafeLatestPoller(nil, 900, time.Second)
+		req := &RPCReq{
+			JSONRPC: JSONRPCVersion,
+			Method:  "eth_blockNumber",
+			ID:      json.RawMessage("1"),
+		}
+		rewritten, overridden := bg.OverwriteConsensusResponses(context.Background(), []*RPCReq{req}, nil, nil)
+
+		require.Empty(t, rewritten)
+		require.Len(t, overridden, 1)
+		require.Equal(t, hexutil.Uint64(0), overridden[0].res.Result)
+	})
+
+	t.Run("bypass auth uses consensus latest", func(t *testing.T) {
+		bg.crossUnsafeLatest = cap
+		bg.crossUnsafeBypassAuth = NewStringSetFromStrings([]string{"interop-filter"})
+		ctx := context.WithValue(context.Background(), ContextKeyAuth, "interop-filter") // nolint:staticcheck
+		req := &RPCReq{
+			JSONRPC: JSONRPCVersion,
+			Method:  "eth_blockNumber",
+			ID:      json.RawMessage("1"),
+		}
+		rewritten, overridden := bg.OverwriteConsensusResponses(ctx, []*RPCReq{req}, nil, nil)
+
+		require.Empty(t, rewritten)
+		require.Len(t, overridden, 1)
+		require.Equal(t, hexutil.Uint64(100), overridden[0].res.Result)
+	})
 }
 
 func TestLimitedHTTPClientDoLimited(t *testing.T) {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -281,6 +281,9 @@ type InteropValidationConfig struct {
 	LoadBalancingUnhealthinessTimeout time.Duration             `toml:"load_balancing_unhealthiness_timeout"`
 	ReqSizeLimit                      int                       `toml:"req_size_limit"`
 	AccessListSizeLimit               int                       `toml:"access_list_size_limit"`
+	EnforceCrossUnsafeLatest          bool                      `toml:"enforce_cross_unsafe_latest"`
+	CrossUnsafeLatestPollInterval     TOMLDuration              `toml:"cross_unsafe_latest_poll_interval"`
+	CrossUnsafeLatestBypassAuth       []string                  `toml:"cross_unsafe_latest_bypass_auth"`
 	RateLimit                         SenderRateLimitConfig     `toml:"sender_rate_limit"`
 }
 

--- a/proxyd/cross_unsafe_latest.go
+++ b/proxyd/cross_unsafe_latest.go
@@ -1,0 +1,123 @@
+package proxyd
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// CrossUnsafeLatestPoller tracks the latest block accepted by op-interop-filter's
+// cross-unsafe validation.
+type CrossUnsafeLatestPoller struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	urls     []string
+	chainID  eth.ChainID
+	interval time.Duration
+
+	latest atomic.Uint64
+	hash   atomic.Value
+	ok     atomic.Bool
+}
+
+func NewCrossUnsafeLatestPoller(urls []string, chainID uint64, interval time.Duration) *CrossUnsafeLatestPoller {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &CrossUnsafeLatestPoller{
+		ctx:      ctx,
+		cancel:   cancel,
+		urls:     urls,
+		chainID:  eth.ChainIDFromUInt64(chainID),
+		interval: interval,
+	}
+}
+
+func (p *CrossUnsafeLatestPoller) Start() {
+	if p.interval <= 0 {
+		p.interval = DefaultPollerInterval
+	}
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		p.poll(p.ctx)
+
+		timer := time.NewTimer(p.interval)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				p.poll(p.ctx)
+				timer.Reset(p.interval)
+			case <-p.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (p *CrossUnsafeLatestPoller) Shutdown() {
+	p.cancel()
+	p.wg.Wait()
+}
+
+func (p *CrossUnsafeLatestPoller) LatestBlock() (eth.BlockID, bool) {
+	if !p.ok.Load() {
+		return eth.BlockID{}, false
+	}
+	hash, _ := p.hash.Load().(common.Hash)
+	return eth.BlockID{
+		Hash:   hash,
+		Number: p.latest.Load(),
+	}, true
+}
+
+func (p *CrossUnsafeLatestPoller) SetLatestBlock(block eth.BlockID) {
+	p.latest.Store(block.Number)
+	p.hash.Store(block.Hash)
+	p.ok.Store(true)
+}
+
+func (p *CrossUnsafeLatestPoller) poll(ctx context.Context) {
+	var min eth.BlockID
+	found := false
+	for _, url := range p.urls {
+		block, err := p.fetchLatestCrossUnsafeBlock(ctx, url)
+		if err != nil {
+			log.Warn("failed to fetch latest cross-unsafe block", "url", url, "chain_id", p.chainID, "err", err)
+			continue
+		}
+		if !found || block.Number < min.Number {
+			min = block
+			found = true
+		}
+	}
+	if !found {
+		return
+	}
+
+	p.SetLatestBlock(min)
+	log.Debug("updated latest cross-unsafe block", "chain_id", p.chainID, "block", min)
+}
+
+func (p *CrossUnsafeLatestPoller) fetchLatestCrossUnsafeBlock(ctx context.Context, url string) (eth.BlockID, error) {
+	cl, err := rpc.DialContext(ctx, url)
+	if err != nil {
+		return eth.BlockID{}, fmt.Errorf("dial interop filter: %w", err)
+	}
+	defer cl.Close()
+
+	var block eth.BlockID
+	if err := cl.CallContext(ctx, &block, "supervisor_getLatestCrossUnsafeBlock", p.chainID); err != nil {
+		return eth.BlockID{}, err
+	}
+	return block, nil
+}

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -320,6 +320,18 @@ func Start(config *Config) (*Server, func(), error) {
 		config.InteropValidationConfig.AccessListSizeLimit = defaultInteropAccessListSizeLimit
 	}
 
+	if config.InteropValidationConfig.EnforceCrossUnsafeLatest {
+		if len(config.InteropValidationConfig.Urls) == 0 {
+			return nil, nil, errors.New("interop_validation.enforce_cross_unsafe_latest is enabled but no urls are configured")
+		}
+		if config.InteropValidationConfig.ChainID == 0 {
+			return nil, nil, errors.New("interop_validation.enforce_cross_unsafe_latest is enabled but chain_id is not configured")
+		}
+		if config.InteropValidationConfig.CrossUnsafeLatestPollInterval == 0 {
+			config.InteropValidationConfig.CrossUnsafeLatestPollInterval = TOMLDuration(DefaultPollerInterval)
+		}
+	}
+
 	log.Info("configured interop validation urls", "urls", config.InteropValidationConfig.Urls)
 	log.Info("configured interop validation strategy", "strategy", config.InteropValidationConfig.Strategy)
 
@@ -376,6 +388,7 @@ func Start(config *Config) (*Server, func(), error) {
 			routingStrategy:        bg.RoutingStrategy,
 			multicallRPCErrorCheck: bg.MulticallRPCErrorCheck,
 			maxBlockRange:          maxBlockRange,
+			crossUnsafeBypassAuth:  NewStringSetFromStrings(config.InteropValidationConfig.CrossUnsafeLatestBypassAuth),
 		}
 	}
 
@@ -512,6 +525,17 @@ func Start(config *Config) (*Server, func(), error) {
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)
+	}
+
+	if config.InteropValidationConfig.EnforceCrossUnsafeLatest {
+		for _, bg := range backendGroups {
+			bg.crossUnsafeLatest = NewCrossUnsafeLatestPoller(
+				config.InteropValidationConfig.Urls,
+				config.InteropValidationConfig.ChainID,
+				time.Duration(config.InteropValidationConfig.CrossUnsafeLatestPollInterval),
+			)
+			bg.crossUnsafeLatest.Start()
+		}
 	}
 
 	// Enable to support browser websocket connections.


### PR DESCRIPTION
## Summary

Adds an opt-in proxyd interop validation setting that polls `supervisor_getLatestCrossUnsafeBlock(chain_id)` and caps consensus `latest` rewrites to the returned block number. When enabled but no cap has been fetched yet, proxyd fails closed by using block 0 rather than falling back to EL latest.

Also adds an authenticated bypass list so trusted internal callers, like op-interop-filter ingestion, can use a dedicated proxyd auth alias and avoid the circular dependency where the filter needs uncapped blocks to advance the cap.

## Motivation

This lets proxyd avoid serving unsafe-chain blocks beyond the latest block that op-interop-filter has cross-unsafe validated, while still allowing the filter itself to ingest from proxyd.

## Validation

- `go test ./...` from `proxyd/`

## Dependency

Depends on the op-interop-filter RPC endpoint from the companion monorepo PR.