### PR TITLE
feat(proxyd): halt CL consensus on unresolvable output root split

### DIFF
--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -531,8 +531,38 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 		}
 	}
 
-	if cp.consensusLayer && lowestSafeBlock > 0 {
-		candidates, lowestSafeBlock, lowestLocalSafeBlock = cp.verifyCLOutputRoots(ctx, candidates, lowestSafeBlock)
+	if cp.consensusLayer {
+		var halted bool
+		if lowestSafeBlock > 0 {
+			candidates, lowestSafeBlock, lowestLocalSafeBlock, halted = cp.verifyCLOutputRoots(ctx, candidates, lowestSafeBlock)
+		}
+		// Record the halted state every cycle (including zero-candidate cycles) so the gauge
+		// always reflects reality and can never get stuck at 1 after a halt.
+		RecordCLConsensusHalted(cp.backendGroup, halted)
+		if halted {
+			// Unresolvable output root split (no majority). Freeze only the client-facing
+			// response: the tracker block height and the cached optimism_syncStatus body are
+			// NOT advanced, so clients keep seeing the last-agreed response. Fail closed for
+			// everything else: empty the served consensus group so general RPCs return
+			// ErrNoBackends rather than being routed to a backend on an uncertain fork.
+			//
+			// Backends are not persistently banned — they are still polled and re-verified
+			// every cycle — so consensus auto-recovers as soon as a majority returns. A halt
+			// signals a potential chain split / derivation divergence and requires manual
+			// intervention.
+			cp.consensusGroupMux.Lock()
+			cp.consensusGroup = []*Backend{}
+			cp.consensusGroupMux.Unlock()
+			RecordGroupConsensusCount(cp.backendGroup, 0)
+
+			log.Error("CL consensus halted on output root split - serving frozen last-agreed response, general RPCs fail closed; manual intervention required",
+				"backend_group", cp.backendGroup.Name,
+				"frozen_safe_block", cp.GetSafeBlockNumber(),
+				"frozen_latest_block", cp.GetLatestBlockNumber(),
+				"frozen_finalized_block", cp.GetFinalizedBlockNumber(),
+			)
+			return
+		}
 	}
 
 	// find the proposed block among the candidates

--- a/proxyd/consensus_poller_cl.go
+++ b/proxyd/consensus_poller_cl.go
@@ -50,13 +50,18 @@ func hasValidBlockHash(hash string) bool {
 // derivation position) rather than rewriting individual fields.
 //
 // Output root verification: each poll cycle the poller calls
-// optimism_outputAtBlock at the consensus safe block on every candidate backend
-// and bans any backend whose output root disagrees with the majority. This
-// catches derivation divergences between heterogeneous CL clients (e.g. op-node
+// optimism_outputAtBlock at the consensus safe block on every candidate backend.
+// A backend whose output root disagrees with a strict majority is banned. If there
+// is no majority (a tie or N-way split), the disagreement is unresolvable and
+// consensus halts: the served block height and the cached optimism_syncStatus body
+// stay frozen at the last-agreed value, while the served group is emptied so general
+// RPCs fail closed rather than routing to a backend on an uncertain fork. Backends are
+// not persistently banned, so consensus auto-recovers as soon as a majority returns.
+// This catches derivation divergences between heterogeneous CL clients (e.g. op-node
 // vs kona-node) before incorrect data reaches consumers.
 //
-// An odd number of backends is required (enforced at initialization) so that
-// a majority is always unambiguous.
+// Any number of backends is permitted, including even/2-node cross-client groups:
+// a no-majority disagreement halts rather than being resolved by eviction.
 func WithCLConsensusMode() ConsensusOpt {
 	return func(cp *ConsensusPoller) {
 		cp.consensusLayer = true
@@ -317,7 +322,7 @@ func (cp *ConsensusPoller) fetchCLSyncStatus(ctx context.Context, be *Backend) (
 }
 
 // verifyCLOutputRoots calls optimism_outputAtBlock(safeBlock) on every candidate
-// and bans any backend whose outputRoot disagrees with the majority.
+// and resolves output root agreement before consensus advances.
 //
 // The outputRoot is a cryptographic commitment to the full L2 state at a block:
 //
@@ -327,13 +332,20 @@ func (cp *ConsensusPoller) fetchCLSyncStatus(ctx context.Context, be *Backend) (
 // the same L1 data, their output roots will differ at the same safe block number.
 // This check catches such derivation divergences before incorrect data is served.
 //
-// Majority semantics: a backend is banned only when the agreed root has ≥2 votes.
-// With an odd number of backends (enforced at init), the majority is always unambiguous:
-//   - 2v1: the minority backend is banned.
-//   - All backends error (outputAtBlock unsupported): graceful degradation,
-//     candidates returned unchanged.
+// Resolution semantics, given the responding backends (errors/timeouts excluded):
+//   - No disagreement (0 or 1 distinct root): proceed; no bans. Covers all-errored
+//     (verification could not run) and unanimous/single-responder cases.
+//   - Strict-majority disagreement (one root has more than half the responders' votes):
+//     ban the dissenting minority and advance on the majority root.
+//   - No-majority disagreement (a tie at the top, e.g. 1v1 / 2-2, or an N-way split):
+//     the split is unresolvable. Return halt=true and ban no one — the caller freezes the
+//     served block height and cached syncStatus at the last-agreed value and empties the
+//     served group (general RPCs fail closed) until a majority returns. This is a potential
+//     chain split / derivation divergence and warrants manual intervention.
 //
-// Returns the filtered candidates map and recomputed lowestSafeBlock / lowestLocalSafeBlock.
+// Returns the filtered candidates map, the recomputed lowestSafeBlock / lowestLocalSafeBlock,
+// and halt (true when an unresolvable split was detected; the block values are then unused
+// because the caller does not advance).
 //
 // clOutputRootTimeouts mutations are protected by backendStateMux, which synchronizes
 // with concurrent Ban/Unban and UpdateBackend callers.
@@ -341,7 +353,7 @@ func (cp *ConsensusPoller) verifyCLOutputRoots(
 	ctx context.Context,
 	candidates map[*Backend]*backendState,
 	safeBlock hexutil.Uint64,
-) (map[*Backend]*backendState, hexutil.Uint64, hexutil.Uint64) {
+) (map[*Backend]*backendState, hexutil.Uint64, hexutil.Uint64, bool) {
 	type result struct {
 		be         *Backend
 		outputRoot string
@@ -441,34 +453,48 @@ func (cp *ConsensusPoller) verifyCLOutputRoots(
 		return lowestSafe, lowestLocalSafe
 	}
 
-	if maxCount < 2 {
-		// Cannot establish a clear majority:
-		//   - all backends errored (maxCount == 0), or
-		//   - every backend returned a unique root (all-disagree, no quorum).
-		// Don't ban anyone — we can't determine which backend is correct.
-		if len(counts) > 1 {
-			backendNames := make([]string, 0, len(results))
-			for _, r := range results {
-				if r.err == nil {
-					backendNames = append(backendNames, r.be.Name)
-					RecordCLOutputRootDisagreement(r.be)
-				}
-			}
-			log.Error("CL output root disagreement detected but no majority — cannot determine correct root",
-				"safe_block", safeBlock,
-				"distinct_roots", len(counts),
-				"backends", backendNames,
-			)
-		}
+	// No disagreement: at most one distinct root among responders. This covers the
+	// all-errored case (verification could not run) and the unanimous/single-responder
+	// case. Nothing to resolve - proceed without bans.
+	if len(counts) <= 1 {
 		lowestSafe, lowestLocalSafe := lowestFromCandidates()
-		return candidates, lowestSafe, lowestLocalSafe
+		return candidates, lowestSafe, lowestLocalSafe, false
+	}
+
+	// Disagreement exists. responders is the number of backends that returned a usable
+	// output root (errors and timeouts excluded), i.e. the total votes cast across all
+	// distinct roots. A backend root is canonical only with a strict majority of the
+	// responders (more than half); otherwise the top is a tie (1v1, 2-2, ...) or an N-way
+	// split, which cannot be resolved safely.
+	responders := 0
+	for _, count := range counts {
+		responders += count
+	}
+	if maxCount*2 <= responders {
+		// Unresolvable split: record the disagreement and return halt=true without banning
+		// anyone. See the function doc for how the caller handles a halt.
+		backendNames := make([]string, 0, len(results))
+		for _, r := range results {
+			if r.err == nil {
+				backendNames = append(backendNames, r.be.Name)
+				RecordCLOutputRootDisagreement(r.be)
+			}
+		}
+		log.Error("CL output root split with no majority - halting consensus advancement; serving last-agreed block; manual intervention required",
+			"safe_block", safeBlock,
+			"distinct_roots", len(counts),
+			"responders", responders,
+			"top_root_votes", maxCount,
+			"backends", backendNames,
+		)
+		return candidates, 0, 0, true
 	}
 
 	log.Info("CL output root verification",
 		"agreed_root", agreedRoot,
 		"safe_block", safeBlock,
 		"agreeing_backends", maxCount,
-		"total_responding", len(counts),
+		"total_responding", responders,
 	)
 
 	for _, r := range results {
@@ -497,7 +523,7 @@ func (cp *ConsensusPoller) verifyCLOutputRoots(
 	}
 
 	lowestSafe, lowestLocalSafe := lowestFromCandidates()
-	return candidates, lowestSafe, lowestLocalSafe
+	return candidates, lowestSafe, lowestLocalSafe, false
 }
 
 // fetchCLOutputRoot calls optimism_outputAtBlock and returns the outputRoot hash.

--- a/proxyd/consensus_poller_cl_test.go
+++ b/proxyd/consensus_poller_cl_test.go
@@ -210,6 +210,27 @@ func TestVerifyCLOutputRoots_TopTieHalts(t *testing.T) {
 	}
 }
 
+func TestVerifyCLOutputRoots_PluralityNoMajorityHalts(t *testing.T) {
+	// Five backends split 2-1-1-1: the top root leads with 2 votes (a plurality) but holds
+	// no strict majority of the 5 responders (2*2 == 4, not > 5). Without a strict majority
+	// the lead cannot be trusted as canonical, so verify must halt and ban no one.
+	roots := []string{"root_A", "root_A", "root_B", "root_C", "root_D"}
+	backends := make([]*Backend, 0, len(roots))
+	for _, root := range roots {
+		srv := httptest.NewServer(outputRootHandler(root))
+		defer srv.Close()
+		backends = append(backends, newTestBackend(t, srv, 2*time.Second))
+	}
+	cp := newTestPoller(backends, WithCLConsensusMode())
+
+	_, _, _, halt := cp.verifyCLOutputRoots(context.Background(), candidatesForMulti(cp, backends...), hexutil.Uint64(225))
+
+	require.True(t, halt, "2-1-1-1 plurality without a strict majority — must halt")
+	for _, be := range backends {
+		require.False(t, cp.IsBanned(be), "halt must not ban any backend")
+	}
+}
+
 func TestVerifyCLOutputRoots_MajorityResolvesNoHalt(t *testing.T) {
 	// 2v1 majority: a clear winner exists, so verify resolves (bans the minority) rather
 	// than halting. This is the "disagreement but majority -> don't halt" case.

--- a/proxyd/consensus_poller_cl_test.go
+++ b/proxyd/consensus_poller_cl_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -46,9 +47,21 @@ func newTestBackend(t *testing.T, srv *httptest.Server, timeout time.Duration) *
 	return be
 }
 
-// newTestPoller creates a ConsensusPoller with the given backends.
+// newTestPoller creates a ConsensusPoller with the given backends, registering each as a
+// primary so it is eligible as a consensus candidate (Primaries() requires an explicit
+// non-fallback entry in FallbackBackends).
+//
+// It defaults to a noop async handler so NewConsensusPoller does not spawn background
+// poller goroutines: these tests drive verifyCLOutputRoots / UpdateBackendGroupConsensus
+// synchronously and mutate backendState directly, so a live poller would race them.
+// Callers may override by passing their own WithAsyncHandler (last one wins).
 func newTestPoller(backends []*Backend, opts ...ConsensusOpt) *ConsensusPoller {
-	bg := &BackendGroup{Backends: backends}
+	fallbacks := make(map[string]bool, len(backends))
+	for _, be := range backends {
+		fallbacks[be.Name] = false
+	}
+	bg := &BackendGroup{Backends: backends, FallbackBackends: fallbacks}
+	opts = append([]ConsensusOpt{WithAsyncHandler(NewNoopAsyncHandler())}, opts...)
 	return NewConsensusPoller(bg, opts...)
 }
 
@@ -58,6 +71,19 @@ func candidatesFor(cp *ConsensusPoller, be *Backend) map[*Backend]*backendState 
 	bs.safeBlockNumber = hexutil.Uint64(225)
 	bs.localSafeBlockNumber = hexutil.Uint64(225)
 	return map[*Backend]*backendState{be: bs}
+}
+
+// candidatesForMulti returns a candidates map containing all the given backends, each with a
+// safe/local-safe block of 225 so verifyCLOutputRoots fetches the output root at that block.
+func candidatesForMulti(cp *ConsensusPoller, backends ...*Backend) map[*Backend]*backendState {
+	m := make(map[*Backend]*backendState, len(backends))
+	for _, be := range backends {
+		bs := cp.backendState[be]
+		bs.safeBlockNumber = hexutil.Uint64(225)
+		bs.localSafeBlockNumber = hexutil.Uint64(225)
+		m[be] = bs
+	}
+	return m
 }
 
 func TestVerifyCLOutputRoots_SingleTimeoutDoesNotBan(t *testing.T) {
@@ -117,4 +143,202 @@ func TestVerifyCLOutputRoots_ConfigurableBanThreshold(t *testing.T) {
 
 	cp.verifyCLOutputRoots(context.Background(), candidatesFor(cp, be), hexutil.Uint64(225))
 	require.True(t, cp.IsBanned(be), "threshold=1: first timeout should immediately ban")
+}
+
+// --- halt-on-tie: verifyCLOutputRoots decision tests ---
+
+func TestVerifyCLOutputRoots_TieHalts(t *testing.T) {
+	// Two backends disagree 1v1 — no majority. The split is unresolvable, so verify halts
+	// and bans no one.
+	srvA := httptest.NewServer(outputRootHandler("root_A"))
+	defer srvA.Close()
+	srvB := httptest.NewServer(outputRootHandler("root_B"))
+	defer srvB.Close()
+
+	beA := newTestBackend(t, srvA, 2*time.Second)
+	beB := newTestBackend(t, srvB, 2*time.Second)
+	cp := newTestPoller([]*Backend{beA, beB}, WithCLConsensusMode())
+
+	candidates := candidatesForMulti(cp, beA, beB)
+	resultCandidates, _, _, halt := cp.verifyCLOutputRoots(context.Background(), candidates, hexutil.Uint64(225))
+
+	require.True(t, halt, "1v1 disagreement has no majority — must halt")
+	require.False(t, cp.IsBanned(beA), "halt must not ban any backend")
+	require.False(t, cp.IsBanned(beB), "halt must not ban any backend")
+	require.Len(t, resultCandidates, 2, "no backend should be removed on halt")
+}
+
+func TestVerifyCLOutputRoots_ThreeWaySplitHalts(t *testing.T) {
+	// Three backends, three distinct roots — no majority. Must halt, ban no one.
+	srvA := httptest.NewServer(outputRootHandler("root_A"))
+	defer srvA.Close()
+	srvB := httptest.NewServer(outputRootHandler("root_B"))
+	defer srvB.Close()
+	srvC := httptest.NewServer(outputRootHandler("root_C"))
+	defer srvC.Close()
+
+	beA := newTestBackend(t, srvA, 2*time.Second)
+	beB := newTestBackend(t, srvB, 2*time.Second)
+	beC := newTestBackend(t, srvC, 2*time.Second)
+	cp := newTestPoller([]*Backend{beA, beB, beC}, WithCLConsensusMode())
+
+	_, _, _, halt := cp.verifyCLOutputRoots(context.Background(), candidatesForMulti(cp, beA, beB, beC), hexutil.Uint64(225))
+
+	require.True(t, halt, "3-way split has no majority — must halt")
+	require.False(t, cp.IsBanned(beA))
+	require.False(t, cp.IsBanned(beB))
+	require.False(t, cp.IsBanned(beC))
+}
+
+func TestVerifyCLOutputRoots_TopTieHalts(t *testing.T) {
+	// Five backends split 2-2-1: the top two roots tie at 2 votes each (2*2 == 4, not > 5
+	// responders, and certainly not a strict majority). No clear winner — must halt.
+	roots := []string{"root_A", "root_A", "root_B", "root_B", "root_C"}
+	backends := make([]*Backend, 0, len(roots))
+	for _, root := range roots {
+		srv := httptest.NewServer(outputRootHandler(root))
+		defer srv.Close()
+		backends = append(backends, newTestBackend(t, srv, 2*time.Second))
+	}
+	cp := newTestPoller(backends, WithCLConsensusMode())
+
+	_, _, _, halt := cp.verifyCLOutputRoots(context.Background(), candidatesForMulti(cp, backends...), hexutil.Uint64(225))
+
+	require.True(t, halt, "2-2-1 has a tie at the top — must halt")
+	for _, be := range backends {
+		require.False(t, cp.IsBanned(be), "halt must not ban any backend")
+	}
+}
+
+func TestVerifyCLOutputRoots_MajorityResolvesNoHalt(t *testing.T) {
+	// 2v1 majority: a clear winner exists, so verify resolves (bans the minority) rather
+	// than halting. This is the "disagreement but majority -> don't halt" case.
+	srvA := httptest.NewServer(outputRootHandler("root_majority"))
+	defer srvA.Close()
+	srvB := httptest.NewServer(outputRootHandler("root_majority"))
+	defer srvB.Close()
+	srvC := httptest.NewServer(outputRootHandler("root_minority"))
+	defer srvC.Close()
+
+	beA := newTestBackend(t, srvA, 2*time.Second)
+	beB := newTestBackend(t, srvB, 2*time.Second)
+	beC := newTestBackend(t, srvC, 2*time.Second)
+	cp := newTestPoller([]*Backend{beA, beB, beC}, WithCLConsensusMode())
+
+	resultCandidates, _, _, halt := cp.verifyCLOutputRoots(context.Background(), candidatesForMulti(cp, beA, beB, beC), hexutil.Uint64(225))
+
+	require.False(t, halt, "a strict majority resolves the disagreement — must not halt")
+	require.True(t, cp.IsBanned(beC), "the minority backend must be banned")
+	require.False(t, cp.IsBanned(beA), "majority backends must not be banned")
+	require.False(t, cp.IsBanned(beB), "majority backends must not be banned")
+	require.Len(t, resultCandidates, 2, "only the banned minority is removed")
+}
+
+func TestVerifyCLOutputRoots_UnanimousNoHalt(t *testing.T) {
+	// All agree — no disagreement, no halt, no bans.
+	srvA := httptest.NewServer(outputRootHandler("root_same"))
+	defer srvA.Close()
+	srvB := httptest.NewServer(outputRootHandler("root_same"))
+	defer srvB.Close()
+	srvC := httptest.NewServer(outputRootHandler("root_same"))
+	defer srvC.Close()
+
+	beA := newTestBackend(t, srvA, 2*time.Second)
+	beB := newTestBackend(t, srvB, 2*time.Second)
+	beC := newTestBackend(t, srvC, 2*time.Second)
+	cp := newTestPoller([]*Backend{beA, beB, beC}, WithCLConsensusMode())
+
+	resultCandidates, _, _, halt := cp.verifyCLOutputRoots(context.Background(), candidatesForMulti(cp, beA, beB, beC), hexutil.Uint64(225))
+
+	require.False(t, halt, "unanimous agreement must not halt")
+	require.Len(t, resultCandidates, 3, "no backend removed when all agree")
+	require.False(t, cp.IsBanned(beA))
+	require.False(t, cp.IsBanned(beB))
+	require.False(t, cp.IsBanned(beC))
+}
+
+func TestVerifyCLOutputRoots_AllErroredNoHalt(t *testing.T) {
+	// No backend returns a usable root (all time out). Verification could not run — this is
+	// not a disagreement, so it must NOT halt (halting is reserved for genuine splits).
+	srvA := httptest.NewServer(hangingHandler())
+	defer srvA.Close()
+	srvB := httptest.NewServer(hangingHandler())
+	defer srvB.Close()
+
+	beA := newTestBackend(t, srvA, 100*time.Millisecond)
+	beB := newTestBackend(t, srvB, 100*time.Millisecond)
+	cp := newTestPoller([]*Backend{beA, beB}, WithCLConsensusMode())
+
+	_, _, _, halt := cp.verifyCLOutputRoots(context.Background(), candidatesForMulti(cp, beA, beB), hexutil.Uint64(225))
+
+	require.False(t, halt, "all-errored is not a disagreement — must not halt")
+}
+
+// --- halt-on-tie: caller freeze + auto-recover ---
+
+// switchableRootHandler returns an HTTP handler whose served output root can be changed at
+// runtime via the returned setter, so a single backend can flip between disagreement and
+// agreement across consensus cycles.
+func switchableRootHandler(initial string) (http.HandlerFunc, func(string)) {
+	var root atomic.Pointer[string]
+	root.Store(&initial)
+	h := func(w http.ResponseWriter, r *http.Request) {
+		outputRootHandler(*root.Load())(w, r)
+	}
+	return h, func(s string) {
+		v := s
+		root.Store(&v)
+	}
+}
+
+// seedCLBackendState populates the live backend state so the backend passes FilterCandidates
+// in CL mode (healthy, in sync, enough peers, recently updated, not lagging).
+func seedCLBackendState(cp *ConsensusPoller, be *Backend, latest, safe, localSafe, finalized hexutil.Uint64) {
+	bs := cp.backendState[be]
+	bs.latestBlockNumber = latest
+	bs.latestBlockHash = "0xhash"
+	bs.safeBlockNumber = safe
+	bs.localSafeBlockNumber = localSafe
+	bs.finalizedBlockNumber = finalized
+	bs.peerCount = 5
+	bs.inSync = true
+	bs.lastUpdate = time.Now()
+}
+
+func TestUpdateBackendGroupConsensus_HaltFreezesAndRecovers(t *testing.T) {
+	// Backend A flips its root; backend B is fixed at root_B. While they disagree (1v1, no
+	// majority), consensus halts: the served block height stays frozen at the last-agreed
+	// value (200) instead of advancing to the disputed block (225), and the served group is
+	// emptied so general RPCs fail closed. Backends are not persistently banned. Once A
+	// agrees again, consensus auto-recovers: the group repopulates and the block advances.
+	handlerA, setRootA := switchableRootHandler("root_A")
+	srvA := httptest.NewServer(handlerA)
+	defer srvA.Close()
+	srvB := httptest.NewServer(outputRootHandler("root_B"))
+	defer srvB.Close()
+
+	beA := newTestBackend(t, srvA, 2*time.Second)
+	beB := newTestBackend(t, srvB, 2*time.Second)
+	cp := newTestPoller([]*Backend{beA, beB}, WithCLConsensusMode())
+
+	// Seed the last-agreed consensus state.
+	cp.tracker.SetState(ConsensusTrackerState{Latest: 210, Safe: 200, Finalized: 190, LocalSafe: 200})
+	// Both backends now report a higher safe block (225), but their output roots disagree.
+	seedCLBackendState(cp, beA, 230, 225, 225, 190)
+	seedCLBackendState(cp, beB, 230, 225, 225, 190)
+
+	// Disagreement cycle: must halt - freeze the served height and empty the group.
+	cp.UpdateBackendGroupConsensus(context.Background())
+	require.EqualValues(t, 200, cp.GetSafeBlockNumber(), "safe block must stay frozen at the last-agreed value")
+	require.EqualValues(t, 210, cp.GetLatestBlockNumber(), "latest block must stay frozen during a halt")
+	require.Empty(t, cp.GetConsensusGroup(), "served group must be emptied so general RPCs fail closed")
+	require.False(t, cp.IsBanned(beA), "halt must not persistently ban a backend")
+	require.False(t, cp.IsBanned(beB), "halt must not persistently ban a backend")
+
+	// Backends re-agree: consensus must auto-recover and advance.
+	setRootA("root_B")
+	cp.UpdateBackendGroupConsensus(context.Background())
+	require.EqualValues(t, 225, cp.GetSafeBlockNumber(), "safe block must advance once a majority returns")
+	require.EqualValues(t, 230, cp.GetLatestBlockNumber(), "latest block must advance after recovery")
+	require.Len(t, cp.GetConsensusGroup(), 2, "both backends must repopulate the group after recovery")
 }

--- a/proxyd/consensus_poller_cl_test.go
+++ b/proxyd/consensus_poller_cl_test.go
@@ -255,6 +255,40 @@ func TestVerifyCLOutputRoots_MajorityResolvesNoHalt(t *testing.T) {
 	require.Len(t, resultCandidates, 2, "only the banned minority is removed")
 }
 
+func TestVerifyCLOutputRoots_MajorityOverMultipleMinoritiesResolves(t *testing.T) {
+	// Five backends split 3-1-1: the top root holds 3 of 5 votes — a strict majority
+	// (3*2 == 6 > 5). The disagreement resolves rather than halting, and every disagreeing
+	// backend is banned, not just one. This is the companion to the 2-1-1-1 plurality case,
+	// which halts because it falls one vote short of a majority.
+	srvMaj1 := httptest.NewServer(outputRootHandler("root_majority"))
+	defer srvMaj1.Close()
+	srvMaj2 := httptest.NewServer(outputRootHandler("root_majority"))
+	defer srvMaj2.Close()
+	srvMaj3 := httptest.NewServer(outputRootHandler("root_majority"))
+	defer srvMaj3.Close()
+	srvMin1 := httptest.NewServer(outputRootHandler("root_minority_1"))
+	defer srvMin1.Close()
+	srvMin2 := httptest.NewServer(outputRootHandler("root_minority_2"))
+	defer srvMin2.Close()
+
+	beMaj1 := newTestBackend(t, srvMaj1, 2*time.Second)
+	beMaj2 := newTestBackend(t, srvMaj2, 2*time.Second)
+	beMaj3 := newTestBackend(t, srvMaj3, 2*time.Second)
+	beMin1 := newTestBackend(t, srvMin1, 2*time.Second)
+	beMin2 := newTestBackend(t, srvMin2, 2*time.Second)
+	cp := newTestPoller([]*Backend{beMaj1, beMaj2, beMaj3, beMin1, beMin2}, WithCLConsensusMode())
+
+	resultCandidates, _, _, halt := cp.verifyCLOutputRoots(context.Background(), candidatesForMulti(cp, beMaj1, beMaj2, beMaj3, beMin1, beMin2), hexutil.Uint64(225))
+
+	require.False(t, halt, "3-of-5 is a strict majority — must resolve, not halt")
+	require.False(t, cp.IsBanned(beMaj1), "majority backends must not be banned")
+	require.False(t, cp.IsBanned(beMaj2), "majority backends must not be banned")
+	require.False(t, cp.IsBanned(beMaj3), "majority backends must not be banned")
+	require.True(t, cp.IsBanned(beMin1), "every minority backend must be banned")
+	require.True(t, cp.IsBanned(beMin2), "every minority backend must be banned")
+	require.Len(t, resultCandidates, 3, "both minorities are removed, majority remains")
+}
+
 func TestVerifyCLOutputRoots_UnanimousNoHalt(t *testing.T) {
 	// All agree — no disagreement, no halt, no bans.
 	srvA := httptest.NewServer(outputRootHandler("root_same"))
@@ -293,6 +327,41 @@ func TestVerifyCLOutputRoots_AllErroredNoHalt(t *testing.T) {
 	_, _, _, halt := cp.verifyCLOutputRoots(context.Background(), candidatesForMulti(cp, beA, beB), hexutil.Uint64(225))
 
 	require.False(t, halt, "all-errored is not a disagreement — must not halt")
+}
+
+func TestVerifyCLOutputRoots_TimeoutsExcludedFromResponderCount(t *testing.T) {
+	// Five backends, but two time out: only three respond, splitting 2-1. Errored backends
+	// are excluded from the responder count, so the majority is measured over the 3 responders
+	// (2*2 == 4 > 3) — a strict majority that resolves rather than halts. The lone minority
+	// responder is banned; the timed-out backends are tolerated (one timeout is below the ban
+	// threshold) and stay candidates, so four candidates survive.
+	srvMaj1 := httptest.NewServer(outputRootHandler("root_majority"))
+	defer srvMaj1.Close()
+	srvMaj2 := httptest.NewServer(outputRootHandler("root_majority"))
+	defer srvMaj2.Close()
+	srvMin := httptest.NewServer(outputRootHandler("root_minority"))
+	defer srvMin.Close()
+	srvTimeout1 := httptest.NewServer(hangingHandler())
+	defer srvTimeout1.Close()
+	srvTimeout2 := httptest.NewServer(hangingHandler())
+	defer srvTimeout2.Close()
+
+	beMaj1 := newTestBackend(t, srvMaj1, 2*time.Second)
+	beMaj2 := newTestBackend(t, srvMaj2, 2*time.Second)
+	beMin := newTestBackend(t, srvMin, 2*time.Second)
+	beTimeout1 := newTestBackend(t, srvTimeout1, 100*time.Millisecond)
+	beTimeout2 := newTestBackend(t, srvTimeout2, 100*time.Millisecond)
+	cp := newTestPoller([]*Backend{beMaj1, beMaj2, beMin, beTimeout1, beTimeout2}, WithCLConsensusMode())
+
+	resultCandidates, _, _, halt := cp.verifyCLOutputRoots(context.Background(), candidatesForMulti(cp, beMaj1, beMaj2, beMin, beTimeout1, beTimeout2), hexutil.Uint64(225))
+
+	require.False(t, halt, "majority over the 3 responders resolves — timed-out backends don't count toward the split")
+	require.True(t, cp.IsBanned(beMin), "the minority responder must be banned")
+	require.False(t, cp.IsBanned(beMaj1), "majority responders must not be banned")
+	require.False(t, cp.IsBanned(beMaj2), "majority responders must not be banned")
+	require.False(t, cp.IsBanned(beTimeout1), "a single timeout is tolerated — must not ban")
+	require.False(t, cp.IsBanned(beTimeout2), "a single timeout is tolerated — must not ban")
+	require.Len(t, resultCandidates, 4, "minority removed; majority and tolerated-timeout backends remain")
 }
 
 // --- halt-on-tie: caller freeze + auto-recover ---

--- a/proxyd/integration_tests/consensus_cl_test.go
+++ b/proxyd/integration_tests/consensus_cl_test.go
@@ -962,9 +962,11 @@ func TestConsensusCL(t *testing.T) {
 		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
 	})
 
-	t.Run("output root: all backends disagree, no majority — nobody banned", func(t *testing.T) {
-		// 3 backends each return a unique output root → no backend has ≥2 votes.
-		// Without a majority we cannot determine who is correct, so nobody should be banned.
+	t.Run("output root: all backends disagree, no majority — halts and fails closed", func(t *testing.T) {
+		// 3 backends each return a unique output root → no backend has a majority.
+		// Without a majority the split is unresolvable, so consensus halts: nobody is
+		// persistently banned (so it can auto-recover), but the served group is emptied so
+		// general RPCs fail closed rather than being routed to a backend on an uncertain fork.
 		reset()
 		override("node1", "optimism_outputAtBlock", "0xe1", buildResponse(map[string]interface{}{
 			"outputRoot": "root_A",
@@ -983,7 +985,7 @@ func TestConsensusCL(t *testing.T) {
 		require.False(t, bg.Consensus.IsBanned(nodes["node1"].backend))
 		require.False(t, bg.Consensus.IsBanned(nodes["node2"].backend))
 		require.False(t, bg.Consensus.IsBanned(nodes["node3"].backend))
-		require.Equal(t, 3, len(bg.Consensus.GetConsensusGroup()))
+		require.Equal(t, 0, len(bg.Consensus.GetConsensusGroup()), "halt empties the served group (fail closed)")
 	})
 
 	t.Run("output root ban recovery", func(t *testing.T) {

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -532,6 +532,25 @@ var (
 		Help:      "Count of output root disagreement events per backend. Incremented for every backend whose output root does not match the rest of the group, whether or not a ban was issued.",
 	}, []string{"backend_name"})
 
+	// consensusCLHalted is a bool gauge that is set to 1 while a CL backend group is halted
+	// because its backends disagree on the output root with no majority to resolve the split.
+	// While halted, consensus does not advance — the group serves the last-agreed block.
+	// It auto-clears to 0 once a majority returns. Alert on this gauge == 1: a halt signals a
+	// potential chain split or derivation divergence requiring manual intervention.
+	consensusCLHalted = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "consensus_cl_halted",
+		Help:      "Bool gauge: 1 while a CL backend group is halted on an unresolvable output root split (no majority), 0 otherwise.",
+	}, []string{"backend_group_name"})
+
+	// consensusCLHaltTotal counts how many consensus cycles entered the halted state, for
+	// incident frequency tracking and rate alerting.
+	consensusCLHaltTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "consensus_cl_halt_total",
+		Help:      "Count of consensus cycles halted due to an unresolvable output root split (no majority).",
+	}, []string{"backend_group_name"})
+
 	consensusUpdateDelayBackend = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
 		Name:      "consensus_backend_update_delay",
@@ -816,6 +835,18 @@ func RecordCLGroupLocalSafeBlock(group *BackendGroup, blockNumber hexutil.Uint64
 
 func RecordCLOutputRootDisagreement(b *Backend) {
 	consensusCLOutputRootDisagreementTotal.WithLabelValues(b.Name).Inc()
+}
+
+// RecordCLConsensusHalted updates the halted gauge for a group: 1 when halted, 0 otherwise.
+// When halted is true it also increments the halt counter; the counter therefore rises once
+// per halted consensus cycle, not once per transition into the halted state.
+func RecordCLConsensusHalted(group *BackendGroup, halted bool) {
+	if halted {
+		consensusCLHalted.WithLabelValues(group.Name).Set(1)
+		consensusCLHaltTotal.WithLabelValues(group.Name).Inc()
+	} else {
+		consensusCLHalted.WithLabelValues(group.Name).Set(0)
+	}
 }
 
 func RecordCLBanNotHealthy(b *Backend) {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -582,12 +582,10 @@ func Start(config *Config) (*Server, func(), error) {
 
 			if bgcfg.RoutingStrategy == ConsensusAwareCLRoutingStrategy {
 				copts = append(copts, WithCLConsensusMode())
-				if n := len(bg.Backends); n%2 == 0 {
-					log.Crit("CL consensus requires an odd number of backends: output root verification needs a majority to evict a diverging backend; an even-sized group cannot resolve a tie",
-						"backend_group", bgName,
-						"backend_count", n,
-					)
-				}
+				// Any backend count is permitted, including even/2-node cross-client groups
+				// (e.g. op-node + kona-node). An output root disagreement with no majority is
+				// not resolved by eviction — consensus halts and serves the last-agreed block
+				// until a majority returns (see verifyCLOutputRoots).
 				for _, be := range bg.Backends {
 					if be.client.Timeout == 0 {
 						log.Crit("CL consensus requires a backend timeout; set response_timeout_seconds or response_timeout_milliseconds",


### PR DESCRIPTION
**Description**

Adds output-root split protection to proxyd's CL (consensus layer) routing. Each consensus cycle the poller calls `optimism_outputAtBlock` at the group's safe block on every candidate backend and compares the returned output roots:

- **Strict-majority disagreement** — a backend whose root differs from a strict majority of responders is banned (now precisely defined as `topVotes*2 > responders`).
- **No-majority disagreement** — a tie (1v1, 2-2) or an N-way split has no safe winner, so consensus **halts** instead of guessing:
  - the served block height and the cached `optimism_syncStatus` body **freeze** at the last-agreed value, so clients keep seeing the previous response;
  - the served consensus group is **emptied**, so general RPCs **fail closed** (`ErrNoBackends`) rather than being routed to a backend on an uncertain fork.

Backends are **not** persistently banned during a halt — they are still polled and re-verified every cycle — so consensus **auto-recovers** as soon as a majority returns. A halt signals a potential chain split / derivation divergence and warrants operator attention.

This also removes the odd-backend-count startup guard: **any backend count is now permitted**, including even / 2-node cross-client groups (e.g. op-node + kona-node), since ties now halt rather than needing a majority to resolve.

New metrics:
- `proxyd_consensus_cl_halted` — bool gauge, set to 1 while a group is halted (alert target).
- `proxyd_consensus_cl_halt_total` — counter of halted consensus cycles.

**Tests**

- Unit decision tests for `verifyCLOutputRoots`: 1v1 / 3-way / 2-2-1 tie → halt; 2v1 majority bans the minority; unanimous and all-errored → no halt.
- End-to-end `UpdateBackendGroupConsensus` test: a split freezes the served height and empties the group, then auto-recovers (group repopulates, block advances) once backends re-agree.
- CL integration test (`TestConsensusCL`): the all-backends-disagree case now asserts the group fails closed (emptied) with nobody persistently banned.
- All pass under `-race`; the full integration suite is green.

**Additional context**

- The halt is intentionally fail-closed (general RPCs error during a split) rather than serving possibly-forked data — a deliberate safety-over-availability choice for derivation divergence.
- Known edge case: a slow / timing-out **majority** backend can momentarily collapse a 2v1 into a 1v1 tie and trigger a transient (single-cycle) halt that auto-recovers the next cycle. A persistence threshold could be added later if this proves noisy.

**Metadata**

- Fixes #[Link to Issue]
