### PR TITLE
feat(proxyd): add metrics for interop validation outcomes

### DIFF
--- a/proxyd/interop_validation_result_test.go
+++ b/proxyd/interop_validation_result_test.go
@@ -1,0 +1,59 @@
+package proxyd
+
+import (
+	"errors"
+	"testing"
+
+	interopErrors "github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInteropValidationResult(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nil error is passed",
+			err:  nil,
+			want: "passed",
+		},
+		{
+			name: "interop filter rejection (4xx RPCErr) is filtered",
+			err:  interopRPCErrorMap[interopErrors.ErrSkipped], // 422
+			want: "filtered",
+		},
+		{
+			name: "access list out of bounds (413 RPCErr) is filtered",
+			err:  ErrInteropAccessListOutOfBounds, // 413
+			want: "filtered",
+		},
+		{
+			name: "failsafe enabled (503 RPCErr) is errored",
+			err:  interopRPCErrorMap[interopErrors.ErrFailsafeEnabled], // 503
+			want: "errored",
+		},
+		{
+			name: "internal RPCErr (500) is errored",
+			err:  &RPCErr{Code: JSONRPCErrorInternal, HTTPErrorCode: 500},
+			want: "errored",
+		},
+		{
+			name: "non-RPCErr error is errored",
+			err:  errors.New("interop filter backend unavailable"),
+			want: "errored",
+		},
+		{
+			name: "no interop filter backend (non-RPCErr) is errored",
+			err:  interopErrors.ErrNoRPCSource,
+			want: "errored",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, interopValidationResult(tt.err))
+		})
+	}
+}

--- a/proxyd/interop_validation_result_test.go
+++ b/proxyd/interop_validation_result_test.go
@@ -30,8 +30,18 @@ func TestInteropValidationResult(t *testing.T) {
 			want: "filtered",
 		},
 		{
-			name: "failsafe enabled (503 RPCErr) is errored",
-			err:  interopRPCErrorMap[interopErrors.ErrFailsafeEnabled], // 503
+			name: "failsafe enabled is its own bucket",
+			err:  interopRPCErrorMap[interopErrors.ErrFailsafeEnabled], // -320602
+			want: "failsafe",
+		},
+		{
+			name: "future data (soft out-of-sync, 422) is errored not filtered",
+			err:  interopRPCErrorMap[interopErrors.ErrFuture], // -321401, HTTP 422
+			want: "errored",
+		},
+		{
+			name: "uninitialized (soft out-of-sync, 400) is errored not filtered",
+			err:  interopRPCErrorMap[interopErrors.ErrUninitialized], // -320400, HTTP 400
 			want: "errored",
 		},
 		{

--- a/proxyd/interop_validation_result_test.go
+++ b/proxyd/interop_validation_result_test.go
@@ -85,9 +85,9 @@ func TestInteropValidationReason(t *testing.T) {
 			want: "-32022",
 		},
 		{
-			name: "failsafe maps to its rpc error code",
+			name: "failsafe maps to its dedicated rpc error code",
 			err:  interopRPCErrorMap[interopErrors.ErrFailsafeEnabled],
-			want: "-32602",
+			want: "-320602",
 		},
 		{
 			name: "non-RPCErr is internal",

--- a/proxyd/interop_validation_result_test.go
+++ b/proxyd/interop_validation_result_test.go
@@ -57,3 +57,53 @@ func TestInteropValidationResult(t *testing.T) {
 		})
 	}
 }
+
+func TestInteropValidationReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nil error is none",
+			err:  nil,
+			want: "none",
+		},
+		{
+			name: "skipped maps to its rpc error code",
+			err:  interopRPCErrorMap[interopErrors.ErrSkipped],
+			want: "-320500",
+		},
+		{
+			name: "conflict maps to its rpc error code",
+			err:  interopRPCErrorMap[interopErrors.ErrConflict],
+			want: "-320600",
+		},
+		{
+			name: "access list out of bounds maps to its rpc error code",
+			err:  ErrInteropAccessListOutOfBounds,
+			want: "-32022",
+		},
+		{
+			name: "failsafe maps to its rpc error code",
+			err:  interopRPCErrorMap[interopErrors.ErrFailsafeEnabled],
+			want: "-32602",
+		},
+		{
+			name: "non-RPCErr is internal",
+			err:  errors.New("interop filter backend unavailable"),
+			want: "internal",
+		},
+		{
+			name: "arbitrary RPCErr maps to its code",
+			err:  &RPCErr{Code: -39999, HTTPErrorCode: 400},
+			want: "-39999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, interopValidationReason(tt.err))
+		})
+	}
+}

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -98,9 +98,10 @@ var (
 	rpcInteropValidationsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "rpc_interop_validations_total",
-		Help:      "Count of interop transactions by validation result (passed, filtered, errored).",
+		Help:      "Count of interop transactions by validation result (passed, filtered, errored) and reason.",
 	}, []string{
 		"result",
+		"reason",
 		"strategy",
 	})
 

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -98,7 +98,7 @@ var (
 	rpcInteropValidationsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "rpc_interop_validations_total",
-		Help:      "Count of interop transactions by validation result (passed, filtered, errored) and reason.",
+		Help:      "Count of interop transactions by validation result (passed, filtered, errored, failsafe) and reason.",
 	}, []string{
 		"result",
 		"reason",

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -95,6 +95,15 @@ var (
 		"outcome",
 	})
 
+	rpcInteropValidationsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "rpc_interop_validations_total",
+		Help:      "Count of interop transactions by validation result (passed, filtered, errored).",
+	}, []string{
+		"result",
+		"strategy",
+	})
+
 	rpcErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "rpc_errors_total",

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -560,18 +560,28 @@ func (s *Server) validateInteropSendRpcRequest(ctx context.Context, tx *types.Tr
 }
 
 // interopValidationResult classifies the outcome of an interop access list
-// validation for metrics purposes:
+// validation for metrics purposes. It keys on the same helpers the validation
+// strategies use, rather than the raw HTTP status, so the buckets match how the
+// filter actually treats each error:
 //   - "passed":   the transaction was validated successfully (err == nil).
-//   - "filtered": the transaction was rejected by interop validation (a client-side
-//     4xx RPCErr, e.g. the interop filter rejected the access list or it failed a pre-check).
-//   - "errored":  validation could not be completed reliably (a 5xx RPCErr or any
-//     non-RPCErr error, e.g. no interop filter backend available or an internal error).
+//   - "failsafe": the filter rejected the tx because failsafe mode is engaged — a
+//     deliberate reject-all (see isFailsafeError), not a per-tx verdict.
+//   - "filtered": a definitive INVALID verdict from the filter (see
+//     isDefinitiveInteropRejection).
+//   - "errored":  validation could not be completed reliably — soft out-of-sync
+//     failures (ErrFuture/ErrUninitialized, see isSoftInteropFailure), 5xx/transport
+//     failures, no interop filter backend, or an internal error.
+//
+// Note: soft out-of-sync failures are 4xx but are not rejections (the node just
+// lacks the data yet), so they intentionally land in "errored", not "filtered".
 func interopValidationResult(err error) string {
 	if err == nil {
 		return "passed"
 	}
-	var rpcErr *RPCErr
-	if errors.As(err, &rpcErr) && rpcErr.HTTPErrorCode >= 400 && rpcErr.HTTPErrorCode < 500 {
+	if isFailsafeError(err) {
+		return "failsafe"
+	}
+	if isDefinitiveInteropRejection(err) {
 		return "filtered"
 	}
 	return "errored"

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -545,12 +545,35 @@ func (s *Server) validateInteropSendRpcRequest(ctx context.Context, tx *types.Tr
 
 	finalErr := s.interopStrategy.ValidateAccessList(ctx, interopAccessList)
 
+	rpcInteropValidationsTotal.WithLabelValues(
+		interopValidationResult(finalErr),
+		string(s.interopValidatingConfig.Strategy),
+	).Inc()
+
 	if finalErr == nil {
 		log.Info("interop access list validated successfully", "req_id", GetReqID(ctx), "tx_hash", tx.Hash())
 	} else {
 		log.Info("interop access list validation failed", "req_id", GetReqID(ctx), "tx_hash", tx.Hash(), "error", finalErr)
 	}
 	return finalErr
+}
+
+// interopValidationResult classifies the outcome of an interop access list
+// validation for metrics purposes:
+//   - "passed":   the transaction was validated successfully (err == nil).
+//   - "filtered": the transaction was rejected by interop validation (a client-side
+//     4xx RPCErr, e.g. the interop filter rejected the access list or it failed a pre-check).
+//   - "errored":  validation could not be completed reliably (a 5xx RPCErr or any
+//     non-RPCErr error, e.g. no interop filter backend available or an internal error).
+func interopValidationResult(err error) string {
+	if err == nil {
+		return "passed"
+	}
+	var rpcErr *RPCErr
+	if errors.As(err, &rpcErr) && rpcErr.HTTPErrorCode >= 400 && rpcErr.HTTPErrorCode < 500 {
+		return "filtered"
+	}
+	return "errored"
 }
 
 func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isLimited limiterFunc, isBatch bool, bypassLimit bool) ([]*RPCRes, bool, string, error) {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -585,9 +585,10 @@ func interopValidationResult(err error) string {
 //   - the interop RPC error code as a string (e.g. "-320500"), when rejected.
 //   - "internal": a non-RPCErr error (e.g. backend unavailable, internal error).
 //
-// Note: codes that the interop filter overloads (e.g. -32602 for both failsafe
-// and invalid params) are not disambiguated here; a symbolic breakdown can be
-// layered on later.
+// Note: failsafe has a dedicated code (-320602) as of optimism#21205, so it is
+// already distinguishable from generic invalid-params (-32602); any remaining
+// overloaded codes are not further disambiguated here. A symbolic breakdown can
+// be layered on later.
 func interopValidationReason(err error) string {
 	if err == nil {
 		return "none"

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -547,6 +547,7 @@ func (s *Server) validateInteropSendRpcRequest(ctx context.Context, tx *types.Tr
 
 	rpcInteropValidationsTotal.WithLabelValues(
 		interopValidationResult(finalErr),
+		interopValidationReason(finalErr),
 		string(s.interopValidatingConfig.Strategy),
 	).Inc()
 
@@ -574,6 +575,28 @@ func interopValidationResult(err error) string {
 		return "filtered"
 	}
 	return "errored"
+}
+
+// interopValidationReason returns a low-cardinality label for the interop
+// validation outcome, for metrics breakdown. It reuses the interop RPC error
+// code that ParseInteropError already resolved rather than introducing a
+// separate mapping:
+//   - "none":     validation passed (err == nil).
+//   - the interop RPC error code as a string (e.g. "-320500"), when rejected.
+//   - "internal": a non-RPCErr error (e.g. backend unavailable, internal error).
+//
+// Note: codes that the interop filter overloads (e.g. -32602 for both failsafe
+// and invalid params) are not disambiguated here; a symbolic breakdown can be
+// layered on later.
+func interopValidationReason(err error) string {
+	if err == nil {
+		return "none"
+	}
+	var rpcErr *RPCErr
+	if errors.As(err, &rpcErr) {
+		return strconv.Itoa(rpcErr.Code)
+	}
+	return "internal"
 }
 
 func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isLimited limiterFunc, isBatch bool, bypassLimit bool) ([]*RPCRes, bool, string, error) {


### PR DESCRIPTION
## Summary

Adds a per-transaction Prometheus metric tracking how many interop transactions are **passed through**, **filtered**, or **errored** by interop access list validation, with a breakdown of the specific **reason**.

New counter: `proxyd_rpc_interop_validations_total`, with labels:
- `result` — `passed` | `filtered` | `errored`
- `reason` — the resolved interop RPC error code (or `none`/`internal`); see below
- `strategy` — the configured interop validation strategy

Incremented exactly once per interop transaction in `validateInteropSendRpcRequest`, right after `ValidateAccessList`. This complements the existing per-check supervisor/interop-filter checks metric, which counts individual backend checks rather than transaction outcomes.

## Result classification

`interopValidationResult(err)` maps the validation outcome to a label:
- **passed** — `err == nil`
- **filtered** — a client-side `4xx` `*RPCErr` (the access list was rejected, or it failed a pre-check such as the access-list size limit)
- **errored** — a `5xx` `*RPCErr` or any non-`RPCErr` error (e.g. no backend available, failsafe enabled, internal errors)

## Reason breakdown

`interopValidationReason(err)` **reuses the interop RPC error code** that `ParseInteropError` already resolves — no new mapping is introduced, keeping the diff minimal:
- `none` — passed (`err == nil`)
- the interop RPC error code as a string when rejected — e.g. `-320500` (skipped), `-320600` (conflict), `-32022` (access-list too large), `-320602` (failsafe, dedicated code per optimism#21205), `-32602` (other invalid-params)
- `internal` — a non-`RPCErr` error (e.g. backend unavailable)

Note: failsafe has a dedicated code (`-320602`, optimism#21205), so it is distinguishable from generic invalid-params (`-32602`) automatically. Codes are intentionally **not** redefined in proxyd beyond the existing map entry. A symbolic, human-readable breakdown can be layered on as a follow-up.

## Example metrics

```
# HELP proxyd_rpc_interop_validations_total Count of interop transactions by validation result (passed, filtered, errored) and reason.
# TYPE proxyd_rpc_interop_validations_total counter
proxyd_rpc_interop_validations_total{result="passed",   reason="none",     strategy="multicall"} 142357
proxyd_rpc_interop_validations_total{result="filtered", reason="-320500",  strategy="multicall"} 218
proxyd_rpc_interop_validations_total{result="filtered", reason="-320600",  strategy="multicall"} 17
proxyd_rpc_interop_validations_total{result="filtered", reason="-32022",   strategy="multicall"} 9
proxyd_rpc_interop_validations_total{result="errored",  reason="-320602",  strategy="multicall"} 405
proxyd_rpc_interop_validations_total{result="errored",  reason="internal", strategy="multicall"} 2
```

## Testing

- `go build ./...`
- `TestInteropValidationResult` — passed/filtered/errored classification
- `TestInteropValidationReason` — reason maps to the resolved rpc error code (and `internal` for non-RPCErr)

---
Split out from #642. The supervisor→interop-filter rename is in #644.



