### PR TITLE
fix(docker): ignore lifecycle scripts in replica-healthcheck image

### DIFF
--- a/replica-healthcheck/.yarnrc
+++ b/replica-healthcheck/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/replica-healthcheck/Dockerfile
+++ b/replica-healthcheck/Dockerfile
@@ -3,7 +3,7 @@ FROM node:23-alpine3.20 AS builder
 WORKDIR /opt/optimism/replica-healthcheck
 COPY ./replica-healthcheck .
 
-RUN yarn install --frozen-lockfile && yarn cache clean
+RUN yarn install --frozen-lockfile --ignore-scripts && yarn cache clean
 RUN yarn build
 
 FROM dhi.io/node:22-alpine3.23-dev

--- a/replica-healthcheck/docs/docker-ignore-scripts.md
+++ b/replica-healthcheck/docs/docker-ignore-scripts.md
@@ -1,6 +1,6 @@
 # Docker Node install scripts policy
 
-Dependency installs in `Dockerfile` use `--ignore-scripts` by default.
+Dependency installs in `Dockerfile` use `--ignore-scripts` by default (see `replica-healthcheck/.yarnrc`).
 
 ## Allowlist
 

--- a/replica-healthcheck/docs/docker-ignore-scripts.md
+++ b/replica-healthcheck/docs/docker-ignore-scripts.md
@@ -1,9 +1,0 @@
-# Docker Node install scripts policy
-
-Dependency installs in `Dockerfile` use `--ignore-scripts` by default (see `replica-healthcheck/.yarnrc`).
-
-## Allowlist
-
-| Package | Reason | Dockerfile step |
-|---------|--------|-----------------|
-| _(none)_ | TypeScript app; no native install scripts required for image build | |

--- a/replica-healthcheck/docs/docker-ignore-scripts.md
+++ b/replica-healthcheck/docs/docker-ignore-scripts.md
@@ -1,0 +1,9 @@
+# Docker Node install scripts policy
+
+Dependency installs in `Dockerfile` use `--ignore-scripts` by default.
+
+## Allowlist
+
+| Package | Reason | Dockerfile step |
+|---------|--------|-----------------|
+| _(none)_ | TypeScript app; no native install scripts required for image build | |


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to dependency install steps in Dockerfiles
- Add `replica-healthcheck/.yarnrc` with `ignore-scripts true`

## Test plan
- [x] Local `docker build` for in-scope image target(s)
- [x] CI green