### PR TITLE
circleci: migrate Tier A jobs to Gen2 (same-size, 3 docker jobs)

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -212,7 +212,7 @@ jobs:
         environment:
           POSTGRES_USER: opc
           POSTGRES_HOST_AUTH_METHOD: trust
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - run:
           name: Install codecov
@@ -260,7 +260,7 @@ jobs:
         type: string
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
-    resource_class: large
+    resource_class: large.gen2
     steps:
       - setup_remote_docker
       - gcp-cli/install
@@ -294,7 +294,7 @@ jobs:
     docker:
       - image: cimg/go:1.26
         user: root
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - circleci-utils/checkout-with-mise
       - run:


### PR DESCRIPTION
## Summary

Same-size Gen1→Gen2 swap for 3 docker jobs in `infra`. Mechanical token replacement (`<class>` → `<class>.gen2`). No dimension changes, no behavior changes outside of the Gen2 platform itself.

Part of W4 of the CircleCI cost-reduction initiative — see ethereum-optimism/core-team#2564.

## Change

3 docker job defs in `.circleci/continue_config.yml`:

| Current → New | Jobs |
|---|---|
| `medium` → `medium.gen2` | `go-test`, `op-acceptor-test-all` |
| `large` → `large.gen2` | `go-release` |

## Rationale

Same-size Gen2 swaps are equivalent in vCPU/RAM to Gen1 counterparts at the same advertised class. They position us ahead of Gen1 deprecation and typically run slightly faster on identical workloads. No xlsx telemetry was available for this repo — primarily Gen1-deprecation prep.

## Validation

Mechanical token replacement only. File byte-size delta matches `5 bytes × 3 edits = +15` exactly. No structural changes.

## Known unrelated CI failures — `op-acceptor-test-all`

The `op-acceptor-test-all` job exposes 2 pre-existing assertion failures in `op-acceptor/runner` that are **not caused by this PR**:

- `TestRunTestTimeout_SingleTest_ExceedsTimeout` — asserts captured subprocess output contains `"TIMEOUT: Test timed out after 1s"` and `"actual duration:"`
- `TestPackageTimeoutErrorMessage` — asserts captured subprocess output contains `"package test failures include timeouts:"`

The captured output in both cases is the raw Go runtime panic from Go 1.26.3 (the version installed via `mise.toml`) with no friendly-text wrapping applied. The marker strings live in `op-acceptor/runner/parser.go` — the parser's pattern-matching against Go's timeout-panic format is not firing.

Hypothesis: Go 1.26 changed the timeout-panic output format (or some other recent change) in a way the parser doesn't recognize. The `op-acceptor` workflow is path-filtered on `op-acceptor/**` changes, and no recent merged PR to `infra` touched that directory, so these failures had been latent until this config-changing PR fanned out into all workflows.

Evidence that this is unrelated to the Gen2 swap:
- 588 tests ran to completion on `medium.gen2`; the job ran end-to-end with no infra errors. Only 2 assertions failed.
- The failing logic is pure Go string pattern-matching in a parser — no plausible mechanism for a resource-class change to affect it.
- `go-test` (`op-acceptor-tests` etc.) on the same `medium.gen2` runs successfully.

Recommend tracking the parser fix as a separate workstream — happy to file the issue if helpful.

## Refs

- ethereum-optimism/core-team#2564 (W4 CircleCI Gen2 migration)
- ethereum-optimism/optimism#20917 (W4 optimism Tier A PR — establishes the same-size Gen2 pattern, all 99 checks green)
- ethereum-optimism/optimism#20899 (pilot PR, merged green)