### PR TITLE
feat(peer-mgmt-service): add external peer support

### DIFF
--- a/peer-mgmt-service/config.example.yaml
+++ b/peer-mgmt-service/config.example.yaml
@@ -20,9 +20,16 @@ nodes:
     rpc_address: http://op-node-0:9545
   op-node-1:
     rpc_address: http://op-node-1:9545
+  # External peer: no rpc_address. PMS will not poll it. Internal nodes that
+  # share a network with this entry will dial peer_address and protect peer_id.
+  # peer_id and peer_address are required when rpc_address is omitted.
+  external-bootnode:
+    peer_id: 16Uiu2HAm...
+    peer_address: /dns4/bootnode.example.com/tcp/9003/p2p/16Uiu2HAm...
 
 networks:
   network_name:
     members:
       - op-node-0
       - op-node-1
+      - external-bootnode

--- a/peer-mgmt-service/config.example.yaml
+++ b/peer-mgmt-service/config.example.yaml
@@ -24,8 +24,8 @@ nodes:
   # share a network with this entry will dial peer_address and protect peer_id.
   # peer_id and peer_address are required when rpc_address is omitted.
   external-bootnode:
-    peer_id: 16Uiu2HAm...
-    peer_address: /dns4/bootnode.example.com/tcp/9003/p2p/16Uiu2HAm...
+    peer_id: 16Uiu2HAmFV3qmRmrnEByXMWFNVbBxbnLuG9PvKsgpvJgZqLF2sB1
+    peer_address: /dns4/bootnode.example.com/tcp/9003/p2p/16Uiu2HAmFV3qmRmrnEByXMWFNVbBxbnLuG9PvKsgpvJgZqLF2sB1
 
 networks:
   network_name:

--- a/peer-mgmt-service/pkg/config/config.go
+++ b/peer-mgmt-service/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
@@ -101,6 +102,9 @@ func (c *Config) Validate() error {
 			if node.PeerAddress == "" {
 				return errors.Errorf("node [%s] is external (no rpc_address) but peer_address is missing", name)
 			}
+			if _, err := peer.Decode(node.PeerID); err != nil {
+				return errors.Errorf("node [%s] has invalid peer_id [%s]: %v", name, node.PeerID, err)
+			}
 		}
 	}
 
@@ -108,10 +112,18 @@ func (c *Config) Validate() error {
 		if len(network.Members) < 2 {
 			return errors.Errorf("network [%s] has less than 2 members", name)
 		}
+		internalCount := 0
 		for _, member := range network.Members {
-			if _, ok := c.Nodes[member]; !ok {
+			nodeCfg, ok := c.Nodes[member]
+			if !ok {
 				return errors.Errorf("network [%s] member [%s] is not configured", name, member)
 			}
+			if !nodeCfg.IsExternal() {
+				internalCount++
+			}
+		}
+		if internalCount == 0 {
+			return errors.Errorf("network [%s] has no internal members (all members are external; nothing to dial from)", name)
 		}
 	}
 

--- a/peer-mgmt-service/pkg/config/config.go
+++ b/peer-mgmt-service/pkg/config/config.go
@@ -54,6 +54,13 @@ type NetworkConfig struct {
 	Members []string `yaml:"members"`
 }
 
+// IsExternal reports whether this node is an external peer.
+// External peers have no rpc_address; PMS only dials them from internal nodes
+// using the static peer_address.
+func (n *NodeConfig) IsExternal() bool {
+	return n.RPCAddress == ""
+}
+
 func New(file string) (*Config, error) {
 	cfg := &Config{}
 	contents, err := os.ReadFile(file)
@@ -86,9 +93,14 @@ func (c *Config) Validate() error {
 		return errors.New("no networks configured")
 	}
 
-	for name, nodes := range c.Nodes {
-		if nodes.RPCAddress == "" {
-			return errors.Errorf("node [%s] rpc address is missing", name)
+	for name, node := range c.Nodes {
+		if node.IsExternal() {
+			if node.PeerID == "" {
+				return errors.Errorf("node [%s] is external (no rpc_address) but peer_id is missing", name)
+			}
+			if node.PeerAddress == "" {
+				return errors.Errorf("node [%s] is external (no rpc_address) but peer_address is missing", name)
+			}
 		}
 	}
 

--- a/peer-mgmt-service/pkg/config/config_test.go
+++ b/peer-mgmt-service/pkg/config/config_test.go
@@ -63,7 +63,10 @@ func TestConfig_Validate_ExternalPeer(t *testing.T) {
 		return &Config{
 			Nodes: map[string]*NodeConfig{
 				"internal": {RPCAddress: "http://internal:9545"},
-				"external": {PeerID: "16Uiu2HAm...", PeerAddress: "/dns4/ext/tcp/9003/p2p/16Uiu2HAm..."},
+				"external": {
+					PeerID:      "16Uiu2HAmFV3qmRmrnEByXMWFNVbBxbnLuG9PvKsgpvJgZqLF2sB1",
+					PeerAddress: "/dns4/ext/tcp/9003/p2p/16Uiu2HAmFV3qmRmrnEByXMWFNVbBxbnLuG9PvKsgpvJgZqLF2sB1",
+				},
 			},
 			Networks: map[string]*NetworkConfig{
 				"net": {Members: []string{"internal", "external"}},
@@ -96,5 +99,27 @@ func TestConfig_Validate_ExternalPeer(t *testing.T) {
 		c.Nodes["external"] = &NodeConfig{}
 		err := c.Validate()
 		require.Error(t, err)
+	})
+
+	t.Run("invalid: external peer with malformed peer_id", func(t *testing.T) {
+		c := base()
+		c.Nodes["external"].PeerID = "not-a-valid-peer-id"
+		err := c.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid peer_id")
+	})
+
+	t.Run("invalid: network with no internal members", func(t *testing.T) {
+		c := base()
+		// Make the internal node external too, so the network has only externals.
+		c.Nodes["internal"] = &NodeConfig{
+			PeerID:      "16Uiu2HAmFV3qmRmrnEByXMWFNVbBxbnLuG9PvKsgpvJgZqLF2sB1",
+			PeerAddress: "/dns4/x/tcp/9003/p2p/16Uiu2HAmFV3qmRmrnEByXMWFNVbBxbnLuG9PvKsgpvJgZqLF2sB1",
+		}
+		c.Nodes["external"].PeerID = "16Uiu2HAmFV3qmRmrnEByXMWFNVbBxbnLuG9PvKsgpvJgZqLF2sB1"
+		c.Nodes["external"].PeerAddress = "/dns4/y/tcp/9003/p2p/16Uiu2HAmFV3qmRmrnEByXMWFNVbBxbnLuG9PvKsgpvJgZqLF2sB1"
+		err := c.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no internal members")
 	})
 }

--- a/peer-mgmt-service/pkg/config/config_test.go
+++ b/peer-mgmt-service/pkg/config/config_test.go
@@ -29,14 +29,16 @@ func TestConfig(t *testing.T) {
 		require.Equal(t, mustParseDuration("1h"), config.NodeStateExpiration)
 		require.Equal(t, mustParseDuration("15s"), config.RPCTimeout)
 
-		require.Equal(t, 2, len(config.Nodes))
+		require.Equal(t, 3, len(config.Nodes))
 		require.Equal(t, "http://op-node-0:9545", config.Nodes["op-node-0"].RPCAddress)
 		require.Equal(t, "http://op-node-1:9545", config.Nodes["op-node-1"].RPCAddress)
+		require.True(t, config.Nodes["external-bootnode"].IsExternal())
 
 		require.Equal(t, 1, len(config.Networks))
-		require.Equal(t, 2, len(config.Networks["network_name"].Members))
+		require.Equal(t, 3, len(config.Networks["network_name"].Members))
 		require.Equal(t, "op-node-0", config.Networks["network_name"].Members[0])
 		require.Equal(t, "op-node-1", config.Networks["network_name"].Members[1])
+		require.Equal(t, "external-bootnode", config.Networks["network_name"].Members[2])
 
 		require.NoError(t, config.Validate())
 	})

--- a/peer-mgmt-service/pkg/config/config_test.go
+++ b/peer-mgmt-service/pkg/config/config_test.go
@@ -49,3 +49,50 @@ func mustParseDuration(s string) time.Duration {
 	}
 	return d
 }
+
+func TestNodeConfig_IsExternal(t *testing.T) {
+	require.True(t, (&NodeConfig{}).IsExternal())
+	require.True(t, (&NodeConfig{PeerID: "p", PeerAddress: "/dns4/foo/p2p/p"}).IsExternal())
+	require.False(t, (&NodeConfig{RPCAddress: "http://x"}).IsExternal())
+}
+
+func TestConfig_Validate_ExternalPeer(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			Nodes: map[string]*NodeConfig{
+				"internal": {RPCAddress: "http://internal:9545"},
+				"external": {PeerID: "16Uiu2HAm...", PeerAddress: "/dns4/ext/tcp/9003/p2p/16Uiu2HAm..."},
+			},
+			Networks: map[string]*NetworkConfig{
+				"net": {Members: []string{"internal", "external"}},
+			},
+		}
+	}
+
+	t.Run("valid: external peer with peer_id and peer_address", func(t *testing.T) {
+		require.NoError(t, base().Validate())
+	})
+
+	t.Run("invalid: external peer missing peer_id", func(t *testing.T) {
+		c := base()
+		c.Nodes["external"].PeerID = ""
+		err := c.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "peer_id")
+	})
+
+	t.Run("invalid: external peer missing peer_address", func(t *testing.T) {
+		c := base()
+		c.Nodes["external"].PeerAddress = ""
+		err := c.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "peer_address")
+	})
+
+	t.Run("invalid: node missing both rpc_address and peer info", func(t *testing.T) {
+		c := base()
+		c.Nodes["external"] = &NodeConfig{}
+		err := c.Validate()
+		require.Error(t, err)
+	})
+}

--- a/peer-mgmt-service/pkg/pms/network.go
+++ b/peer-mgmt-service/pkg/pms/network.go
@@ -56,9 +56,10 @@ func New(
 		},
 	}
 
-	// Pre-register external peers so their PeerIDs resolve to a known name
-	// without ever polling them.
-	for nodeName, nodeConfig := range nodesConfig {
+	// Pre-register external peers (members of this network with no rpc_address)
+	// so their PeerIDs resolve to a known name without ever polling them.
+	for _, nodeName := range networkConfig.Members {
+		nodeConfig := nodesConfig[nodeName]
 		if nodeConfig.IsExternal() {
 			network.state.nodesByPeerID[nodeConfig.PeerID] = nodeName
 		}

--- a/peer-mgmt-service/pkg/pms/network.go
+++ b/peer-mgmt-service/pkg/pms/network.go
@@ -55,6 +55,15 @@ func New(
 			nodesByPeerID: make(map[string]string, len(nodesConfig)),
 		},
 	}
+
+	// Pre-register external peers so their PeerIDs resolve to a known name
+	// without ever polling them.
+	for nodeName, nodeConfig := range nodesConfig {
+		if nodeConfig.IsExternal() {
+			network.state.nodesByPeerID[nodeConfig.PeerID] = nodeName
+		}
+	}
+
 	return network
 }
 

--- a/peer-mgmt-service/pkg/pms/poll.go
+++ b/peer-mgmt-service/pkg/pms/poll.go
@@ -52,6 +52,9 @@ func (n *Network) cleanup(ctx context.Context) {
 
 func (n *Network) poll(ctx context.Context) {
 	for nodeName, nodeConfig := range n.nodesConfig {
+		if nodeConfig.IsExternal() {
+			continue
+		}
 		n.pollNode(ctx, nodeName, nodeConfig)
 	}
 }

--- a/peer-mgmt-service/pkg/pms/poll.go
+++ b/peer-mgmt-service/pkg/pms/poll.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/infra/peer-mgmt-service/pkg/metrics"
 	"github.com/ethereum-optimism/infra/peer-mgmt-service/pkg/metrics/opp2p_client"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 func (n *Network) Tick(ctx context.Context) {
@@ -271,50 +272,27 @@ func (n *Network) connectPeer(ctx context.Context, nodeName string, peerName str
 
 	nodeState := n.state.nodes[nodeName]
 	nodeConfig := n.nodesConfig[nodeName]
-	peerState := n.state.nodes[peerName]
 	peerConfig := n.nodesConfig[peerName]
 
 	if nodeState == nil {
-		log.Error("node state not found",
-			"network", n.name,
-			"node", nodeName)
+		log.Error("node state not found", "network", n.name, "node", nodeName)
 		return
 	}
-
 	if nodeConfig == nil {
-		log.Error("node config not found",
-			"network", n.name,
-			"node", nodeName)
+		log.Error("node config not found", "network", n.name, "node", nodeName)
 		return
 	}
-
-	if peerState == nil {
-		log.Error("peer state not found",
-			"network", n.name,
-			"node", nodeName,
-			"peer", peerName)
-		return
-	}
-
 	if peerConfig == nil {
-		log.Error("peer config not found",
-			"network", n.name,
-			"node", nodeName,
-			"peer", peerName)
+		log.Error("peer config not found", "network", n.name, "node", nodeName, "peer", peerName)
 		return
 	}
 
 	if nodeConfig.PreventOutbound {
-		log.Debug("node has outbound disabled",
-			"network", n.name,
-			"node", nodeName)
+		log.Debug("node has outbound disabled", "network", n.name, "node", nodeName)
 		return
 	}
-
 	if peerConfig.PreventInbound {
-		log.Debug("peer has inbound disabled",
-			"network", n.name,
-			"peer", peerName)
+		log.Debug("peer has inbound disabled", "network", n.name, "peer", peerName)
 		return
 	}
 
@@ -323,6 +301,29 @@ func (n *Network) connectPeer(ctx context.Context, nodeName string, peerName str
 		return
 	}
 
+	if peerConfig.IsExternal() {
+		n.connectExternalPeer(ctx, client, nodeName, nodeConfig, peerName, peerConfig)
+		return
+	}
+
+	peerState := n.state.nodes[peerName]
+	if peerState == nil {
+		log.Error("peer state not found", "network", n.name, "node", nodeName, "peer", peerName)
+		return
+	}
+	n.connectInternalPeer(ctx, client, nodeName, nodeConfig, nodeState, peerName, peerConfig, peerState)
+}
+
+func (n *Network) connectInternalPeer(
+	ctx context.Context,
+	client *opp2p_client.InstrumentedOpP2PClient,
+	nodeName string,
+	nodeConfig *config.NodeConfig,
+	nodeState *NodeState,
+	peerName string,
+	peerConfig *config.NodeConfig,
+	peerState *NodeState,
+) {
 	peerClient, err := opp2p_client.New(ctx, n.config, n.name, peerName, peerConfig.RPCAddress)
 	if err != nil {
 		return
@@ -344,7 +345,6 @@ func (n *Network) connectPeer(ctx context.Context, nodeName string, peerName str
 		peerID = peerState.self.PeerID.String()
 	}
 
-	// special case for automatic PeerID discovery
 	const PEER_ID_PLACEHOLDER = "{peer_id}"
 	if strings.HasPrefix(peerAddr, "/dns4/") && strings.HasSuffix(peerAddr, "/p2p/"+PEER_ID_PLACEHOLDER) {
 		peerAddr = peerAddr[0:len(peerAddr)-len(PEER_ID_PLACEHOLDER)] + peerID
@@ -362,111 +362,107 @@ func (n *Network) connectPeer(ctx context.Context, nodeName string, peerName str
 		"peer_cluster", peerConfig.Cluster,
 		"peer_addr", peerAddr)
 
-	err = client.UnprotectPeer(ctx, peerState.self.PeerID)
-	if err != nil {
-		log.Error("cant unprotect peer",
-			"network", n.name,
-			"node", nodeName,
-			"rpc_address", nodeConfig.RPCAddress,
-			"peer", peerName,
-			"peer_addr", peerAddr,
-			"peer_id", peerID,
-			"err", err)
+	if err := client.UnprotectPeer(ctx, peerState.self.PeerID); err != nil {
+		log.Error("cant unprotect peer", "network", n.name, "node", nodeName, "peer", peerName, "err", err)
 		return
 	}
-
-	err = peerClient.UnprotectPeer(ctx, nodeState.self.PeerID)
-	if err != nil {
-		log.Error("cant unprotect peer (reverse)",
-			"network", n.name,
-			"node", nodeName,
-			"node_id", nodeState.self.PeerID,
-			"peer_rpc_address", peerConfig.RPCAddress,
-			"peer", peerName,
-			"err", err)
+	if err := peerClient.UnprotectPeer(ctx, nodeState.self.PeerID); err != nil {
+		log.Error("cant unprotect peer (reverse)", "network", n.name, "node", nodeName, "peer", peerName, "err", err)
 		return
 	}
-
-	err = client.UnblockPeer(ctx, peerState.self.PeerID)
-	if err != nil {
-		log.Error("cant disconnect peer",
-			"network", n.name,
-			"node", nodeName,
-			"rpc_address", nodeConfig.RPCAddress,
-			"peer", peerName,
-			"peer_addr", peerAddr,
-			"peer_id", peerID,
-			"err", err)
+	if err := client.UnblockPeer(ctx, peerState.self.PeerID); err != nil {
+		log.Error("cant unblock peer", "network", n.name, "node", nodeName, "peer", peerName, "err", err)
 		return
 	}
-
-	err = peerClient.UnblockPeer(ctx, nodeState.self.PeerID)
-	if err != nil {
-		log.Error("cant disconnect peer (reverse)",
-			"network", n.name,
-			"node", nodeName,
-			"node_id", nodeState.self.PeerID,
-			"peer_rpc_address", peerConfig.RPCAddress,
-			"peer", peerName,
-			"err", err)
+	if err := peerClient.UnblockPeer(ctx, nodeState.self.PeerID); err != nil {
+		log.Error("cant unblock peer (reverse)", "network", n.name, "node", nodeName, "peer", peerName, "err", err)
 		return
 	}
-
-	err = client.DisconnectPeer(ctx, peerState.self.PeerID)
-	if err != nil {
-		log.Error("cant disconnect peer",
-			"network", n.name,
-			"node", nodeName,
-			"rpc_address", nodeConfig.RPCAddress,
-			"peer", peerName,
-			"peer_addr", peerAddr,
-			"peer_id", peerID,
-			"err", err)
+	if err := client.DisconnectPeer(ctx, peerState.self.PeerID); err != nil {
+		log.Error("cant disconnect peer", "network", n.name, "node", nodeName, "peer", peerName, "err", err)
 		return
 	}
-
-	err = peerClient.DisconnectPeer(ctx, nodeState.self.PeerID)
-	if err != nil {
-		log.Error("cant disconnect peer (reverse)",
-			"network", n.name,
-			"node", nodeName,
-			"node_id", nodeState.self.PeerID,
-			"peer_rpc_address", peerConfig.RPCAddress,
-			"peer", peerName,
-			"err", err)
+	if err := peerClient.DisconnectPeer(ctx, nodeState.self.PeerID); err != nil {
+		log.Error("cant disconnect peer (reverse)", "network", n.name, "node", nodeName, "peer", peerName, "err", err)
 		return
 	}
-
-	err = client.ConnectPeer(ctx, peerAddr)
-	if err != nil {
-		log.Error("cant connect to peer",
-			"network", n.name,
-			"node", nodeName,
-			"rpc_address", nodeConfig.RPCAddress,
-			"peer", peerName,
-			"peer_addr", peerAddr,
-			"err", err)
+	if err := client.ConnectPeer(ctx, peerAddr); err != nil {
+		log.Error("cant connect to peer", "network", n.name, "node", nodeName, "peer", peerName, "peer_addr", peerAddr, "err", err)
 		return
 	}
-
-	err = client.ProtectPeer(ctx, peerState.self.PeerID)
-	if err != nil {
-		log.Error("cant protect peer",
-			"network", n.name,
-			"node", nodeName,
-			"rpc_address", nodeConfig.RPCAddress,
-			"peer", peerName,
-			"peer_addr", peerAddr,
-			"peer_id", peerID,
-			"err", err)
+	if err := client.ProtectPeer(ctx, peerState.self.PeerID); err != nil {
+		log.Error("cant protect peer", "network", n.name, "node", nodeName, "peer", peerName, "err", err)
 		return
 	}
 
 	log.Info("connected to peer",
+		"network", n.name, "node", nodeName, "peer", peerName, "peer_addr", peerAddr, "peer_id", peerID)
+}
+
+func (n *Network) connectExternalPeer(
+	ctx context.Context,
+	client *opp2p_client.InstrumentedOpP2PClient,
+	nodeName string,
+	nodeConfig *config.NodeConfig,
+	peerName string,
+	peerConfig *config.NodeConfig,
+) {
+	peerIDStr := peerConfig.PeerID
+	peerID, err := peer.Decode(peerIDStr)
+	if err != nil {
+		log.Error("invalid external peer_id",
+			"network", n.name, "peer", peerName, "peer_id", peerIDStr, "err", err)
+		return
+	}
+
+	peerAddr := peerConfig.PeerAddress
+	if nodeConfig.Cluster == peerConfig.Cluster && peerConfig.PeerAddressLocal != "" {
+		peerAddr = peerConfig.PeerAddressLocal
+	}
+
+	const PEER_ID_PLACEHOLDER = "{peer_id}"
+	if strings.HasPrefix(peerAddr, "/dns4/") && strings.HasSuffix(peerAddr, "/p2p/"+PEER_ID_PLACEHOLDER) {
+		peerAddr = peerAddr[0:len(peerAddr)-len(PEER_ID_PLACEHOLDER)] + peerIDStr
+	}
+
+	metrics.RecordResolvedState(n.name, nodeName, peerName, peerIDStr, peerAddr)
+
+	log.Info("connecting to external peer",
 		"network", n.name,
 		"node", nodeName,
+		"node_cluster", nodeConfig.Cluster,
 		"rpc_address", nodeConfig.RPCAddress,
 		"peer", peerName,
-		"peer_addr", peerAddr,
-		"peer_id", peerID)
+		"peer_id", peerIDStr,
+		"peer_cluster", peerConfig.Cluster,
+		"peer_addr", peerAddr)
+
+	if err := client.UnprotectPeer(ctx, peerID); err != nil {
+		log.Error("cant unprotect external peer",
+			"network", n.name, "node", nodeName, "peer", peerName, "err", err)
+		return
+	}
+	if err := client.UnblockPeer(ctx, peerID); err != nil {
+		log.Error("cant unblock external peer",
+			"network", n.name, "node", nodeName, "peer", peerName, "err", err)
+		return
+	}
+	if err := client.DisconnectPeer(ctx, peerID); err != nil {
+		log.Error("cant disconnect external peer",
+			"network", n.name, "node", nodeName, "peer", peerName, "err", err)
+		return
+	}
+	if err := client.ConnectPeer(ctx, peerAddr); err != nil {
+		log.Error("cant connect to external peer",
+			"network", n.name, "node", nodeName, "peer", peerName, "peer_addr", peerAddr, "err", err)
+		return
+	}
+	if err := client.ProtectPeer(ctx, peerID); err != nil {
+		log.Error("cant protect external peer",
+			"network", n.name, "node", nodeName, "peer", peerName, "err", err)
+		return
+	}
+
+	log.Info("connected to external peer",
+		"network", n.name, "node", nodeName, "peer", peerName, "peer_addr", peerAddr, "peer_id", peerIDStr)
 }

--- a/peer-mgmt-service/pkg/pms/poll.go
+++ b/peer-mgmt-service/pkg/pms/poll.go
@@ -147,6 +147,19 @@ func (n *Network) updateGraph(ctx context.Context) {
 	}
 }
 
+// internalMemberCount returns the number of network members with an RPC address.
+// External peers are excluded because PMS can only verify connectivity from the
+// internal side, so they should not weight the health denominator.
+func (n *Network) internalMemberCount() int {
+	count := 0
+	for _, m := range n.networkConfig.Members {
+		if cfg := n.nodesConfig[m]; cfg != nil && !cfg.IsExternal() {
+			count++
+		}
+	}
+	return count
+}
+
 func (n *Network) reportMetrics(ctx context.Context) {
 	log.Debug("network state",
 		"network", n.name,
@@ -172,7 +185,11 @@ func (n *Network) reportMetrics(ctx context.Context) {
 			}
 			connectedness := strings.ToLower(peerState.Connectedness.String())
 
-			healthy := connectedness == "connected" && knownPeer
+			// External peers are excluded from the health denominator, so don't credit them
+			// to the numerator either. They are still reported in the knownnessConnectedness
+			// gauge below so visibility is preserved.
+			peerIsExternal := knownPeer && n.nodesConfig[peerName] != nil && n.nodesConfig[peerName].IsExternal()
+			healthy := connectedness == "connected" && knownPeer && !peerIsExternal
 			if healthy {
 				healthyPeers++
 
@@ -223,10 +240,14 @@ func (n *Network) reportMetrics(ctx context.Context) {
 
 	metrics.RecordNetworkMemberCount(n.name, len(n.networkConfig.Members))
 
-	// when all N members of the network are mutually connected,
+	// when all N internal members of the network are mutually connected,
 	// we'll observe (N * (N-1)) connections
-	expectedHealthy := float64(len(n.networkConfig.Members) * (len(n.networkConfig.Members) - 1))
-	percentageHealthy := float64(healthyPeers) / expectedHealthy
+	internalCount := n.internalMemberCount()
+	expectedHealthy := float64(internalCount * (internalCount - 1))
+	percentageHealthy := float64(0)
+	if expectedHealthy > 0 {
+		percentageHealthy = float64(healthyPeers) / expectedHealthy
+	}
 	metrics.RecordNetworkPeerHealthness(n.name, percentageHealthy)
 
 }

--- a/peer-mgmt-service/pkg/pms/poll_test.go
+++ b/peer-mgmt-service/pkg/pms/poll_test.go
@@ -73,6 +73,21 @@ func TestNetwork_updateGraph(t *testing.T) {
 	})
 }
 
+func TestNetwork_New_PreregistersExternalPeers(t *testing.T) {
+	cfg := &config.Config{}
+	netCfg := &config.NetworkConfig{Members: []string{"internal", "external"}}
+	nodes := map[string]*config.NodeConfig{
+		"internal": {RPCAddress: "http://internal:9545"},
+		"external": {PeerID: "ext-peer-id", PeerAddress: "/dns4/ext/tcp/9003/p2p/ext-peer-id"},
+	}
+
+	n := New(cfg, "net", netCfg, nodes)
+
+	require.Equal(t, "external", n.state.nodesByPeerID["ext-peer-id"])
+	_, hasInternal := n.state.nodesByPeerID["internal"]
+	require.False(t, hasInternal, "internal nodes should not be pre-registered (their peer_id is discovered)")
+}
+
 func TestNetwork_resolveState(t *testing.T) {
 	t.Run("should connect to known peers", func(t *testing.T) {
 		type connectPeerArgs struct {

--- a/peer-mgmt-service/pkg/pms/poll_test.go
+++ b/peer-mgmt-service/pkg/pms/poll_test.go
@@ -88,6 +88,38 @@ func TestNetwork_New_PreregistersExternalPeers(t *testing.T) {
 	require.False(t, hasInternal, "internal nodes should not be pre-registered (their peer_id is discovered)")
 }
 
+func TestNetwork_resolveState_DialsExternalPeer(t *testing.T) {
+	type args struct{ node, peer string }
+	calls := []args{}
+
+	n := &Network{
+		overrideConnectPeer: func(ctx context.Context, nodeName, peerName string) {
+			calls = append(calls, args{nodeName, peerName})
+		},
+		networkConfig: &config.NetworkConfig{Members: []string{"internal", "external"}},
+		nodesConfig: map[string]*config.NodeConfig{
+			"internal": {RPCAddress: "http://internal:9545"},
+			"external": {PeerID: "ext-peer-id", PeerAddress: "/dns4/ext/tcp/9003/p2p/ext-peer-id"},
+		},
+		state: &NetworkState{
+			nodes: map[string]*NodeState{
+				"internal": {
+					self:  &p2p.PeerInfo{PeerID: "internal-peer-id"},
+					peers: &p2p.PeerDump{Peers: map[string]*p2p.PeerInfo{}},
+				},
+			},
+			nodesByPeerID: map[string]string{
+				"internal-peer-id": "internal",
+				"ext-peer-id":      "external",
+			},
+		},
+	}
+
+	n.resolveState(context.Background())
+
+	require.Equal(t, []args{{"internal", "external"}}, calls)
+}
+
 func TestNetwork_resolveState(t *testing.T) {
 	t.Run("should connect to known peers", func(t *testing.T) {
 		type connectPeerArgs struct {

--- a/peer-mgmt-service/pkg/pms/poll_test.go
+++ b/peer-mgmt-service/pkg/pms/poll_test.go
@@ -177,3 +177,15 @@ func TestNetwork_resolveState(t *testing.T) {
 		}
 	})
 }
+
+func TestNetwork_internalMemberCount(t *testing.T) {
+	n := &Network{
+		networkConfig: &config.NetworkConfig{Members: []string{"a", "b", "ext"}},
+		nodesConfig: map[string]*config.NodeConfig{
+			"a":   {RPCAddress: "http://a:9545"},
+			"b":   {RPCAddress: "http://b:9545"},
+			"ext": {PeerID: "x", PeerAddress: "/dns4/ext/tcp/9003/p2p/x"},
+		},
+	}
+	require.Equal(t, 2, n.internalMemberCount())
+}


### PR DESCRIPTION
## Summary
- Allow nodes in pms config to omit `rpc_address`; such "external peers" must carry `peer_id` + `peer_address` and are reachable only from internal nodes
- Skip polling and reverse-RPC for external peers; dial them one-sided via static `peer_address`, with `prevent_inbound` still honored
- Exclude external peers from the `network_peer_healthness` denominator so the metric reflects the internal mesh only
- Validate external `peer_id` format at config load and reject networks composed entirely of external peers

## Test plan
- [x] `go test ./...` passes in `peer-mgmt-service/`
- [x] `go vet ./...` clean
- [ ] Verify on a devnet config: add an external peer entry and confirm internal nodes dial it
- [ ] Confirm `network_peer_healthness` stays at 100% for the internal mesh when external peers are listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)