### PR TITLE
feat(proxyd): consensus-gated /readyz and idle graceful shutdown

### DIFF
--- a/proxyd/Dockerfile
+++ b/proxyd/Dockerfile
@@ -9,7 +9,7 @@ ARG GITVERSION=docker
 
 RUN apk add make jq git gcc musl-dev linux-headers
 
-COPY ./ /app
+COPY ./proxyd /app
 
 WORKDIR /app
 

--- a/proxyd/Dockerfile
+++ b/proxyd/Dockerfile
@@ -9,7 +9,7 @@ ARG GITVERSION=docker
 
 RUN apk add make jq git gcc musl-dev linux-headers
 
-COPY ./proxyd /app
+COPY ./ /app
 
 WORKDIR /app
 

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -140,6 +140,8 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 		nil,                                    // limExemptKeys
 		TxValidationMiddlewareConfig{},         // txValidationConfig
 		10*time.Second,                         // gracefulShutdownDuration
+		false,                                  // gracefulShutdownIdle
+		10*time.Second,                         // gracefulShutdownIdleDuration
 	)
 	require.NoError(t, err)
 

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -37,6 +37,14 @@ type ServerConfig struct {
 	// GracefulShutdownSeconds is the duration to wait during drain before shutting down.
 	// Defaults to 0 (no drain delay). Set to a positive value to enable graceful drain.
 	GracefulShutdownSeconds int `toml:"graceful_shutdown_seconds"`
+
+	// GracefulShutdownIdle, when true, replaces the drain-then-sleep shutdown
+	// behaviour with an idle-based one: on shutdown signal /readyz starts
+	// returning 503 (so k8s removes the pod from the Service), but the RPC
+	// and WS endpoints keep serving. The process exits only after no
+	// non-healthcheck request has been received for GracefulShutdownIdleSeconds.
+	GracefulShutdownIdle        bool `toml:"graceful_shutdown_idle"`
+	GracefulShutdownIdleSeconds int  `toml:"graceful_shutdown_idle_seconds"`
 }
 
 type CacheConfig struct {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -509,6 +509,8 @@ func Start(config *Config) (*Server, func(), error) {
 		apiKeys,
 		config.TxValidationMiddlewareConfig,
 		time.Duration(config.Server.GracefulShutdownSeconds)*time.Second,
+		config.Server.GracefulShutdownIdle,
+		gracefulShutdownIdleDuration(config.Server.GracefulShutdownIdleSeconds),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)
@@ -687,6 +689,13 @@ func Start(config *Config) (*Server, func(), error) {
 	}
 
 	return srv, shutdownFunc, nil
+}
+
+func gracefulShutdownIdleDuration(seconds int) time.Duration {
+	if seconds <= 0 {
+		return 10 * time.Second
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 func validateReceiptsTarget(val string) (string, error) {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -92,14 +92,18 @@ type Server struct {
 	publicAccess            bool
 	enableTxHashLogging     bool
 
-	enableTxValidation       bool
-	txValidationFn           TxValidationFunc
-	txValidationEndpoint     string
-	txValidationMethods      TxValidationMethodSet
-	txValidationClient       *TxValidationClient
-	txValidationFailOpen     bool
-	isDraining               atomic.Bool
-	gracefulShutdownDuration time.Duration
+	enableTxValidation           bool
+	txValidationFn               TxValidationFunc
+	txValidationEndpoint         string
+	txValidationMethods          TxValidationMethodSet
+	txValidationClient           *TxValidationClient
+	txValidationFailOpen         bool
+	isDraining                   atomic.Bool
+	gracefulShutdownDuration     time.Duration
+	gracefulShutdownIdle         bool
+	gracefulShutdownIdleDuration time.Duration
+	isShuttingDown               atomic.Bool
+	lastRequestNanos             atomic.Int64
 }
 
 type limiterFunc func(method string) bool
@@ -131,6 +135,8 @@ func NewServer(
 	limExemptKeys []string,
 	txValidationConfig TxValidationMiddlewareConfig,
 	gracefulShutdownDuration time.Duration,
+	gracefulShutdownIdle bool,
+	gracefulShutdownIdleDuration time.Duration,
 ) (*Server, error) {
 	if cache == nil {
 		cache = &NoopRPCCache{}
@@ -221,7 +227,7 @@ func NewServer(
 		txValidationFailOpen = *txValidationConfig.FailOpen
 	}
 
-	return &Server{
+	srv := &Server{
 		BackendGroups:        backendGroups,
 		wsBackendGroup:       wsBackendGroup,
 		wsMethodWhitelist:    wsMethodWhitelist,
@@ -239,27 +245,31 @@ func NewServer(
 		upgrader: &websocket.Upgrader{
 			HandshakeTimeout: defaultWSHandshakeTimeout,
 		},
-		mainLim:                  mainLim,
-		overrideLims:             overrideLims,
-		globallyLimitedMethods:   globalMethodLims,
-		senderLim:                senderLim,
-		interopSenderLim:         interopSenderLim,
-		allowedChainIds:          senderRateLimitConfig.AllowedChainIds,
-		limExemptOrigins:         limExemptOrigins,
-		limExemptUserAgents:      limExemptUserAgents,
-		limExemptKeys:            limExemptKeys,
-		rateLimitHeader:          rateLimitHeader,
-		interopValidatingConfig:  interopValidatingConfig,
-		interopStrategy:          interopStrategy,
-		enableTxHashLogging:      enableTxHashLogging,
-		enableTxValidation:       txValidationConfig.Enabled,
-		txValidationFn:           txValidationClient.Validate,
-		txValidationEndpoint:     txValidationConfig.Endpoint,
-		txValidationMethods:      txValidationMethods,
-		txValidationClient:       txValidationClient,
-		txValidationFailOpen:     txValidationFailOpen,
-		gracefulShutdownDuration: gracefulShutdownDuration,
-	}, nil
+		mainLim:                      mainLim,
+		overrideLims:                 overrideLims,
+		globallyLimitedMethods:       globalMethodLims,
+		senderLim:                    senderLim,
+		interopSenderLim:             interopSenderLim,
+		allowedChainIds:              senderRateLimitConfig.AllowedChainIds,
+		limExemptOrigins:             limExemptOrigins,
+		limExemptUserAgents:          limExemptUserAgents,
+		limExemptKeys:                limExemptKeys,
+		rateLimitHeader:              rateLimitHeader,
+		interopValidatingConfig:      interopValidatingConfig,
+		interopStrategy:              interopStrategy,
+		enableTxHashLogging:          enableTxHashLogging,
+		enableTxValidation:           txValidationConfig.Enabled,
+		txValidationFn:               txValidationClient.Validate,
+		txValidationEndpoint:         txValidationConfig.Endpoint,
+		txValidationMethods:          txValidationMethods,
+		txValidationClient:           txValidationClient,
+		txValidationFailOpen:         txValidationFailOpen,
+		gracefulShutdownDuration:     gracefulShutdownDuration,
+		gracefulShutdownIdle:         gracefulShutdownIdle,
+		gracefulShutdownIdleDuration: gracefulShutdownIdleDuration,
+	}
+	srv.lastRequestNanos.Store(time.Now().UnixNano())
+	return srv, nil
 }
 
 func (s *Server) RPCListenAndServe(host string, port int) error {
@@ -301,6 +311,21 @@ func (s *Server) WSListenAndServe(host string, port int) error {
 }
 
 func (s *Server) Drain() {
+	if s.gracefulShutdownIdle {
+		s.isShuttingDown.Store(true)
+		log.Info("graceful shutdown: waiting for idle window",
+			"idle", s.gracefulShutdownIdleDuration)
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			last := time.Unix(0, s.lastRequestNanos.Load())
+			if time.Since(last) >= s.gracefulShutdownIdleDuration {
+				log.Info("graceful shutdown: idle window elapsed, shutting down")
+				return
+			}
+		}
+		return
+	}
 	s.isDraining.Store(true)
 	time.Sleep(s.gracefulShutdownDuration)
 }
@@ -328,7 +353,7 @@ func (s *Server) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) HandleReadyz(w http.ResponseWriter, r *http.Request) {
-	if s.isDraining.Load() {
+	if s.isDraining.Load() || s.isShuttingDown.Load() {
 		http.Error(w, "Server is draining", http.StatusServiceUnavailable)
 		return
 	}
@@ -345,6 +370,8 @@ func (s *Server) HandleReadyz(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
+	s.lastRequestNanos.Store(time.Now().UnixNano())
+
 	ctx := s.populateContext(w, r)
 	if ctx == nil {
 		return
@@ -800,6 +827,8 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 }
 
 func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
+	s.lastRequestNanos.Store(time.Now().UnixNano())
+
 	ctx := s.populateContext(w, r)
 	if ctx == nil {
 		return

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -266,6 +266,7 @@ func (s *Server) RPCListenAndServe(host string, port int) error {
 	s.srvMu.Lock()
 	hdlr := mux.NewRouter()
 	hdlr.HandleFunc("/healthz", s.HandleHealthz).Methods("GET")
+	hdlr.HandleFunc("/readyz", s.HandleReadyz).Methods("GET")
 	hdlr.HandleFunc("/", s.HandleRPC).Methods("POST")
 	hdlr.HandleFunc("/{authorization}", s.HandleRPC).Methods("POST")
 	c := cors.New(cors.Options{
@@ -322,6 +323,23 @@ func (s *Server) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 	if s.isDraining.Load() {
 		http.Error(w, "Server is draining", http.StatusServiceUnavailable)
 		return
+	}
+	_, _ = w.Write([]byte("OK"))
+}
+
+func (s *Server) HandleReadyz(w http.ResponseWriter, r *http.Request) {
+	if s.isDraining.Load() {
+		http.Error(w, "Server is draining", http.StatusServiceUnavailable)
+		return
+	}
+	for name, bg := range s.BackendGroups {
+		if bg.Consensus == nil {
+			continue
+		}
+		if len(bg.Consensus.GetConsensusGroup()) == 0 || bg.Consensus.GetLatestBlockNumber() == 0 {
+			http.Error(w, fmt.Sprintf("consensus not ready: %s", name), http.StatusServiceUnavailable)
+			return
+		}
 	}
 	_, _ = w.Write([]byte("OK"))
 }

--- a/proxyd/server_test.go
+++ b/proxyd/server_test.go
@@ -3,9 +3,11 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
+	"net/http/httptest"
 	"os"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,6 +95,84 @@ func TestIsValidAPIKey(t *testing.T) {
 			if got != tt.expected {
 				t.Errorf("isValidAPIKey() = %v, want %v: %s", got, tt.expected, tt.description)
 			}
+		})
+	}
+}
+
+func TestHandleReadyz(t *testing.T) {
+	newConsensusGroup := func(members int, latest hexutil.Uint64) *BackendGroup {
+		bg := &BackendGroup{}
+		cg := make([]*Backend, members)
+		for i := range cg {
+			cg[i] = &Backend{}
+		}
+		tracker := NewInMemoryConsensusTracker()
+		tracker.SetState(ConsensusTrackerState{Latest: latest})
+		bg.Consensus = &ConsensusPoller{
+			backendGroup:   bg,
+			consensusGroup: cg,
+			tracker:        tracker,
+		}
+		return bg
+	}
+
+	tests := []struct {
+		name     string
+		draining bool
+		groups   map[string]*BackendGroup
+		want     int
+	}{
+		{
+			name:     "draining returns 503",
+			draining: true,
+			groups:   map[string]*BackendGroup{"main": newConsensusGroup(2, 100)},
+			want:     503,
+		},
+		{
+			name:   "no backend groups returns 200",
+			groups: map[string]*BackendGroup{},
+			want:   200,
+		},
+		{
+			name:   "group without consensus is skipped",
+			groups: map[string]*BackendGroup{"main": {}},
+			want:   200,
+		},
+		{
+			name:   "empty consensus group returns 503",
+			groups: map[string]*BackendGroup{"main": newConsensusGroup(0, 100)},
+			want:   503,
+		},
+		{
+			name:   "consensus group with latest=0 returns 503",
+			groups: map[string]*BackendGroup{"main": newConsensusGroup(2, 0)},
+			want:   503,
+		},
+		{
+			name:   "ready consensus group returns 200",
+			groups: map[string]*BackendGroup{"main": newConsensusGroup(2, 100)},
+			want:   200,
+		},
+		{
+			name: "any unready group fails the gate",
+			groups: map[string]*BackendGroup{
+				"main":  newConsensusGroup(2, 100),
+				"other": newConsensusGroup(0, 100),
+			},
+			want: 503,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{BackendGroups: tt.groups}
+			s.isDraining.Store(tt.draining)
+
+			req := httptest.NewRequest("GET", "/readyz", nil)
+			rec := httptest.NewRecorder()
+			s.HandleReadyz(rec, req)
+
+			require.Equal(t, tt.want, rec.Code)
 		})
 	}
 }


### PR DESCRIPTION
**Description**

Two related changes that together let Kubernetes drive proxyd's startup and shutdown cleanly without dropping requests on either end.

### 1. Split `/healthz` and add `/readyz`

`/healthz` is unchanged — it returns 503 only when the server is draining, suitable for liveness probes (won't restart the pod on transient upstream/consensus flaps).

A new `/readyz` endpoint is added for readiness probes. It returns 503 when:

- the server is draining or shutting down, **or**
- any consensus-aware backend group has an empty consensus group / `Latest == 0`.

Otherwise it returns 200. Backend groups without consensus enabled are skipped, so `/readyz` behaves identically to `/healthz` for non-consensus deployments and is safe to wire unconditionally.

### 2. Idle-based graceful shutdown mode

Adds an opt-in graceful shutdown mode that swaps the existing "drain everything immediately" behaviour for an idle-based one. Behind a config flag; default behaviour is unchanged.

When enabled (`graceful_shutdown_idle = true`), on shutdown signal proxyd will:

1. Flip `/readyz` to 503 (so Kubernetes removes the pod from Service endpoints).
2. Keep `/healthz` returning 200 (so the kubelet does not restart the pod mid-shutdown).
3. **Continue serving** RPC and WebSocket requests normally — no 503 injection on `/` or `/{authorization}`.
4. Wait until no non-healthcheck request has been received for `graceful_shutdown_idle_seconds` (default `10`).
5. Only then close the listeners and exit.

This lets in-flight clients finish naturally instead of seeing a wall of 503s the moment a pod starts terminating, while still giving k8s a clean signal to stop sending new traffic. Existing `/{authorization}` paths bump the idle timer the same way unauthenticated `/` requests do — both go through the same `HandleRPC`/`HandleWS` entry point.

New config (in `[server]`):

```toml
graceful_shutdown_idle = true
graceful_shutdown_idle_seconds = 10  # default if omitted
```

Suggested k8s probe wiring

```yaml
livenessProbe:
  httpGet: { path: /healthz, port: <rpc_port> }
  periodSeconds: 10
  failureThreshold: 3
readinessProbe:
  httpGet: { path: /readyz, port: <rpc_port> }
  periodSeconds: 2
  failureThreshold: 2
```

### Implementation notes

- New `HandleReadyz` in `proxyd/server.go`: iterates `BackendGroups` and 503s if any consensus-aware group has `len(GetConsensusGroup()) == 0` or `GetLatestBlockNumber() == 0`. Also 503s on `isDraining` or `isShuttingDown`.
- New `Server` fields: `gracefulShutdownIdle bool`, `gracefulShutdownIdleDuration time.Duration`, `isShuttingDown atomic.Bool`, `lastRequestNanos atomic.Int64`.
- `HandleRPC` and `HandleWS` bump `lastRequestNanos` at handler entry, before any auth/rate-limit work, so retries still keep the pod alive (matches the "is anyone still using me" semantics).
- `Drain()` branches on the flag: legacy path is untouched (sets `isDraining`, sleeps `graceful_shutdown_seconds`); idle path sets `isShuttingDown` only, ticks every 1s, and returns when `time.Since(lastRequest) >= idleDuration`.
- WebSocket caveat: the idle timer is bumped on connection upgrade, not per-message. A long-lived subscription with no new connects after SIGTERM will not extend the idle window. The legacy `Drain()` already closes WS abruptly, so this is not a regression — calling it out so reviewers are aware.

**Tests**

Added `TestHandleReadyz` in `proxyd/server_test.go`: a table-driven unit test covering the gate logic — drain, no backend groups, group without consensus enabled, empty consensus group, `Latest == 0`, ready group, and the multi-group case where any unready group fails the gate. Constructs `*ConsensusPoller` directly with an in-memory tracker, no real backends or goroutines required.

The new idle-shutdown path is not covered by a dedicated unit test — it is intrinsically time-dependent (ticker + `time.Since` against `lastRequestNanos`), and a faithful test would either need a fake clock injected into `Drain()` or a real-time wait, neither of which feels worth it for the size of the change. Manually verified end-to-end against a HA deployment (Redis-backed consensus tracker + Redis cache, multiple replicas):

- `/readyz` returns 503 during cold start and flips to 200 once the first consensus cycle completes; `/healthz` stays 200 throughout.
- `/readyz` returns 200 on a deployment with no consensus-aware backend groups.
- Killing a backend so the consensus group empties flips `/readyz` back to 503 while `/healthz` remains 200.
- With `graceful_shutdown_idle = true` and no traffic, `Drain()` returns after ~`idle_seconds` from start.
- Sending a request every second keeps `Drain()` blocked; stopping traffic causes it to exit ~`idle_seconds` later.
- During the idle wait, `/readyz` returns 503 while `/healthz` and `/` keep returning 200.
- With the flag off, shutdown behaviour is byte-identical to before (sleep for `graceful_shutdown_seconds`, then shut down).

Happy to add a fake-clock unit test for `Drain()` if reviewers want one.

**Additional context**

Two motivating problems, both observed on rollouts of a HA proxyd deployment (Redis-backed consensus tracker + Redis cache):

1. **Cold-start error storm.** proxyd starts accepting RPC traffic before backend probes have completed (`probe_success_threshold` defaults to 2 → ~8s minimum), before the consensus poller has run its first cycle (so `GetConsensusGroup()` is empty and `tracker.Latest == 0`), and before the HA leader has been elected (`stateHeartbeat()` skips lock acquisition while local state is invalid). During this window the cache is also cold, so every request becomes a miss that cascades into `BackendGroup.Forward()` and either returns `ErrNoBackends` or, in CL mode, `ErrCLConsensusSyncNotReady` (-32025). The result is a noisy spike of 5xx responses on every cold start. A k8s readiness probe is the standard fix: a 503 on `/readyz` keeps the pod out of the Service endpoints until consensus is ready, so the cold-start error storm never reaches clients. We deliberately did not overload `/healthz` for this — consensus state is allowed to flap during normal operation, and failing liveness on a transient consensus break would cause k8s to kill an otherwise-healthy proxyd.

2. **Shutdown error storm.** As soon as `Drain()` is called today, every RPC request gets a 503 for the full `graceful_shutdown_seconds` window — even though those requests could have been served correctly. K8s already handles "stop sending new traffic" via the readiness probe (now that `/readyz` exists); we don't need proxyd to also reject in-flight requests to achieve a clean rollout. The new mode delegates the "stop traffic" job to k8s and uses the idle window purely as a "is anyone still using me" check before exit.

The two changes are intentionally bundled because the idle-shutdown mode is only safe with the new `/readyz` endpoint: without a separate readiness signal, k8s would have no way to know it should stop sending traffic to a pod that is still happily serving on `/`.