### PR TITLE
[codex] test(proxyd): wait for websocket close handler

### DIFF
--- a/proxyd/integration_tests/ws_test.go
+++ b/proxyd/integration_tests/ws_test.go
@@ -218,10 +218,13 @@ func TestWSClientExceedReadLimit(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	closed := false
+	closed := make(chan struct{}, 1)
 	originalHandler := client.conn.CloseHandler()
 	client.conn.SetCloseHandler(func(code int, text string) error {
-		closed = true
+		select {
+		case closed <- struct{}{}:
+		default:
+		}
 		return originalHandler(code, text)
 	})
 
@@ -236,6 +239,10 @@ func TestWSClientExceedReadLimit(t *testing.T) {
 		[]byte(clientReq),
 	)
 	require.Error(t, err)
-	require.True(t, closed)
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("expected client close handler to run")
+	}
 
 }


### PR DESCRIPTION
## Summary

Stabilizes `TestWSClientExceedReadLimit` by waiting for the websocket close handler to run instead of checking a boolean immediately after `WriteMessage` returns.

## Why

After #626 fixed CircleCI path filtering and let proxyd tests run again, both stacked proxyd PRs failed in this test at `ws_test.go:239`. The oversized write can return an error before the close handler callback runs, so the old assertion was timing-sensitive.

## Validation

- `go test ./integration_tests -run TestWSClientExceedReadLimit -count=1 -v`