### PR TITLE
fix(cci-stats): nil-check Vcs before branch pattern match

### DIFF
--- a/cci-stats/pkg/service/service.go
+++ b/cci-stats/pkg/service/service.go
@@ -206,7 +206,7 @@ func fetchPipelines(ctx context.Context, config config.Config, cutoff time.Time,
 
 		var done bool
 		for _, p := range pipelines.Items {
-			if !config.BranchPatternRegex.MatchString(p.Vcs.Branch) {
+			if p.Vcs == nil || !config.BranchPatternRegex.MatchString(p.Vcs.Branch) {
 				continue
 			}
 			if p.CreatedAt.Before(cutoff) {


### PR DESCRIPTION
## Summary

- `Pipeline.Vcs` is a `*VCS` pointer in the go-circleci library; CircleCI returns `null` for `vcs` on API-triggered and scheduled pipelines
- Without a nil guard, `fetchPipelines` dereferenced `p.Vcs.Branch` on such pipelines, causing a `SIGSEGV` (nil pointer dereference at `service.go:209`)
- Added a `p.Vcs == nil` check so pipelines without VCS info are skipped — they have no branch to match against anyway

## Root cause identification

Two signals in the logs pointed directly to the cause:

1. **`[signal SIGSEGV: segmentation violation code=0x1 addr=0x20]`** — the fault address `0x20` (32 bytes) is not a random address; it is the memory offset of the `Branch` field within the `VCS` struct. When `p.Vcs` is a nil pointer, reading `p.Vcs.Branch` computes `nil + 0x20`, which the runtime rejects as an invalid dereference. This made it immediately clear the pointer receiver was nil, not some deeper heap corruption.

2. **The last successful log line** — `fetched pipelines count=20 last=2026-05-12T19:35:13.197Z` appeared just before the crash. The service had already fetched a page of pipelines and was iterating through them when it hit the panic, confirming the crash occurred during the per-pipeline branch-filter loop rather than during network I/O.

Together these narrowed the fault to the single `p.Vcs.Branch` access at `service.go:209` with no other candidate nil dereferences in that code path.

## Test plan

- [ ] Verify cci-stats runs without panic against a project that has API-triggered or scheduled pipelines
- [ ] Confirm branch-filtered pipelines continue to be ingested correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)