### PR TITLE
feat(op-conductor-ops): add bootstrap-standby-cluster command

### DIFF
--- a/op-conductor-ops/op-conductor-ops.py
+++ b/op-conductor-ops/op-conductor-ops.py
@@ -766,7 +766,9 @@ def bootstrap_standby_cluster(
         print_error(f"Could not find current leader in network {network}")
         raise typer.Exit(code=1)
 
-    typer.echo(f"Found bootstrapped leader: {leader.sequencer_id}. Updating cluster membership...")
+    typer.echo(
+        f"Found bootstrapped leader: {leader.sequencer_id}. Updating cluster membership..."
+    )
 
     update_cluster_membership(network)
 

--- a/op-conductor-ops/op-conductor-ops.py
+++ b/op-conductor-ops/op-conductor-ops.py
@@ -735,14 +735,14 @@ def bootstrap_standby_cluster(
     network_obj = get_network(network)
 
     wait_for_condition(
-        "all sequencers to start",
+        "all conductor/sequencer RPCs to become reachable",
         lambda: network_obj.update_successful,
         update_func=network_obj.update,
         timeout_seconds=sequencer_start_timeout,
         retry_seconds=10,
     )
 
-    typer.echo("All sequencers are running. Bootstrapping standby cluster...")
+    typer.echo("All RPCs reachable. Bootstrapping standby cluster...")
 
     for sequencer in network_obj.sequencers:
         if sequencer.sequencer_active:

--- a/op-conductor-ops/op-conductor-ops.py
+++ b/op-conductor-ops/op-conductor-ops.py
@@ -706,5 +706,75 @@ def bootstrap_cluster(
     typer.echo("Conductors resumed. Bootstrap complete.")
 
 
+@app.command()
+def bootstrap_standby_cluster(
+    network: str,
+    sequencer_start_timeout: Annotated[
+        int,
+        typer.Option(
+            "--sequencer-start-timeout",
+            help="Timeout for sequencer start in seconds. Default is 300 seconds.",
+            envvar="BOOTSTRAP_SEQUENCER_START_TIMEOUT",
+        ),
+    ] = 300,
+):
+    """Bootstraps a new cluster in standby mode.
+
+    Forms the raft cluster across all conductor/sequencer pairs but leaves every
+    conductor paused and does not start a sequencer. Intended for standing up a
+    new set of nodes that will follow an existing network as verifiers, ready to
+    take over sequencing later via `resume` and `force-active-sequencer`.
+
+    Preconditions:
+    - All sequencer/conductor RPCs reachable.
+    - No sequencer is currently active.
+    - All conductors are paused.
+    - Exactly one conductor was started with raftBootstrap=true and reports itself
+      as leader.
+    """
+    network_obj = get_network(network)
+
+    wait_for_condition(
+        "all sequencers to start",
+        lambda: network_obj.update_successful,
+        update_func=network_obj.update,
+        timeout_seconds=sequencer_start_timeout,
+        retry_seconds=10,
+    )
+
+    typer.echo("All sequencers are running. Bootstrapping standby cluster...")
+
+    for sequencer in network_obj.sequencers:
+        if sequencer.sequencer_active:
+            print_error(
+                f"Sequencer {sequencer.sequencer_id} is active; "
+                f"bootstrap-standby-cluster expects all sequencers paused / verifier-only."
+            )
+            raise typer.Exit(code=1)
+
+    for sequencer in network_obj.sequencers:
+        if sequencer.conductor_active:
+            print_error(
+                f"Conductor for {sequencer.sequencer_id} is not paused. "
+                f"bootstrap-standby-cluster requires all conductors paused. "
+                f"Please run the `pause` command first."
+            )
+            raise typer.Exit(code=1)
+
+    leader = network_obj.find_conductor_leader()
+    if leader is None:
+        print_error(f"Could not find current leader in network {network}")
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Found bootstrapped leader: {leader.sequencer_id}. Updating cluster membership...")
+
+    update_cluster_membership(network)
+
+    typer.echo(
+        "Standby cluster formed. All conductors remain paused; no sequencer started. "
+        "Use `resume` and `force-active-sequencer` when ready to take over sequencing."
+    )
+
+
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
## Summary

- Adds a new `bootstrap-standby-cluster` command to `op-conductor-ops`.
- Forms a fresh raft cluster across the configured conductor/sequencer pairs but leaves every conductor paused and does not start a sequencer.
- Intended for standing up a new set of nodes that will follow an existing network as verifiers, ready to take over sequencing later via `resume` and `force-active-sequencer`.

## Behavior

Compared with the existing `bootstrap-cluster`, the new command:

- Still waits for all conductor/sequencer RPCs to be reachable.
- Adds stricter preconditions: aborts if any sequencer is active **or** any conductor is unpaused.
- Still locates the bootstrapped raft leader and runs `update_cluster_membership` to populate voters/non-voters.
- **Skips** `force_active_sequencer`, the `is_healthy` wait, and the final `resume`.

The `--sequencer-start-timeout` option (env `BOOTSTRAP_SEQUENCER_START_TIMEOUT`) is shared with `bootstrap-cluster`; no new envvar is introduced.

## Test plan

This CLI has no automated test suite. Manual verification on a devnet is pending:

- [ ] On a devnet with all conductors paused and one started with `raftBootstrap=true`, run `op-conductor-ops bootstrap-standby-cluster <network>` and confirm exit 0 plus the success message.
- [ ] Run `op-conductor-ops status <network>` and confirm `conductor_active == False` and `sequencer_active == False` for every node, with correct voter/non-voter membership.
- [ ] Run `op-conductor-ops resume <network>` and `op-conductor-ops force-active-sequencer <network> <leader-id>` and confirm normal sequencing kicks in (the standby state is a valid starting point for the existing flow).
- [ ] Exercise the precondition guards: an active sequencer, an unpaused conductor, and a network with no bootstrapped leader should each abort with a clear, actionable error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)