### PR TITLE
feat(proxyd): add metrics for interop validation outcomes

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -145,7 +145,7 @@ var (
 )
 
 /*
-These adhere to the interop RPC error codes defined in the supervisor spec
+These adhere to the interop RPC error codes defined in the interop filter spec
 Ref: https://github.com/ethereum-optimism/specs/blob/41a2ea8d362ac132ad2edf7f577bd393ec8beccc/specs/interop/supervisor.md
 Summary:
 

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -134,12 +134,12 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 		func(dur time.Duration, max int, prefix string) FrontendRateLimiter {
 			return NoopFrontendRateLimiter
 		}, // limiterFactory
-		InteropValidationConfig{},              // interopValidatingConfig
-		NewFirstSupervisorStrategy([]string{}), // interopStrategy
-		false,                                  // enableTxHashLogging
-		nil,                                    // limExemptKeys
-		TxValidationMiddlewareConfig{},         // txValidationConfig
-		10*time.Second,                         // gracefulShutdownDuration
+		InteropValidationConfig{},                 // interopValidatingConfig
+		NewFirstInteropFilterStrategy([]string{}), // interopStrategy
+		false,                          // enableTxHashLogging
+		nil,                            // limExemptKeys
+		TxValidationMiddlewareConfig{}, // txValidationConfig
+		10*time.Second,                 // gracefulShutdownDuration
 	)
 	require.NoError(t, err)
 

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -288,7 +288,7 @@ type InteropValidationStrategy string
 
 const (
 	EmptyStrategy                    InteropValidationStrategy = ""
-	FirstSupervisorStrategy          InteropValidationStrategy = "first-supervisor"
+	FirstInteropFilterStrategy       InteropValidationStrategy = "first-interop-filter"
 	MulticallStrategy                InteropValidationStrategy = "multicall"
 	HealthAwareLoadBalancingStrategy InteropValidationStrategy = "health-aware-load-balancing"
 )

--- a/proxyd/integration_tests/interop_validation_test.go
+++ b/proxyd/integration_tests/interop_validation_test.go
@@ -97,9 +97,9 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 	goodValidatingBackend1 := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
 	defer goodValidatingBackend1.Close()
 
-	badSupervisorUrl1 := badValidatingBackend1.URL()
-	badSupervisorUrl2 := badValidatingBackend2.URL()
-	goodSupervisorUrl := goodValidatingBackend1.URL()
+	badInteropFilterUrl1 := badValidatingBackend1.URL()
+	badInteropFilterUrl2 := badValidatingBackend2.URL()
+	goodInteropFilterUrl := goodValidatingBackend1.URL()
 
 	config := ReadConfig("interop_validation")
 	config.SenderRateLimit.Limit = math.MaxInt // Don't perform rate limiting in this test since we're only testing interop validation.
@@ -121,9 +121,9 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 	}
 	cases := []testCase{
 		{
-			name:     "first-supervisor strategy with first url returning error",
-			strategy: proxyd.FirstSupervisorStrategy,
-			urls:     []string{badSupervisorUrl1, goodSupervisorUrl},
+			name:     "first-interop-filter strategy with first url returning error",
+			strategy: proxyd.FirstInteropFilterStrategy,
+			urls:     []string{badInteropFilterUrl1, goodInteropFilterUrl},
 			expectedResp: respDetails{
 				code:         409,
 				jsonResponse: []byte(expectedErrResp1),
@@ -132,7 +132,7 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 		{
 			name:     "default strategy with first url returning success",
 			strategy: proxyd.EmptyStrategy,
-			urls:     []string{goodSupervisorUrl, badSupervisorUrl1},
+			urls:     []string{goodInteropFilterUrl, badInteropFilterUrl1},
 			expectedResp: respDetails{
 				code:         200,
 				jsonResponse: []byte(dummyHealthyRes),
@@ -141,7 +141,7 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 		{
 			name:     "multicall strategy with atleast one good url",
 			strategy: proxyd.MulticallStrategy,
-			urls:     []string{badSupervisorUrl1, goodSupervisorUrl},
+			urls:     []string{badInteropFilterUrl1, goodInteropFilterUrl},
 			expectedResp: respDetails{
 				code:         200,
 				jsonResponse: []byte(dummyHealthyRes),
@@ -150,7 +150,7 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 		{
 			name:                  "multicall strategy with all bad urls",
 			strategy:              proxyd.MulticallStrategy,
-			urls:                  []string{badSupervisorUrl1, badSupervisorUrl2},
+			urls:                  []string{badInteropFilterUrl1, badInteropFilterUrl2},
 			multiplePossibilities: true,
 			possibilities: []respDetails{
 				{
@@ -487,7 +487,7 @@ func TestInteropValidation_Deduplication(t *testing.T) {
 	require.Equal(t, 413, observedCode, "the request should have failed because of the expectation of the deduplicated entries being 5")
 	require.Contains(t, string(observedResp), fmt.Sprintf("\"code\":%d", -32022))
 	require.Contains(t, string(observedResp), "access list out of bounds")
-	require.Equal(t, len(validatingBackend1.requests), 0) // no request was sent to the validating backend (supervisor) because the number of entries to be passed were found to be more than the size limit of 4
+	require.Equal(t, len(validatingBackend1.requests), 0) // no request was sent to the validating backend (interop filter) because the number of entries to be passed were found to be more than the size limit of 4
 
 	shutdown()
 	firstShutdownAlreadyCalled = true
@@ -502,7 +502,7 @@ func TestInteropValidation_Deduplication(t *testing.T) {
 	_, observedCode, err = client.SendRequest(sendRawTransaction)
 	require.NoError(t, err)
 	require.Equal(t, 200, observedCode, "the request should have succeeded because of the expectation of the deduplicated entries being 5")
-	require.Equal(t, len(validatingBackend1.requests), 1) // the success is represented by the fact that the request was sent to the validating backend (supervisor)
+	require.Equal(t, len(validatingBackend1.requests), 1) // the success is represented by the fact that the request was sent to the validating backend (interop filter)
 }
 
 func TestInteropValidation_StaticParseAccessPrevalidationCheck(t *testing.T) {
@@ -529,7 +529,7 @@ func TestInteropValidation_StaticParseAccessPrevalidationCheck(t *testing.T) {
 
 	// subroutine for checking the bad path
 	// i.e. a request with an invalid access list that is rejected by the ParseAccess check itself
-	// without needing to reach the validating backend (supervisor)
+	// without needing to reach the validating backend (interop filter)
 	{
 		wrongTx := fakeTxBuilder(func(tx *types.AccessListTx) {
 			// make the access list's storage keys invalid enough to be failed by the ParseAccess check itself
@@ -548,13 +548,13 @@ func TestInteropValidation_StaticParseAccessPrevalidationCheck(t *testing.T) {
 		require.Equal(t, 400, observedCode)
 		require.Contains(t, string(observedResp), fmt.Sprintf("\"code\":%d", -32602))
 
-		// request failed aptly without needing to reach the validating backend (supervisor)
+		// request failed aptly without needing to reach the validating backend (interop filter)
 		require.Equal(t, len(validatingBackend1.requests), 0)
 	}
 
 	// subroutine for checking the good path
 	// i.e. a request with a valid access list that is validated by the ParseAccess check itself
-	// is allowed to the validating backend (supervisor) for potentially other validation checks which can only be performed by the supervisor
+	// is allowed to the validating backend (interop filter) for potentially other validation checks which can only be performed by the interop filter
 	{
 		rightTx := fakeTxBuilder()
 		rightInteropReqParams, err := convertTxToReqParams(rightTx)
@@ -622,7 +622,7 @@ func TestInteropValidation_SenderRateLimit(t *testing.T) {
 	require.Contains(t, string(observedResp2), "sender is over rate limit")
 	require.Contains(t, string(observedResp2), fmt.Sprintf("\"code\":%d", -32017))
 
-	// ensuring that the second call didn't contribute to additional validating backend (supervisor) requests
+	// ensuring that the second call didn't contribute to additional validating backend (interop filter) requests
 	require.Equal(t, len(validatingBackend1.requests), 1)
 
 	// make a non-interop request to ensure that it succeeds despite the breaked rate limit depicting that the rate limit is not applied to non-interop requests
@@ -649,7 +649,7 @@ func TestInteropValidation_SenderRateLimit(t *testing.T) {
 	require.NoError(t, err3)
 	require.Equal(t, 200, observedCode3)
 
-	// ensuring that this call did contribute to additional validating backend (supervisor) requests due to being within the rate limit
+	// ensuring that this call did contribute to additional validating backend (interop filter) requests due to being within the rate limit
 	require.Equal(t, len(validatingBackend1.requests), 2)
 }
 
@@ -904,7 +904,7 @@ func TestInteropValidation_HealthAwareLoadBalancingStrategy_NoHealthyBackends_Cu
 	require.NoError(t, err)
 	defer shutdown()
 
-	expectedResp := `{"jsonrpc":"2.0","error":{"code":-32000,"message":"no healthy supervisor backends found"},"id":1}`
+	expectedResp := `{"jsonrpc":"2.0","error":{"code":-32000,"message":"no healthy interop filter backends found"},"id":1}`
 
 	client := NewProxydClient("http://127.0.0.1:8545")
 

--- a/proxyd/integration_tests/testdata/interop_validation.toml
+++ b/proxyd/integration_tests/testdata/interop_validation.toml
@@ -23,7 +23,7 @@ urls = [
 "$VALIDATING_BACKEND_RPC_URL_1",
 "$VALIDATING_BACKEND_RPC_URL_2"
 ]
-strategy = "first-supervisor"
+strategy = "first-interop-filter"
 req_params_size_limit = 131072 ## 128KB
 access_list_size_limit = 1000000
 

--- a/proxyd/interop.go
+++ b/proxyd/interop.go
@@ -19,7 +19,7 @@ func accessObjectToKey(accessObject messages.Access) string {
 // validateAndDeduplicateInteropAccessList
 // - validates all the interop access list entries by trying to successfully parse them on a per "Access" basis
 // - discard any successfully parsed yet duplicate "Access" objects along the way.
-// This is because op-supervisor does the same for the incoming inbox entries and validates them against its DB on a per "Access" basis.
+// This is because the interop filter does the same for the incoming inbox entries and validates them against its DB on a per "Access" basis.
 // So it makes sense to recognise and discard duplicate "Access" objects early.
 func validateAndDeduplicateInteropAccessList(entriesToParse []common.Hash) ([]common.Hash, error) {
 	if len(entriesToParse) == 0 {

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -343,14 +343,14 @@ func performCheckAccessListOp(ctx context.Context, accessList []common.Hash, url
 
 	log.Debug(
 		"an interop validating backend has responded",
-		"supervisor_url", url,
+		"interop_filter_url", url,
 		"strategy", strategy,
 		"req_id", GetReqID(ctx),
 		"method", "eth_sendRawTransaction",
 		"error", err,
 	)
 
-	rpcSupervisorChecksTotal.WithLabelValues(
+	rpcInteropFilterChecksTotal.WithLabelValues(
 		url,
 		strconv.Itoa(httpCode),
 		rpcErrorCode,

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -28,7 +28,7 @@ type commonInteropStrategy struct {
 	accessListSizeLimit                     int
 	reqSizeLimit                            int
 	validateAndDeduplicateInteropAccessList bool
-	skipOnNoSupervisorBackend               bool
+	skipOnNoInteropFilterBackend            bool
 }
 
 func NewCommonInteropStrategy(urls []string, opts ...commonStrategyOpt) *commonInteropStrategy {
@@ -37,7 +37,7 @@ func NewCommonInteropStrategy(urls []string, opts ...commonStrategyOpt) *commonI
 		accessListSizeLimit:                     0,
 		reqSizeLimit:                            0,
 		validateAndDeduplicateInteropAccessList: true,
-		skipOnNoSupervisorBackend:               false,
+		skipOnNoInteropFilterBackend:            false,
 	}
 
 	for _, opt := range opts {
@@ -71,9 +71,9 @@ var WithValidateAndDeduplicateInteropAccessList = func(validateAndDeduplicateInt
 	}
 }
 
-var WithSkipOnNoSupervisorBackend = func(skipOnNoSupervisorBackend bool) commonStrategyOpt {
+var WithSkipOnNoInteropFilterBackend = func(skipOnNoInteropFilterBackend bool) commonStrategyOpt {
 	return func(s *commonInteropStrategy) {
-		s.skipOnNoSupervisorBackend = skipOnNoSupervisorBackend
+		s.skipOnNoInteropFilterBackend = skipOnNoInteropFilterBackend
 	}
 }
 
@@ -85,7 +85,7 @@ var WithChainID = func(chainID uint64) commonStrategyOpt {
 
 func (s *commonInteropStrategy) preflightChecksAndCleanupAccessList(ctx context.Context, interopAccessList []common.Hash) ([]common.Hash, bool, error) {
 	if len(s.urls) == 0 {
-		if s.skipOnNoSupervisorBackend {
+		if s.skipOnNoInteropFilterBackend {
 			log.Info(
 				"no validating backends found for an interop transaction, skipping",
 				"req_id", GetReqID(ctx),
@@ -124,17 +124,17 @@ func (s *commonInteropStrategy) preflightChecksAndCleanupAccessList(ctx context.
 	return interopAccessList, true, nil
 }
 
-type firstSupervisorStrategyImpl struct {
+type firstInteropFilterStrategyImpl struct {
 	*commonInteropStrategy
 }
 
-func NewFirstSupervisorStrategy(urls []string, opts ...commonStrategyOpt) *firstSupervisorStrategyImpl {
-	return &firstSupervisorStrategyImpl{
+func NewFirstInteropFilterStrategy(urls []string, opts ...commonStrategyOpt) *firstInteropFilterStrategyImpl {
+	return &firstInteropFilterStrategyImpl{
 		commonInteropStrategy: NewCommonInteropStrategy(urls, opts...),
 	}
 }
 
-func (s *firstSupervisorStrategyImpl) ValidateAccessList(ctx context.Context, interopAccessList []common.Hash) error {
+func (s *firstInteropFilterStrategyImpl) ValidateAccessList(ctx context.Context, interopAccessList []common.Hash) error {
 	accessListToValidate, proceedFurther, err := s.preflightChecksAndCleanupAccessList(ctx, interopAccessList)
 	if err != nil {
 		return err
@@ -144,10 +144,10 @@ func (s *firstSupervisorStrategyImpl) ValidateAccessList(ctx context.Context, in
 		return nil
 	}
 
-	firstSupervisorUrl := s.urls[0]
+	firstInteropFilterUrl := s.urls[0]
 
-	ctx = context.WithValue(ctx, ContextKeyInteropValidationStrategy, FirstSupervisorStrategy) // nolint:staticcheck
-	_, _, err = performCheckAccessListOp(ctx, accessListToValidate, firstSupervisorUrl, s.chainID)
+	ctx = context.WithValue(ctx, ContextKeyInteropValidationStrategy, FirstInteropFilterStrategy) // nolint:staticcheck
+	_, _, err = performCheckAccessListOp(ctx, accessListToValidate, firstInteropFilterUrl, s.chainID)
 	return err
 }
 
@@ -265,7 +265,7 @@ func (s *healthAwareLoadBalancingStrategyImpl) ValidateAccessList(ctx context.Co
 	}
 
 	// retries exhausted
-	return ParseInteropError(fmt.Errorf("no healthy supervisor backends found"))
+	return ParseInteropError(fmt.Errorf("no healthy interop filter backends found"))
 }
 
 type healthAwareBackend struct {

--- a/proxyd/interop_validation_result_test.go
+++ b/proxyd/interop_validation_result_test.go
@@ -1,0 +1,59 @@
+package proxyd
+
+import (
+	"errors"
+	"testing"
+
+	interopErrors "github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInteropValidationResult(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nil error is passed",
+			err:  nil,
+			want: "passed",
+		},
+		{
+			name: "supervisor rejection (4xx RPCErr) is filtered",
+			err:  interopRPCErrorMap[interopErrors.ErrSkipped], // 422
+			want: "filtered",
+		},
+		{
+			name: "access list out of bounds (413 RPCErr) is filtered",
+			err:  ErrInteropAccessListOutOfBounds, // 413
+			want: "filtered",
+		},
+		{
+			name: "failsafe enabled (503 RPCErr) is errored",
+			err:  interopRPCErrorMap[interopErrors.ErrFailsafeEnabled], // 503
+			want: "errored",
+		},
+		{
+			name: "internal RPCErr (500) is errored",
+			err:  &RPCErr{Code: JSONRPCErrorInternal, HTTPErrorCode: 500},
+			want: "errored",
+		},
+		{
+			name: "non-RPCErr error is errored",
+			err:  errors.New("interop filter backend unavailable"),
+			want: "errored",
+		},
+		{
+			name: "no supervisor backend (non-RPCErr) is errored",
+			err:  interopErrors.ErrNoRPCSource,
+			want: "errored",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, interopValidationResult(tt.err))
+		})
+	}
+}

--- a/proxyd/interop_validation_result_test.go
+++ b/proxyd/interop_validation_result_test.go
@@ -20,7 +20,7 @@ func TestInteropValidationResult(t *testing.T) {
 			want: "passed",
 		},
 		{
-			name: "supervisor rejection (4xx RPCErr) is filtered",
+			name: "interop filter rejection (4xx RPCErr) is filtered",
 			err:  interopRPCErrorMap[interopErrors.ErrSkipped], // 422
 			want: "filtered",
 		},
@@ -45,7 +45,7 @@ func TestInteropValidationResult(t *testing.T) {
 			want: "errored",
 		},
 		{
-			name: "no supervisor backend (non-RPCErr) is errored",
+			name: "no interop filter backend (non-RPCErr) is errored",
 			err:  interopErrors.ErrNoRPCSource,
 			want: "errored",
 		},

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -77,6 +77,15 @@ var (
 		"strategy",
 	})
 
+	rpcInteropValidationsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "rpc_interop_validations_total",
+		Help:      "Count of interop transactions by validation result (passed, filtered, errored).",
+	}, []string{
+		"result",
+		"strategy",
+	})
+
 	rpcErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "rpc_errors_total",

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -66,12 +66,12 @@ var (
 		"batched",
 	})
 
-	rpcSupervisorChecksTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	rpcInteropFilterChecksTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
-		Name:      "rpc_supervisor_checks_total",
-		Help:      "Count of total supervisor checks.",
+		Name:      "rpc_interop_filter_checks_total",
+		Help:      "Count of total interop filter checks.",
 	}, []string{
-		"supervisor_url",
+		"interop_filter_url",
 		"http_code",
 		"rpc_error_code",
 		"strategy",

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -458,8 +458,8 @@ func Start(config *Config) (*Server, func(), error) {
 	)
 
 	switch config.InteropValidationConfig.Strategy {
-	case FirstSupervisorStrategy, EmptyStrategy:
-		interopStrategy = NewFirstSupervisorStrategy(
+	case FirstInteropFilterStrategy, EmptyStrategy:
+		interopStrategy = NewFirstInteropFilterStrategy(
 			config.InteropValidationConfig.Urls,
 			opts...,
 		)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -545,12 +545,35 @@ func (s *Server) validateInteropSendRpcRequest(ctx context.Context, tx *types.Tr
 
 	finalErr := s.interopStrategy.ValidateAccessList(ctx, interopAccessList)
 
+	rpcInteropValidationsTotal.WithLabelValues(
+		interopValidationResult(finalErr),
+		string(s.interopValidatingConfig.Strategy),
+	).Inc()
+
 	if finalErr == nil {
 		log.Info("interop access list validated successfully", "req_id", GetReqID(ctx), "tx_hash", tx.Hash())
 	} else {
 		log.Info("interop access list validation failed", "req_id", GetReqID(ctx), "tx_hash", tx.Hash(), "error", finalErr)
 	}
 	return finalErr
+}
+
+// interopValidationResult classifies the outcome of an interop access list
+// validation for metrics purposes:
+//   - "passed":   the transaction was validated successfully (err == nil).
+//   - "filtered": the transaction was rejected by interop validation (a client-side
+//     4xx RPCErr, e.g. the supervisor rejected the access list or it failed a pre-check).
+//   - "errored":  validation could not be completed reliably (a 5xx RPCErr or any
+//     non-RPCErr error, e.g. no supervisor backend available or an internal error).
+func interopValidationResult(err error) string {
+	if err == nil {
+		return "passed"
+	}
+	var rpcErr *RPCErr
+	if errors.As(err, &rpcErr) && rpcErr.HTTPErrorCode >= 400 && rpcErr.HTTPErrorCode < 500 {
+		return "filtered"
+	}
+	return "errored"
 }
 
 func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isLimited limiterFunc, isBatch bool, bypassLimit bool) ([]*RPCRes, bool, string, error) {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -51,7 +51,7 @@ const (
 	maxRequestBodyLogLen                            = 2000
 	defaultMaxUpstreamBatchSize                     = 10
 	defaultRateLimitHeader                          = "X-Forwarded-For"
-	defaultInteropValidationStrategy                = FirstSupervisorStrategy
+	defaultInteropValidationStrategy                = FirstInteropFilterStrategy
 	defaultInteropReqSizeLimit                      = 128 * opt.KiB
 	defaultInteropAccessListSizeLimit               = 1000
 	defaultInteropLoadBalancingUnhealthinessTimeout = 10 * time.Second
@@ -562,9 +562,9 @@ func (s *Server) validateInteropSendRpcRequest(ctx context.Context, tx *types.Tr
 // validation for metrics purposes:
 //   - "passed":   the transaction was validated successfully (err == nil).
 //   - "filtered": the transaction was rejected by interop validation (a client-side
-//     4xx RPCErr, e.g. the supervisor rejected the access list or it failed a pre-check).
+//     4xx RPCErr, e.g. the interop filter rejected the access list or it failed a pre-check).
 //   - "errored":  validation could not be completed reliably (a 5xx RPCErr or any
-//     non-RPCErr error, e.g. no supervisor backend available or an internal error).
+//     non-RPCErr error, e.g. no interop filter backend available or an internal error).
 func interopValidationResult(err error) string {
 	if err == nil {
 		return "passed"


### PR DESCRIPTION
## Summary

Adds a per-transaction Prometheus metric tracking how many interop transactions are **passed through**, **filtered**, or **errored** by interop access list validation.

New counter: `proxyd_rpc_interop_validations_total`, with labels:
- `result` — `passed` | `filtered` | `errored`
- `strategy` — the configured interop validation strategy (e.g. `first-supervisor`, `multicall`, `health-aware-load-balancing`)

It's incremented exactly once per interop transaction in `validateInteropSendRpcRequest`, right after `ValidateAccessList`. This complements the existing per-supervisor-check `rpc_supervisor_checks_total` metric, which counts individual backend checks rather than transaction outcomes.

## Result classification

`interopValidationResult(err)` maps the validation outcome to a label:
- **passed** — `err == nil`
- **filtered** — a client-side `4xx` `*RPCErr` (the supervisor rejected the access list, or it failed a pre-check such as the access-list size limit)
- **errored** — a `5xx` `*RPCErr` or any non-`RPCErr` error (e.g. no supervisor backend available, failsafe enabled, internal errors)

The 4xx/5xx split mirrors how outcomes are already encoded via `http_code` in `rpc_supervisor_checks_total`.

## Testing

- `go build ./...`
- New unit test `TestInteropValidationResult` covering passed/filtered/errored cases (supervisor rejection, access-list-out-of-bounds, failsafe, internal error, backend-unavailable, no-RPC-source).

---

## Rename: `rpc_supervisor_checks_total` → `rpc_interop_filter_checks_total`

Aligns the existing per-check metric with the `InteropFilterClient` naming:

| Before | After |
| --- | --- |
| `rpc_supervisor_checks_total` | `rpc_interop_filter_checks_total` |
| label `supervisor_url` | label `interop_filter_url` |

`http_code`, `rpc_error_code`, and `strategy` labels are unchanged. The matching debug log field was renamed too.

⚠️ **Breaking change** for any dashboard/alert referencing the old metric name or `supervisor_url` label.
