### PR TITLE
ci: forward plan matrix tag to factory docker publish

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -39,8 +39,11 @@ jobs:
     uses: ethereum-optimism/factory/.github/workflows/docker.yaml@d1304a6e3ef93a8fcb0f672707f5f2ae9737a59d
     with:
       image_name: ${{ matrix.image_name }}
+      tag: ${{ matrix.tag }}
       context: ${{ matrix.context }}
       dockerfile: ${{ matrix.dockerfile }}
+      env: ${{ matrix.env }}
+      build_args: ${{ matrix.build_args }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
     permissions:


### PR DESCRIPTION
## Summary

Restores `tag`, `env`, and `build_args` from the factory `plan` matrix when calling `docker.yaml`. Fixes release publishes using `github.ref_name` (e.g. `proxyd/v4.27.2` → sanitized `proxyd-v4.27.2`) instead of semver (`v4.27.2`).

Regression introduced in #616 when `tags.yaml` was consolidated into `build-images.yaml` without forwarding these inputs.

## Test plan

- [ ] Merge and cut a test tag (or re-run release workflow) for one image; confirm merge job logs show `sanitized_tag=$(echo vX.Y.Z ...)` and `imagetools create ... -t ...:vX.Y.Z`
- [ ] Re-publish affected releases (`proxyd/v4.27.2`, `op-conductor-ops/v0.0.4`, etc.)

Closes ethereum-optimism/cloud-security#180