### PR TITLE
refactor(proxyd): bundle CL sync body into ConsensusTrackerState

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@1.3.0
+  path-filtering: circleci/path-filtering@3.0.0
 
 workflows:
   check-updated-files:

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -56,12 +56,6 @@ type ConsensusPoller struct {
 	clHeadL1MaxAge           time.Duration
 	clOutputRootBanThreshold uint
 
-	// Pin-backend cache for optimism_syncStatus (CL mode only).
-	// selectConsensusSyncStatusBody selects the pin backend after each consensus
-	// cycle and stores its full response body here for serving.
-	syncStatusBodyMu  sync.RWMutex
-	consensusSyncBody json.RawMessage // served response body for optimism_syncStatus
-	lastServedCLL1Num uint64          // monotonicity floor for pin selection
 }
 
 type backendState struct {

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -55,7 +55,6 @@ type ConsensusPoller struct {
 	clSyncThreshold          uint64
 	clHeadL1MaxAge           time.Duration
 	clOutputRootBanThreshold uint
-
 }
 
 type backendState struct {

--- a/proxyd/consensus_poller_cl.go
+++ b/proxyd/consensus_poller_cl.go
@@ -174,15 +174,13 @@ func (cp *ConsensusPoller) validateCLBackendUpdate(be *Backend, safeBlockNumber,
 // GetConsensusSyncStatusBody returns the cached optimism_syncStatus response body
 // from the current pin backend. Returns nil if no poll cycle has completed yet.
 func (cp *ConsensusPoller) GetConsensusSyncStatusBody() json.RawMessage {
-	cp.syncStatusBodyMu.RLock()
-	defer cp.syncStatusBodyMu.RUnlock()
-	return cp.consensusSyncBody
+	body, _ := cp.tracker.GetCLSyncBody()
+	return body
 }
 
 // selectConsensusSyncStatusBody selects the consensus-group backend with the lowest
 // current_l1.number (subject to a monotonicity floor) and caches its full
-// optimism_syncStatus response body. This ensures the served response is internally
-// consistent — all fields come from one backend snapshot, not a mix of backends.
+// optimism_syncStatus response body via the tracker.
 func (cp *ConsensusPoller) selectConsensusSyncStatusBody(consensusGroup []*Backend) {
 	type pinCandidate struct {
 		be   *Backend
@@ -192,9 +190,7 @@ func (cp *ConsensusPoller) selectConsensusSyncStatusBody(consensusGroup []*Backe
 	var pin *pinCandidate
 	lowestL1 := uint64(math.MaxUint64)
 
-	cp.syncStatusBodyMu.RLock()
-	floor := cp.lastServedCLL1Num
-	cp.syncStatusBodyMu.RUnlock()
+	_, floor := cp.tracker.GetCLSyncBody()
 
 	for _, be := range consensusGroup {
 		bs := cp.backendState[be]
@@ -218,10 +214,7 @@ func (cp *ConsensusPoller) selectConsensusSyncStatusBody(consensusGroup []*Backe
 		return
 	}
 
-	cp.syncStatusBodyMu.Lock()
-	cp.consensusSyncBody = pin.body
-	cp.lastServedCLL1Num = pin.l1
-	cp.syncStatusBodyMu.Unlock()
+	cp.tracker.SetCLSyncBody(pin.body, pin.l1)
 
 	RecordCLGroupPinL1(cp.backendGroup, pin.be, pin.l1)
 	log.Info("CL pin backend selected",

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -49,9 +49,9 @@ type InMemoryConsensusTracker struct {
 	mutex sync.Mutex
 	state *ConsensusTrackerState
 
-	clSyncMu        sync.RWMutex
-	clSyncBody      json.RawMessage
-	clLastServedL1  uint64
+	clSyncMu       sync.RWMutex
+	clSyncBody     json.RawMessage
+	clLastServedL1 uint64
 }
 
 func NewInMemoryConsensusTracker() ConsensusTracker {

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -49,9 +49,9 @@ type InMemoryConsensusTracker struct {
 	mutex sync.Mutex
 	state *ConsensusTrackerState
 
-	clSyncMu       sync.RWMutex
-	clSyncBody     json.RawMessage
-	clLastServedL1 uint64
+	clSyncMu        sync.RWMutex
+	clSyncBody      json.RawMessage
+	clLastServedL1  uint64
 }
 
 func NewInMemoryConsensusTracker() ConsensusTracker {
@@ -321,8 +321,7 @@ func (ct *RedisConsensusTracker) GetCLSyncBody() (json.RawMessage, uint64) {
 
 func (ct *RedisConsensusTracker) SetCLSyncBody(body json.RawMessage, l1Num uint64) {
 	ct.local.SetCLSyncBody(body, l1Num)
-	// Mirror to remote so GetCLSyncBody returns fresh data on the leader immediately.
-	ct.remote.SetCLSyncBody(body, l1Num)
+	// updates to remote should only happen via a leader-only section of code like in postPayload function
 }
 
 // clSyncBodyPayload is the JSON envelope stored in Redis for the CL sync status body.

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -385,6 +385,7 @@ func (ct *RedisConsensusTracker) postPayload(mutexVal string) {
 			RecordGroupConsensusError(ct.backendGroup, "leader_post_cl_sync_body", err)
 			return
 		}
+		ct.remote.SetCLSyncBody(localBody, localL1)
 		log.Debug("posted CL sync body", "l1_num", localL1, "body_len", len(localBody))
 	}
 }

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -32,6 +32,9 @@ type ConsensusTrackerState struct {
 	Safe      hexutil.Uint64 `json:"safe"`
 	Finalized hexutil.Uint64 `json:"finalized"`
 	LocalSafe hexutil.Uint64 `json:"local_safe"`
+
+	CLSyncBody json.RawMessage `json:"cl_sync_body,omitempty"`
+	CLL1Num    uint64          `json:"cl_l1_num,omitempty"`
 }
 
 func (ct *InMemoryConsensusTracker) update(o *ConsensusTrackerState) {
@@ -42,16 +45,19 @@ func (ct *InMemoryConsensusTracker) update(o *ConsensusTrackerState) {
 	ct.state.Safe = o.Safe
 	ct.state.Finalized = o.Finalized
 	ct.state.LocalSafe = o.LocalSafe
+
+	// Only overwrite CL fields when the source has them set.
+	// SetState (EL path) does not populate CL fields; SetCLSyncBody does.
+	if len(o.CLSyncBody) > 0 {
+		ct.state.CLSyncBody = o.CLSyncBody
+		ct.state.CLL1Num = o.CLL1Num
+	}
 }
 
 // InMemoryConsensusTracker store and retrieve in memory, async-safe
 type InMemoryConsensusTracker struct {
 	mutex sync.Mutex
 	state *ConsensusTrackerState
-
-	clSyncMu        sync.RWMutex
-	clSyncBody      json.RawMessage
-	clLastServedL1  uint64
 }
 
 func NewInMemoryConsensusTracker() ConsensusTracker {
@@ -89,16 +95,16 @@ func (ct *InMemoryConsensusTracker) SetState(state ConsensusTrackerState) {
 }
 
 func (ct *InMemoryConsensusTracker) GetCLSyncBody() (json.RawMessage, uint64) {
-	ct.clSyncMu.RLock()
-	defer ct.clSyncMu.RUnlock()
-	return ct.clSyncBody, ct.clLastServedL1
+	ct.mutex.Lock()
+	defer ct.mutex.Unlock()
+	return ct.state.CLSyncBody, ct.state.CLL1Num
 }
 
 func (ct *InMemoryConsensusTracker) SetCLSyncBody(body json.RawMessage, l1Num uint64) {
-	ct.clSyncMu.Lock()
-	defer ct.clSyncMu.Unlock()
-	ct.clSyncBody = body
-	ct.clLastServedL1 = l1Num
+	ct.mutex.Lock()
+	defer ct.mutex.Unlock()
+	ct.state.CLSyncBody = body
+	ct.state.CLL1Num = l1Num
 }
 
 // RedisConsensusTracker store and retrieve in a shared Redis cluster, with leader election
@@ -216,7 +222,6 @@ func (ct *RedisConsensusTracker) stateHeartbeat() {
 			}
 			ct.postPayload(val)
 		} else {
-			mutexVal := val // capture before val is shadowed below
 			// retrieve current leader
 			leaderName, err := ct.client.Get(ct.ctx, ct.key(fmt.Sprintf("leader:%s", val))).Result()
 			if err != nil && err != redis.Nil {
@@ -253,22 +258,8 @@ func (ct *RedisConsensusTracker) stateHeartbeat() {
 			RecordGroupConsensusHALatestBlock(ct.backendGroup, leaderName, remoteState.Latest)
 			RecordGroupConsensusHASafeBlock(ct.backendGroup, leaderName, remoteState.Safe)
 			RecordGroupConsensusHAFinalizedBlock(ct.backendGroup, leaderName, remoteState.Finalized)
-
-			// Read CL sync body from Redis (best-effort; stale data preferred over none).
-			clVal, err := ct.client.Get(ct.ctx, ct.key(fmt.Sprintf("cl_sync_body:%s", mutexVal))).Result()
-			if err != nil && err != redis.Nil {
-				log.Warn("serving stale CL sync body, redis unavailable", "err", err)
-				RecordGroupConsensusError(ct.backendGroup, "read_cl_sync_body", err)
-			} else if clVal != "" {
-				var payload clSyncBodyPayload
-				if err := json.Unmarshal([]byte(clVal), &payload); err != nil {
-					log.Error("failed to unmarshal remote CL sync body", "err", err)
-					RecordGroupConsensusError(ct.backendGroup, "read_unmarshal_cl_sync_body", err)
-				} else {
-					ct.remote.SetCLSyncBody(payload.Body, payload.L1Num)
-					RecordGroupConsensusHACLPinL1(ct.backendGroup, leaderName, payload.L1Num)
-					log.Debug("updated CL sync body from remote", "l1_num", payload.L1Num, "body_len", len(payload.Body))
-				}
+			if remoteState.CLL1Num > 0 {
+				RecordGroupConsensusHACLPinL1(ct.backendGroup, leaderName, remoteState.CLL1Num)
 			}
 		}
 	} else {
@@ -324,12 +315,6 @@ func (ct *RedisConsensusTracker) SetCLSyncBody(body json.RawMessage, l1Num uint6
 	// updates to remote should only happen via a leader-only section of code like in postPayload function
 }
 
-// clSyncBodyPayload is the JSON envelope stored in Redis for the CL sync status body.
-type clSyncBodyPayload struct {
-	Body  json.RawMessage `json:"body"`
-	L1Num uint64          `json:"l1_num"`
-}
-
 func (ct *RedisConsensusTracker) postPayload(mutexVal string) {
 	state := ct.local.GetState()
 	jsonState, err := json.Marshal(state)
@@ -365,26 +350,7 @@ func (ct *RedisConsensusTracker) postPayload(mutexVal string) {
 	RecordGroupConsensusHALatestBlock(ct.backendGroup, leader, remoteState.Latest)
 	RecordGroupConsensusHASafeBlock(ct.backendGroup, leader, remoteState.Safe)
 	RecordGroupConsensusHAFinalizedBlock(ct.backendGroup, leader, remoteState.Finalized)
-
-	localBody, localL1 := ct.local.GetCLSyncBody()
-
-	if len(localBody) > 0 {
-		RecordGroupConsensusHACLPinL1(ct.backendGroup, leader, localL1)
-
-		payload := clSyncBodyPayload{Body: localBody, L1Num: localL1}
-		jsonPayload, err := json.Marshal(payload)
-		if err != nil {
-			log.Error("failed to marshal CL sync body payload", "err", err)
-			RecordGroupConsensusError(ct.backendGroup, "leader_marshal_cl_sync_body", err)
-			return
-		}
-		err = ct.client.Set(ct.ctx, ct.key(fmt.Sprintf("cl_sync_body:%s", mutexVal)), jsonPayload, ct.lockPeriod).Err()
-		if err != nil {
-			log.Error("failed to post CL sync body", "err", err)
-			RecordGroupConsensusError(ct.backendGroup, "leader_post_cl_sync_body", err)
-			return
-		}
-		ct.remote.SetCLSyncBody(localBody, localL1)
-		log.Debug("posted CL sync body", "l1_num", localL1, "body_len", len(localBody))
+	if remoteState.CLL1Num > 0 {
+		RecordGroupConsensusHACLPinL1(ct.backendGroup, leader, remoteState.CLL1Num)
 	}
 }

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -257,7 +257,7 @@ func (ct *RedisConsensusTracker) stateHeartbeat() {
 			// Read CL sync body from Redis (best-effort; stale data preferred over none).
 			clVal, err := ct.client.Get(ct.ctx, ct.key(fmt.Sprintf("cl_sync_body:%s", mutexVal))).Result()
 			if err != nil && err != redis.Nil {
-				log.Error("failed to read remote CL sync body", "err", err)
+				log.Warn("serving stale CL sync body, redis unavailable", "err", err)
 				RecordGroupConsensusError(ct.backendGroup, "read_cl_sync_body", err)
 			} else if clVal != "" {
 				var payload clSyncBodyPayload

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -20,6 +20,9 @@ import (
 type ConsensusTracker interface {
 	GetState() ConsensusTrackerState
 	SetState(state ConsensusTrackerState)
+
+	GetCLSyncBody() (body json.RawMessage, lastServedL1Num uint64)
+	SetCLSyncBody(body json.RawMessage, l1Num uint64)
 }
 
 // ConsensusTrackerState holds the full consensus state in one snapshot.
@@ -45,6 +48,10 @@ func (ct *InMemoryConsensusTracker) update(o *ConsensusTrackerState) {
 type InMemoryConsensusTracker struct {
 	mutex sync.Mutex
 	state *ConsensusTrackerState
+
+	clSyncMu        sync.RWMutex
+	clSyncBody      json.RawMessage
+	clLastServedL1  uint64
 }
 
 func NewInMemoryConsensusTracker() ConsensusTracker {
@@ -81,6 +88,19 @@ func (ct *InMemoryConsensusTracker) SetState(state ConsensusTrackerState) {
 	ct.update(&state)
 }
 
+func (ct *InMemoryConsensusTracker) GetCLSyncBody() (json.RawMessage, uint64) {
+	ct.clSyncMu.RLock()
+	defer ct.clSyncMu.RUnlock()
+	return ct.clSyncBody, ct.clLastServedL1
+}
+
+func (ct *InMemoryConsensusTracker) SetCLSyncBody(body json.RawMessage, l1Num uint64) {
+	ct.clSyncMu.Lock()
+	defer ct.clSyncMu.Unlock()
+	ct.clSyncBody = body
+	ct.clLastServedL1 = l1Num
+}
+
 // RedisConsensusTracker store and retrieve in a shared Redis cluster, with leader election
 type RedisConsensusTracker struct {
 	ctx          context.Context
@@ -101,6 +121,12 @@ type RedisConsensusTracker struct {
 	// holds a copy of the remote shared state
 	// when leader, updates the remote with the local state
 	remote *InMemoryConsensusTracker
+
+	clSyncMu           sync.RWMutex
+	clLocalSyncBody    json.RawMessage
+	clLocalL1Num       uint64
+	clRemoteSyncBody   json.RawMessage
+	clRemoteL1Num      uint64
 }
 
 type RedisConsensusTrackerOpt func(cp *RedisConsensusTracker)
@@ -196,6 +222,7 @@ func (ct *RedisConsensusTracker) stateHeartbeat() {
 			}
 			ct.postPayload(val)
 		} else {
+			mutexVal := val // capture before val is shadowed below
 			// retrieve current leader
 			leaderName, err := ct.client.Get(ct.ctx, ct.key(fmt.Sprintf("leader:%s", val))).Result()
 			if err != nil && err != redis.Nil {
@@ -232,6 +259,26 @@ func (ct *RedisConsensusTracker) stateHeartbeat() {
 			RecordGroupConsensusHALatestBlock(ct.backendGroup, leaderName, remoteState.Latest)
 			RecordGroupConsensusHASafeBlock(ct.backendGroup, leaderName, remoteState.Safe)
 			RecordGroupConsensusHAFinalizedBlock(ct.backendGroup, leaderName, remoteState.Finalized)
+
+			// Read CL sync body from Redis (best-effort; stale data preferred over none).
+			clVal, err := ct.client.Get(ct.ctx, ct.key(fmt.Sprintf("cl_sync_body:%s", mutexVal))).Result()
+			if err != nil && err != redis.Nil {
+				log.Error("failed to read remote CL sync body", "err", err)
+				RecordGroupConsensusError(ct.backendGroup, "read_cl_sync_body", err)
+			} else if clVal != "" {
+				var payload clSyncBodyPayload
+				if err := json.Unmarshal([]byte(clVal), &payload); err != nil {
+					log.Error("failed to unmarshal remote CL sync body", "err", err)
+					RecordGroupConsensusError(ct.backendGroup, "read_unmarshal_cl_sync_body", err)
+				} else {
+					ct.clSyncMu.Lock()
+					ct.clRemoteSyncBody = payload.Body
+					ct.clRemoteL1Num = payload.L1Num
+					ct.clSyncMu.Unlock()
+					RecordGroupConsensusHACLPinL1(ct.backendGroup, leaderName, payload.L1Num)
+					log.Debug("updated CL sync body from remote", "l1_num", payload.L1Num, "body_len", len(payload.Body))
+				}
+			}
 		}
 	} else {
 		if !ct.local.Valid() {
@@ -277,6 +324,28 @@ func (ct *RedisConsensusTracker) SetState(state ConsensusTrackerState) {
 	ct.local.SetState(state)
 }
 
+func (ct *RedisConsensusTracker) GetCLSyncBody() (json.RawMessage, uint64) {
+	ct.clSyncMu.RLock()
+	defer ct.clSyncMu.RUnlock()
+	return ct.clRemoteSyncBody, ct.clRemoteL1Num
+}
+
+func (ct *RedisConsensusTracker) SetCLSyncBody(body json.RawMessage, l1Num uint64) {
+	ct.clSyncMu.Lock()
+	defer ct.clSyncMu.Unlock()
+	ct.clLocalSyncBody = body
+	ct.clLocalL1Num = l1Num
+	// Mirror to remote so GetCLSyncBody returns fresh data on the leader immediately.
+	ct.clRemoteSyncBody = body
+	ct.clRemoteL1Num = l1Num
+}
+
+// clSyncBodyPayload is the JSON envelope stored in Redis for the CL sync status body.
+type clSyncBodyPayload struct {
+	Body  json.RawMessage `json:"body"`
+	L1Num uint64          `json:"l1_num"`
+}
+
 func (ct *RedisConsensusTracker) postPayload(mutexVal string) {
 	state := ct.local.GetState()
 	jsonState, err := json.Marshal(state)
@@ -312,4 +381,28 @@ func (ct *RedisConsensusTracker) postPayload(mutexVal string) {
 	RecordGroupConsensusHALatestBlock(ct.backendGroup, leader, remoteState.Latest)
 	RecordGroupConsensusHASafeBlock(ct.backendGroup, leader, remoteState.Safe)
 	RecordGroupConsensusHAFinalizedBlock(ct.backendGroup, leader, remoteState.Finalized)
+
+	ct.clSyncMu.RLock()
+	localBody := ct.clLocalSyncBody
+	localL1 := ct.clLocalL1Num
+	ct.clSyncMu.RUnlock()
+
+	if len(localBody) > 0 {
+		RecordGroupConsensusHACLPinL1(ct.backendGroup, leader, localL1)
+
+		payload := clSyncBodyPayload{Body: localBody, L1Num: localL1}
+		jsonPayload, err := json.Marshal(payload)
+		if err != nil {
+			log.Error("failed to marshal CL sync body payload", "err", err)
+			RecordGroupConsensusError(ct.backendGroup, "leader_marshal_cl_sync_body", err)
+			return
+		}
+		err = ct.client.Set(ct.ctx, ct.key(fmt.Sprintf("cl_sync_body:%s", mutexVal)), jsonPayload, ct.lockPeriod).Err()
+		if err != nil {
+			log.Error("failed to post CL sync body", "err", err)
+			RecordGroupConsensusError(ct.backendGroup, "leader_post_cl_sync_body", err)
+			return
+		}
+		log.Debug("posted CL sync body", "l1_num", localL1, "body_len", len(localBody))
+	}
 }

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -121,12 +121,6 @@ type RedisConsensusTracker struct {
 	// holds a copy of the remote shared state
 	// when leader, updates the remote with the local state
 	remote *InMemoryConsensusTracker
-
-	clSyncMu           sync.RWMutex
-	clLocalSyncBody    json.RawMessage
-	clLocalL1Num       uint64
-	clRemoteSyncBody   json.RawMessage
-	clRemoteL1Num      uint64
 }
 
 type RedisConsensusTrackerOpt func(cp *RedisConsensusTracker)
@@ -271,10 +265,7 @@ func (ct *RedisConsensusTracker) stateHeartbeat() {
 					log.Error("failed to unmarshal remote CL sync body", "err", err)
 					RecordGroupConsensusError(ct.backendGroup, "read_unmarshal_cl_sync_body", err)
 				} else {
-					ct.clSyncMu.Lock()
-					ct.clRemoteSyncBody = payload.Body
-					ct.clRemoteL1Num = payload.L1Num
-					ct.clSyncMu.Unlock()
+					ct.remote.SetCLSyncBody(payload.Body, payload.L1Num)
 					RecordGroupConsensusHACLPinL1(ct.backendGroup, leaderName, payload.L1Num)
 					log.Debug("updated CL sync body from remote", "l1_num", payload.L1Num, "body_len", len(payload.Body))
 				}
@@ -325,19 +316,13 @@ func (ct *RedisConsensusTracker) SetState(state ConsensusTrackerState) {
 }
 
 func (ct *RedisConsensusTracker) GetCLSyncBody() (json.RawMessage, uint64) {
-	ct.clSyncMu.RLock()
-	defer ct.clSyncMu.RUnlock()
-	return ct.clRemoteSyncBody, ct.clRemoteL1Num
+	return ct.remote.GetCLSyncBody()
 }
 
 func (ct *RedisConsensusTracker) SetCLSyncBody(body json.RawMessage, l1Num uint64) {
-	ct.clSyncMu.Lock()
-	defer ct.clSyncMu.Unlock()
-	ct.clLocalSyncBody = body
-	ct.clLocalL1Num = l1Num
+	ct.local.SetCLSyncBody(body, l1Num)
 	// Mirror to remote so GetCLSyncBody returns fresh data on the leader immediately.
-	ct.clRemoteSyncBody = body
-	ct.clRemoteL1Num = l1Num
+	ct.remote.SetCLSyncBody(body, l1Num)
 }
 
 // clSyncBodyPayload is the JSON envelope stored in Redis for the CL sync status body.
@@ -382,10 +367,7 @@ func (ct *RedisConsensusTracker) postPayload(mutexVal string) {
 	RecordGroupConsensusHASafeBlock(ct.backendGroup, leader, remoteState.Safe)
 	RecordGroupConsensusHAFinalizedBlock(ct.backendGroup, leader, remoteState.Finalized)
 
-	ct.clSyncMu.RLock()
-	localBody := ct.clLocalSyncBody
-	localL1 := ct.clLocalL1Num
-	ct.clSyncMu.RUnlock()
+	localBody, localL1 := ct.local.GetCLSyncBody()
 
 	if len(localBody) > 0 {
 		RecordGroupConsensusHACLPinL1(ct.backendGroup, leader, localL1)

--- a/proxyd/consensus_tracker_test.go
+++ b/proxyd/consensus_tracker_test.go
@@ -1,0 +1,230 @@
+package proxyd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newDummyServer returns a no-op HTTP server for tests that don't make HTTP calls.
+func newDummyServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// setCLBackendState sets the CL-related fields on a backend's state within the poller.
+func setCLBackendState(cp *ConsensusPoller, be *Backend, l1 uint64, body json.RawMessage) {
+	cp.backendState[be].backendStateMux.Lock()
+	cp.backendState[be].currentL1Number = l1
+	cp.backendState[be].syncStatusRaw = body
+	cp.backendState[be].backendStateMux.Unlock()
+}
+
+// --- InMemoryConsensusTracker tests ---
+
+func TestInMemoryTracker_CLSyncBodyRoundTrip(t *testing.T) {
+	tracker := NewInMemoryConsensusTracker()
+
+	body, l1 := tracker.GetCLSyncBody()
+	require.Nil(t, body)
+	require.Equal(t, uint64(0), l1)
+
+	expected := json.RawMessage(`{"safe_l2":{"number":"0x1"}}`)
+	tracker.SetCLSyncBody(expected, 42)
+
+	body, l1 = tracker.GetCLSyncBody()
+	require.JSONEq(t, string(expected), string(body))
+	require.Equal(t, uint64(42), l1)
+}
+
+func TestInMemoryTracker_CLSyncBodyOverwrite(t *testing.T) {
+	tracker := NewInMemoryConsensusTracker()
+
+	tracker.SetCLSyncBody(json.RawMessage(`{"v":1}`), 10)
+	tracker.SetCLSyncBody(json.RawMessage(`{"v":2}`), 20)
+
+	body, l1 := tracker.GetCLSyncBody()
+	require.JSONEq(t, `{"v":2}`, string(body))
+	require.Equal(t, uint64(20), l1)
+}
+
+func TestInMemoryTracker_CLSyncBodyConcurrentAccess(t *testing.T) {
+	tracker := NewInMemoryConsensusTracker()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		l1 := uint64(i + 1)
+		go func() {
+			defer wg.Done()
+			tracker.SetCLSyncBody(json.RawMessage(`{"v":1}`), l1)
+		}()
+		go func() {
+			defer wg.Done()
+			body, l1Num := tracker.GetCLSyncBody()
+			// Body and L1 should always be consistent with each other:
+			// either both zero (initial) or both set.
+			if body != nil {
+				require.NotEqual(t, uint64(0), l1Num, "body set but l1 is 0")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// --- selectConsensusSyncStatusBody tests ---
+
+func TestSelectConsensusSyncStatusBody_MonotonicityFloor(t *testing.T) {
+	srv := newDummyServer(t)
+	be := newTestBackend(t, srv, 2*time.Second)
+	cp := newTestPoller([]*Backend{be}, WithCLConsensusMode())
+
+	setCLBackendState(cp, be, 100, json.RawMessage(`{"l1":100}`))
+	cp.selectConsensusSyncStatusBody([]*Backend{be})
+
+	body, floor := cp.tracker.GetCLSyncBody()
+	require.NotNil(t, body)
+	require.Equal(t, uint64(100), floor)
+
+	// Higher L1 with single backend: accepted (200 >= floor 100).
+	setCLBackendState(cp, be, 200, json.RawMessage(`{"l1":200}`))
+	cp.selectConsensusSyncStatusBody([]*Backend{be})
+
+	_, floor = cp.tracker.GetCLSyncBody()
+	require.Equal(t, uint64(200), floor)
+
+	// L1 below floor: rejected.
+	setCLBackendState(cp, be, 50, json.RawMessage(`{"l1":50}`))
+	cp.selectConsensusSyncStatusBody([]*Backend{be})
+
+	_, floor = cp.tracker.GetCLSyncBody()
+	require.Equal(t, uint64(200), floor, "L1=50 < floor=200, should not update")
+}
+
+func TestSelectConsensusSyncStatusBody_PicksLowestL1(t *testing.T) {
+	srv := newDummyServer(t)
+	be1 := newTestBackend(t, srv, 2*time.Second)
+	be2 := newTestBackend(t, srv, 2*time.Second)
+	cp := newTestPoller([]*Backend{be1, be2}, WithCLConsensusMode())
+
+	setCLBackendState(cp, be1, 150, json.RawMessage(`{"backend":"be1"}`))
+	setCLBackendState(cp, be2, 100, json.RawMessage(`{"backend":"be2"}`))
+
+	cp.selectConsensusSyncStatusBody([]*Backend{be1, be2})
+
+	body, floor := cp.tracker.GetCLSyncBody()
+	require.Equal(t, uint64(100), floor)
+	require.JSONEq(t, `{"backend":"be2"}`, string(body))
+}
+
+func TestSelectConsensusSyncStatusBody_EmptyGroup(t *testing.T) {
+	srv := newDummyServer(t)
+	be := newTestBackend(t, srv, 2*time.Second)
+	cp := newTestPoller([]*Backend{be}, WithCLConsensusMode())
+
+	// No candidates -> body stays nil.
+	cp.selectConsensusSyncStatusBody([]*Backend{})
+
+	body := cp.GetConsensusSyncStatusBody()
+	require.Nil(t, body, "empty consensus group should not set a body")
+}
+
+func TestSelectConsensusSyncStatusBody_EmptyBodySkipped(t *testing.T) {
+	srv := newDummyServer(t)
+	be := newTestBackend(t, srv, 2*time.Second)
+	cp := newTestPoller([]*Backend{be}, WithCLConsensusMode())
+
+	// Backend has L1 number but empty sync body -> should be skipped.
+	setCLBackendState(cp, be, 100, nil)
+	cp.selectConsensusSyncStatusBody([]*Backend{be})
+
+	body := cp.GetConsensusSyncStatusBody()
+	require.Nil(t, body, "backend with nil syncStatusRaw should not be selected")
+}
+
+func TestSelectConsensusSyncStatusBody_FloorPreservedAcrossCycles(t *testing.T) {
+	srv := newDummyServer(t)
+	be1 := newTestBackend(t, srv, 2*time.Second)
+	be2 := newTestBackend(t, srv, 2*time.Second)
+	cp := newTestPoller([]*Backend{be1, be2}, WithCLConsensusMode())
+
+	// Cycle 1: both at L1=100.
+	setCLBackendState(cp, be1, 100, json.RawMessage(`{"cycle":1}`))
+	setCLBackendState(cp, be2, 100, json.RawMessage(`{"cycle":1,"be2":true}`))
+	cp.selectConsensusSyncStatusBody([]*Backend{be1, be2})
+	_, floor := cp.tracker.GetCLSyncBody()
+	require.Equal(t, uint64(100), floor)
+
+	// Cycle 2: be1 drops out (empty body), be2 at L1=99 (below floor).
+	setCLBackendState(cp, be1, 100, nil)
+	setCLBackendState(cp, be2, 99, json.RawMessage(`{"cycle":2}`))
+	cp.selectConsensusSyncStatusBody([]*Backend{be1, be2})
+
+	// Floor should remain 100 — no valid candidate.
+	body, floor := cp.tracker.GetCLSyncBody()
+	require.Equal(t, uint64(100), floor, "floor should not decrease")
+	require.JSONEq(t, `{"cycle":1}`, string(body), "body should be from cycle 1")
+}
+
+// --- GetConsensusSyncStatusBody serving tests ---
+
+func TestGetConsensusSyncStatusBody_NilBeforeFirstCycle(t *testing.T) {
+	srv := newDummyServer(t)
+	be := newTestBackend(t, srv, 2*time.Second)
+	cp := newTestPoller([]*Backend{be}, WithCLConsensusMode())
+
+	body := cp.GetConsensusSyncStatusBody()
+	require.Nil(t, body)
+}
+
+func TestGetConsensusSyncStatusBody_ReturnsBodyAfterSelection(t *testing.T) {
+	srv := newDummyServer(t)
+	be := newTestBackend(t, srv, 2*time.Second)
+	cp := newTestPoller([]*Backend{be}, WithCLConsensusMode())
+
+	expected := json.RawMessage(`{"safe_l2":{"number":"0x1"}}`)
+	setCLBackendState(cp, be, 100, expected)
+	cp.selectConsensusSyncStatusBody([]*Backend{be})
+
+	body := cp.GetConsensusSyncStatusBody()
+	require.NotNil(t, body)
+	require.JSONEq(t, string(expected), string(body))
+}
+
+func TestGetConsensusSyncStatusBody_BodySurvivesEmptyCycle(t *testing.T) {
+	srv := newDummyServer(t)
+	be := newTestBackend(t, srv, 2*time.Second)
+	cp := newTestPoller([]*Backend{be}, WithCLConsensusMode())
+
+	// Cycle 1: set a valid body.
+	setCLBackendState(cp, be, 100, json.RawMessage(`{"v":"good"}`))
+	cp.selectConsensusSyncStatusBody([]*Backend{be})
+
+	// Cycle 2: no valid candidates.
+	cp.selectConsensusSyncStatusBody([]*Backend{})
+
+	// Should still return the body from cycle 1.
+	body := cp.GetConsensusSyncStatusBody()
+	require.NotNil(t, body)
+	require.JSONEq(t, `{"v":"good"}`, string(body))
+}
+
+// --- EL mode (non-CL) tests ---
+
+func TestNonCLMode_CLSyncBodyUnused(t *testing.T) {
+	srv := newDummyServer(t)
+	be := newTestBackend(t, srv, 2*time.Second)
+	// No WithCLConsensusMode() — EL mode.
+	cp := newTestPoller([]*Backend{be})
+
+	body, l1 := cp.tracker.GetCLSyncBody()
+	require.Nil(t, body)
+	require.Equal(t, uint64(0), l1)
+}

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -329,6 +329,15 @@ var (
 		"leader",
 	})
 
+	consensusHACLPinL1 = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "group_consensus_ha_cl_pin_l1",
+		Help:      "CL pin L1 block number propagated via Redis HA (reported by both leader and follower).",
+	}, []string{
+		"backend_group_name",
+		"leader",
+	})
+
 	backendLatestBlockBackend = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
 		Name:      "backend_latest_block",
@@ -706,6 +715,10 @@ func RecordGroupConsensusHASafeBlock(group *BackendGroup, leader string, blockNu
 
 func RecordGroupConsensusHAFinalizedBlock(group *BackendGroup, leader string, blockNumber hexutil.Uint64) {
 	consensusHAFinalizedBlock.WithLabelValues(group.Name, leader).Set(float64(blockNumber))
+}
+
+func RecordGroupConsensusHACLPinL1(group *BackendGroup, leader string, l1Num uint64) {
+	consensusHACLPinL1.WithLabelValues(group.Name, leader).Set(float64(l1Num))
 }
 
 func RecordGroupConsensusLatestBlock(group *BackendGroup, blockNumber hexutil.Uint64) {


### PR DESCRIPTION
## Summary
- Bundle the CL sync body (`CLSyncBody`) and L1 number (`CLL1Num`) into `ConsensusTrackerState` so they travel through the same single Redis key (`state:<mutex>`) with identical error handling as EL fields
- Remove the separate `cl_sync_body:<mutex>` Redis key, the `clSyncBodyPayload` struct, and the dedicated CL read/write paths in `RedisConsensusTracker`
- Remove separate `clSyncMu`, `clSyncBody`, `clLastServedL1` fields from `InMemoryConsensusTracker` — CL data now uses the existing `ct.mutex` and `ct.state`

This eliminates inconsistencies where:
1. Leader CL write failure did not demote the leader (`ct.leader = false`), but EL did
2. Follower CL read failure was soft (warn + continue), but EL hard-returned
3. Two separate Redis keys created partial failure modes

## Test plan
- [x] `go build ./...` passes
- [x] All unit tests pass (`go test .`)
- [x] All integration tests pass (`go test ./integration_tests/`), including the CL pin monotonicity test
- [x] `goimports` formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)