### PR TITLE
[codex] fix proxyd interop access-list namespace

### DIFF
--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/golang-lru v1.0.2
-	github.com/holiman/uint256 v1.3.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/redis/go-redis/v9 v9.2.1
@@ -80,6 +79,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/holiman/billy v0.0.0-20250707135307-f2f9b9aae7db // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
+	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -7,13 +7,14 @@ import (
 	"sync"
 	"time"
 
+	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	supervisorTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types/interoptypes"
-	"github.com/ethereum/go-ethereum/eth/interop"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/holiman/uint256"
 )
 
 type InteropStrategy interface {
@@ -308,11 +309,15 @@ func (b *healthAwareBackend) Validate(ctx context.Context, accessList []common.H
 }
 
 func performCheckAccessListOp(ctx context.Context, accessList []common.Hash, url string, chainID eth.ChainID) (int, string, error) {
-	validatingBackend := interop.NewInteropClient(url)
-	err := validatingBackend.CheckAccessList(ctx, accessList, interoptypes.CrossUnsafe, interoptypes.ExecutingDescriptor{
-		ChainID:   uint256.Int(chainID),
-		Timestamp: getInteropExecutingDescriptorTimestamp(),
-	})
+	cl, err := client.NewRPC(ctx, log.Root(), url)
+	if err == nil {
+		interopFilter := sources.NewInteropFilterClient(cl)
+		defer interopFilter.Close()
+		err = interopFilter.CheckAccessList(ctx, accessList, safety.CrossUnsafe, messages.ExecutingDescriptor{
+			ChainID:   chainID,
+			Timestamp: getInteropExecutingDescriptorTimestamp(),
+		})
+	}
 
 	var httpCode int
 	var rpcErrorCode string

--- a/proxyd/interop_strategy_test.go
+++ b/proxyd/interop_strategy_test.go
@@ -1,0 +1,43 @@
+package proxyd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerformCheckAccessListOpUsesInteropNamespace(t *testing.T) {
+	methods := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var req RPCReq
+		require.NoError(t, json.Unmarshal(body, &req))
+		methods <- req.Method
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err = w.Write([]byte(`{"jsonrpc":"2.0","result":null,"id":` + string(req.ID) + `}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	httpCode, rpcErrorCode, err := performCheckAccessListOp(
+		context.Background(),
+		[]common.Hash{common.HexToHash("0x01")},
+		server.URL,
+		eth.ChainIDFromUInt64(900),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 200, httpCode)
+	require.Equal(t, "-", rpcErrorCode)
+	require.Equal(t, "interop_checkAccessList", <-methods)
+}


### PR DESCRIPTION
## Summary

Updates proxyd interop access-list validation to use `op-service/sources.InteropFilterClient`. That shared client calls the `interop_checkAccessList` RPC namespace exposed by `op-interop-filter`.

This PR is stacked on #628, which only bumps the Optimism/op-geth dependencies and applies the compile-required access-list helper import moves. Once #628 merges, this PR can be rebased back onto `main`.

## Why

`ethereum-optimism/optimism#20778` moved op-interop-filter's query API to the `interop` RPC namespace, and `ethereum-optimism/optimism#20905` added the shared op-service client for that RPC surface. Proxyd should use the shared client instead of the old op-geth helper, which calls the legacy `supervisor_checkAccessList` namespace.

## Validation

- `go test . -run TestPerformCheckAccessListOpUsesInteropNamespace -count=1`
- `go test . -count=1`
- `go test ./integration_tests -run TestInteropValidation_NormalFlow -count=1 -timeout=90s`
- `go test ./... -count=1 -timeout=10m`