### PR TITLE
[codex] ci: use supported Python for path filtering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ workflows:
     jobs:
       - path-filtering/filter:
           name: check-updated-files
+          tag: "3.10"
           # 3-column, whitespace-delimited mapping. One mapping per
           # line:
           # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>


### PR DESCRIPTION
## Summary

Sets the CircleCI `path-filtering/filter` job image tag to `3.10`.

## Why

The setup job currently resolves to `cimg/python:3.9` and downloads the latest `get-pip.py`, which now exits with:

```
ERROR: This script does not work on Python 3.9. The minimum supported Python version is 3.10.
```

The `circleci/path-filtering@1.3.0` orb supports the `tag` parameter for choosing the Python image tag, so this keeps the existing orb and only moves the setup job to a supported Python runtime.

## Validation

- Existing failing CircleCI job: `check-updated-files` failed before continuation while running `get-pip.py` on Python 3.9.
- This PR is expected to validate through CircleCI because it changes the setup job runtime itself.