### PR TITLE
fix(proxyd): allow CL backends at network genesis (block 0 with valid hash)

### DIFF
--- a/proxyd/consensus_poller_cl.go
+++ b/proxyd/consensus_poller_cl.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -22,11 +23,23 @@ type clSyncStatus struct {
 	LatestBlockNumber    hexutil.Uint64
 	LatestBlockHash      string
 	SafeBlockNumber      hexutil.Uint64
+	SafeBlockHash        string
 	LocalSafeBlockNumber hexutil.Uint64
+	LocalSafeBlockHash   string
 	FinalizedBlockNumber hexutil.Uint64
+	FinalizedBlockHash   string
 	CurrentL1Number      uint64
 	HeadL1Number         uint64
 	HeadL1Timestamp      uint64 // Unix seconds; used to detect L1 connection staleness
+}
+
+// hasValidBlockHash reports whether hash is a well-formed, non-zero block hash.
+// At network genesis op-node reports block number 0 for every safety level but
+// with valid (non-zero) genesis hashes; an uninitialized node instead reports a
+// zero or empty hash. This lets us distinguish a legitimate genesis state from a
+// backend that simply hasn't synced yet.
+func hasValidBlockHash(hash string) bool {
+	return hash != "" && common.HexToHash(hash) != (common.Hash{})
 }
 
 // WithCLConsensusMode enables CL (op-node / consensus layer) consensus mode.
@@ -128,25 +141,28 @@ func (cp *ConsensusPoller) updateCLBackend(ctx context.Context, be *Backend) (*c
 	inSync := l1BlockLagOK && l1TimestampOK
 	RecordConsensusBackendInSync(be, inSync)
 
-	if syncStatus.LatestBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for latest block", "name", be.Name)
+	// Block height 0 is only an error when the corresponding hash is also missing
+	// (an uninitialized node). At network genesis op-node legitimately reports
+	// height 0 with a valid genesis hash, and those responses must pass through.
+	if syncStatus.LatestBlockNumber == 0 && !hasValidBlockHash(syncStatus.LatestBlockHash) {
+		log.Warn("error backend responded a 200 with blockheight 0 and no valid hash for latest block", "name", be.Name)
 		be.intermittentErrorsSlidingWindow.Incr()
-		return nil, nil, false, fmt.Errorf("latest block is 0 for backend %s", be.Name)
+		return nil, nil, false, fmt.Errorf("latest block is 0 with no valid hash for backend %s", be.Name)
 	}
-	if syncStatus.SafeBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for safe block", "name", be.Name)
+	if syncStatus.SafeBlockNumber == 0 && !hasValidBlockHash(syncStatus.SafeBlockHash) {
+		log.Warn("error backend responded a 200 with blockheight 0 and no valid hash for safe block", "name", be.Name)
 		be.intermittentErrorsSlidingWindow.Incr()
-		return nil, nil, false, fmt.Errorf("safe block is 0 for backend %s", be.Name)
+		return nil, nil, false, fmt.Errorf("safe block is 0 with no valid hash for backend %s", be.Name)
 	}
-	if syncStatus.FinalizedBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for finalized block", "name", be.Name)
+	if syncStatus.FinalizedBlockNumber == 0 && !hasValidBlockHash(syncStatus.FinalizedBlockHash) {
+		log.Warn("error backend responded a 200 with blockheight 0 and no valid hash for finalized block", "name", be.Name)
 		be.intermittentErrorsSlidingWindow.Incr()
-		return nil, nil, false, fmt.Errorf("finalized block is 0 for backend %s", be.Name)
+		return nil, nil, false, fmt.Errorf("finalized block is 0 with no valid hash for backend %s", be.Name)
 	}
-	if syncStatus.LocalSafeBlockNumber == 0 {
-		log.Warn("error backend responded with blockheight 0 for local_safe block", "name", be.Name)
+	if syncStatus.LocalSafeBlockNumber == 0 && !hasValidBlockHash(syncStatus.LocalSafeBlockHash) {
+		log.Warn("error backend responded with blockheight 0 and no valid hash for local_safe block", "name", be.Name)
 		be.intermittentErrorsSlidingWindow.Incr()
-		return nil, nil, false, fmt.Errorf("local_safe block is 0 for backend %s", be.Name)
+		return nil, nil, false, fmt.Errorf("local_safe block is 0 with no valid hash for backend %s", be.Name)
 	}
 
 	return syncStatus, rawBody, inSync, nil
@@ -255,17 +271,17 @@ func (cp *ConsensusPoller) fetchCLSyncStatus(ctx context.Context, be *Backend) (
 		return nil, nil, err
 	}
 
-	safeBlockNumber, _, err := parseCLSyncStatusBlock(syncStatusResult, "safe_l2")
+	safeBlockNumber, safeBlockHash, err := parseCLSyncStatusBlock(syncStatusResult, "safe_l2")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	localSafeBlockNumber, _, err := parseCLSyncStatusBlock(syncStatusResult, "local_safe_l2")
+	localSafeBlockNumber, localSafeBlockHash, err := parseCLSyncStatusBlock(syncStatusResult, "local_safe_l2")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	finalizedBlockNumber, _, err := parseCLSyncStatusBlock(syncStatusResult, "finalized_l2")
+	finalizedBlockNumber, finalizedBlockHash, err := parseCLSyncStatusBlock(syncStatusResult, "finalized_l2")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -289,8 +305,11 @@ func (cp *ConsensusPoller) fetchCLSyncStatus(ctx context.Context, be *Backend) (
 		LatestBlockNumber:    hexutil.Uint64(latestBlockNumber),
 		LatestBlockHash:      latestBlockHash,
 		SafeBlockNumber:      hexutil.Uint64(safeBlockNumber),
+		SafeBlockHash:        safeBlockHash,
 		LocalSafeBlockNumber: hexutil.Uint64(localSafeBlockNumber),
+		LocalSafeBlockHash:   localSafeBlockHash,
 		FinalizedBlockNumber: hexutil.Uint64(finalizedBlockNumber),
+		FinalizedBlockHash:   finalizedBlockHash,
 		CurrentL1Number:      currentL1Number,
 		HeadL1Number:         headL1Number,
 		HeadL1Timestamp:      headL1Timestamp,

--- a/proxyd/integration_tests/consensus_cl_test.go
+++ b/proxyd/integration_tests/consensus_cl_test.go
@@ -163,6 +163,34 @@ func clSyncStatusInitializing() map[string]interface{} {
 	}
 }
 
+// clSyncStatusGenesis builds a syncStatus for a chain at network genesis: every
+// L2 safety level is at block number 0 but carries a valid (non-zero) genesis
+// hash, while the node is connected to L1 with a fresh head. This must be served
+// to clients rather than rejected as block-height-0.
+func clSyncStatusGenesis() map[string]interface{} {
+	genesis := map[string]interface{}{
+		"hash":      "0x1111111111111111111111111111111111111111111111111111111111111111",
+		"number":    float64(0),
+		"timestamp": float64(0),
+	}
+	return map[string]interface{}{
+		"unsafe_l2":     genesis,
+		"safe_l2":       genesis,
+		"local_safe_l2": genesis,
+		"finalized_l2":  genesis,
+		"current_l1": map[string]interface{}{
+			"hash":      "hash_l1_100",
+			"number":    float64(100),
+			"timestamp": float64(9999999999),
+		},
+		"head_l1": map[string]interface{}{
+			"hash":      "hash_l1_100",
+			"number":    float64(100),
+			"timestamp": float64(9999999999),
+		},
+	}
+}
+
 func TestConsensusCL(t *testing.T) {
 	nodes, bg, client, shutdown := setupCL(t)
 	defer nodes["node1"].mockBackend.Close()
@@ -1020,4 +1048,38 @@ func TestConsensusCLFirstCycle(t *testing.T) {
 	require.NotNil(t, jsonMap["error"], "should return an RPC error when cache is not yet populated")
 	rpcErr := jsonMap["error"].(map[string]interface{})
 	require.Equal(t, float64(-32025), rpcErr["code"])
+}
+
+// TestConsensusCLGenesis verifies that at network genesis — every L2 safety level
+// at block number 0 but with a valid genesis hash — backends form consensus and
+// their optimism_syncStatus is served to clients, rather than being rejected as
+// block-height-0. Uses a fresh poller so the consensus tracker starts at 0, as it
+// would on a real network at genesis.
+func TestConsensusCLGenesis(t *testing.T) {
+	nodes, bg, _, shutdown := setupCL(t)
+	defer nodes["node1"].mockBackend.Close()
+	defer nodes["node2"].mockBackend.Close()
+	defer nodes["node3"].mockBackend.Close()
+	defer shutdown()
+
+	ctx := context.Background()
+	for _, node := range nodes {
+		node.handler.AddOverride(&ms.MethodTemplate{
+			Method:   "optimism_syncStatus",
+			Block:    "",
+			Response: buildResponse(clSyncStatusGenesis()),
+		})
+	}
+
+	for _, be := range bg.Backends {
+		bg.Consensus.UpdateBackend(ctx, be)
+	}
+	bg.Consensus.UpdateBackendGroupConsensus(ctx)
+
+	consensusGroup := bg.Consensus.GetConsensusGroup()
+	require.Equal(t, 3, len(consensusGroup), "all genesis backends should be in consensus")
+	require.False(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+	require.Equal(t, "0x0", bg.Consensus.GetLatestBlockNumber().String())
+	require.Equal(t, "0x0", bg.Consensus.GetSafeBlockNumber().String())
+	require.Equal(t, "0x0", bg.Consensus.GetFinalizedBlockNumber().String())
 }


### PR DESCRIPTION
## Summary

In proxyd's CL consensus mode, `updateCLBackend` rejected any backend reporting block height `0` for **any** of `unsafe`/`safe`/`local_safe`/`finalized`. At network genesis, op-node reports block height `0` for every safety level — but with valid genesis hashes — so every CL backend was excluded and `optimism_syncStatus` never reached clients while the chain was at genesis.

This changes the block-`0` guard to only reject when the corresponding block **hash is also missing/zero** (an uninitialized node). A genesis state (height `0` + valid hash) now passes through; the all-zero initializing case is still rejected.

## Why this is correct (verified against op-node)

`optimism_syncStatus` returns `eth.SyncStatus` (`op-service/eth/sync_status.go`), whose JSON fields match what proxyd parses (`unsafe_l2`, `safe_l2`, `local_safe_l2`, `finalized_l2`, `current_l1`, `head_l1`).

Genesis values come from `currentHeads` in `op-node/rollup/sync/start.go`:

> "If nothing has been marked finalized yet, the finalized head defaults to the genesis block. If nothing has been marked safe yet, the safe head defaults to the finalized block."

So at genesis all L2 safety levels are the genesis block: **number 0 with a valid (non-zero) genesis hash**. The genesis hash is a real keccak hash from the rollup config, always non-zero. Before the first engine reset completes, the status tracker's L2 fields are the zero `L2BlockRef{}` (empty hash) — which `hasValidBlockHash` still rejects, matching the existing `clSyncStatusInitializing` behavior.

## Scope

Scoped to op-node only. op-supernode does **not** serve `optimism_syncStatus` (it exposes `supernode_syncStatus` with a different, nested schema), so this change has no bearing on supernode — supporting it would be a separate change.

The EL path (`consensus_poller.go`) is intentionally left unchanged.

## Changes

- `proxyd/consensus_poller_cl.go`:
  - Capture `SafeBlockHash`/`LocalSafeBlockHash`/`FinalizedBlockHash` in `clSyncStatus` (previously parsed but discarded).
  - Add `hasValidBlockHash` helper.
  - Block-`0` guards now require the hash to also be invalid before rejecting.
- `proxyd/integration_tests/consensus_cl_test.go`:
  - New `TestConsensusCLGenesis` + `clSyncStatusGenesis` helper.

## Testing

- `go test ./proxyd/integration_tests/ -run 'TestConsensusCL'` — pass (incl. existing all-zero "initializing" rejection)
- `go test ./proxyd/...` — pass
- `go vet ./proxyd/...` — clean