### PR TITLE
refactor(proxyd): rename supervisor terminology to interop-filter

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -271,7 +271,7 @@ func ParseInteropError(err error) *RPCErr {
 	if !isHTTPError {
 		// A JSON-RPC error returned over HTTP 200 surfaces as an rpc.Error (not an
 		// rpc.HTTPError). Read the filter's actual JSON-RPC code so failsafe
-		// (-320602), invalid-params (-32602) and the supervisor codes are all
+		// (-320602), invalid-params (-32602) and the interop filter codes are all
 		// identified by code rather than collapsing to the -32000 fallback.
 		var rpcErr rpc.Error
 		if errors.As(err, &rpcErr) {

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -134,12 +134,12 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 		func(dur time.Duration, max int, prefix string) FrontendRateLimiter {
 			return NoopFrontendRateLimiter
 		}, // limiterFactory
-		InteropValidationConfig{},              // interopValidatingConfig
-		NewFirstSupervisorStrategy([]string{}), // interopStrategy
-		false,                                  // enableTxHashLogging
-		nil,                                    // limExemptKeys
-		TxValidationMiddlewareConfig{},         // txValidationConfig
-		10*time.Second,                         // gracefulShutdownDuration
+		InteropValidationConfig{},                 // interopValidatingConfig
+		NewFirstInteropFilterStrategy([]string{}), // interopStrategy
+		false,                          // enableTxHashLogging
+		nil,                            // limExemptKeys
+		TxValidationMiddlewareConfig{}, // txValidationConfig
+		10*time.Second,                 // gracefulShutdownDuration
 	)
 	require.NoError(t, err)
 

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -134,12 +134,12 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 		func(dur time.Duration, max int, prefix string) FrontendRateLimiter {
 			return NoopFrontendRateLimiter
 		}, // limiterFactory
-		InteropValidationConfig{},                 // interopValidatingConfig
-		NewFirstInteropFilterStrategy([]string{}), // interopStrategy
-		false,                          // enableTxHashLogging
-		nil,                            // limExemptKeys
-		TxValidationMiddlewareConfig{}, // txValidationConfig
-		10*time.Second,                 // gracefulShutdownDuration
+		InteropValidationConfig{},          // interopValidatingConfig
+		NewFirstFilterStrategy([]string{}), // interopStrategy
+		false,                              // enableTxHashLogging
+		nil,                                // limExemptKeys
+		TxValidationMiddlewareConfig{},     // txValidationConfig
+		10*time.Second,                     // gracefulShutdownDuration
 	)
 	require.NoError(t, err)
 

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -296,6 +296,10 @@ const (
 	MulticallStrategy                InteropValidationStrategy = "multicall"
 	HealthAwareLoadBalancingStrategy InteropValidationStrategy = "health-aware-load-balancing"
 	AgreementStrategy                InteropValidationStrategy = "agreement"
+
+	// LegacyFirstSupervisorStrategy is the pre-rename name for FirstFilterStrategy,
+	// accepted for config backwards compatibility.
+	LegacyFirstSupervisorStrategy InteropValidationStrategy = "first-supervisor"
 )
 
 func ReadFromEnvOrConfig(value string) (string, error) {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -292,7 +292,7 @@ type InteropValidationStrategy string
 
 const (
 	EmptyStrategy                    InteropValidationStrategy = ""
-	FirstSupervisorStrategy          InteropValidationStrategy = "first-supervisor"
+	FirstInteropFilterStrategy       InteropValidationStrategy = "first-interop-filter"
 	MulticallStrategy                InteropValidationStrategy = "multicall"
 	HealthAwareLoadBalancingStrategy InteropValidationStrategy = "health-aware-load-balancing"
 	AgreementStrategy                InteropValidationStrategy = "agreement"

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -292,7 +292,7 @@ type InteropValidationStrategy string
 
 const (
 	EmptyStrategy                    InteropValidationStrategy = ""
-	FirstInteropFilterStrategy       InteropValidationStrategy = "first-interop-filter"
+	FirstFilterStrategy              InteropValidationStrategy = "first-filter"
 	MulticallStrategy                InteropValidationStrategy = "multicall"
 	HealthAwareLoadBalancingStrategy InteropValidationStrategy = "health-aware-load-balancing"
 	AgreementStrategy                InteropValidationStrategy = "agreement"

--- a/proxyd/integration_tests/interop_validation_test.go
+++ b/proxyd/integration_tests/interop_validation_test.go
@@ -131,6 +131,15 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 			},
 		},
 		{
+			name:     "legacy first-supervisor value routes to first-filter strategy",
+			strategy: proxyd.LegacyFirstSupervisorStrategy,
+			urls:     []string{badInteropFilterUrl1, goodInteropFilterUrl},
+			expectedResp: respDetails{
+				code:         409,
+				jsonResponse: []byte(expectedErrResp1),
+			},
+		},
+		{
 			name:     "default strategy with first url returning success",
 			strategy: proxyd.EmptyStrategy,
 			urls:     []string{goodInteropFilterUrl, badInteropFilterUrl1},

--- a/proxyd/integration_tests/interop_validation_test.go
+++ b/proxyd/integration_tests/interop_validation_test.go
@@ -122,8 +122,8 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 	}
 	cases := []testCase{
 		{
-			name:     "first-interop-filter strategy with first url returning error",
-			strategy: proxyd.FirstInteropFilterStrategy,
+			name:     "first-filter strategy with first url returning error",
+			strategy: proxyd.FirstFilterStrategy,
 			urls:     []string{badInteropFilterUrl1, goodInteropFilterUrl},
 			expectedResp: respDetails{
 				code:         409,

--- a/proxyd/integration_tests/interop_validation_test.go
+++ b/proxyd/integration_tests/interop_validation_test.go
@@ -98,9 +98,9 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 	goodValidatingBackend1 := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
 	defer goodValidatingBackend1.Close()
 
-	badSupervisorUrl1 := badValidatingBackend1.URL()
-	badSupervisorUrl2 := badValidatingBackend2.URL()
-	goodSupervisorUrl := goodValidatingBackend1.URL()
+	badInteropFilterUrl1 := badValidatingBackend1.URL()
+	badInteropFilterUrl2 := badValidatingBackend2.URL()
+	goodInteropFilterUrl := goodValidatingBackend1.URL()
 
 	config := ReadConfig("interop_validation")
 	config.SenderRateLimit.Limit = math.MaxInt // Don't perform rate limiting in this test since we're only testing interop validation.
@@ -122,9 +122,9 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 	}
 	cases := []testCase{
 		{
-			name:     "first-supervisor strategy with first url returning error",
-			strategy: proxyd.FirstSupervisorStrategy,
-			urls:     []string{badSupervisorUrl1, goodSupervisorUrl},
+			name:     "first-interop-filter strategy with first url returning error",
+			strategy: proxyd.FirstInteropFilterStrategy,
+			urls:     []string{badInteropFilterUrl1, goodInteropFilterUrl},
 			expectedResp: respDetails{
 				code:         409,
 				jsonResponse: []byte(expectedErrResp1),
@@ -133,7 +133,7 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 		{
 			name:     "default strategy with first url returning success",
 			strategy: proxyd.EmptyStrategy,
-			urls:     []string{goodSupervisorUrl, badSupervisorUrl1},
+			urls:     []string{goodInteropFilterUrl, badInteropFilterUrl1},
 			expectedResp: respDetails{
 				code:         200,
 				jsonResponse: []byte(dummyHealthyRes),
@@ -142,7 +142,7 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 		{
 			name:     "multicall strategy with atleast one good url",
 			strategy: proxyd.MulticallStrategy,
-			urls:     []string{badSupervisorUrl1, goodSupervisorUrl},
+			urls:     []string{badInteropFilterUrl1, goodInteropFilterUrl},
 			expectedResp: respDetails{
 				code:         200,
 				jsonResponse: []byte(dummyHealthyRes),
@@ -151,7 +151,7 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 		{
 			name:                  "multicall strategy with all bad urls",
 			strategy:              proxyd.MulticallStrategy,
-			urls:                  []string{badSupervisorUrl1, badSupervisorUrl2},
+			urls:                  []string{badInteropFilterUrl1, badInteropFilterUrl2},
 			multiplePossibilities: true,
 			possibilities: []respDetails{
 				{
@@ -488,7 +488,7 @@ func TestInteropValidation_Deduplication(t *testing.T) {
 	require.Equal(t, 413, observedCode, "the request should have failed because of the expectation of the deduplicated entries being 5")
 	require.Contains(t, string(observedResp), fmt.Sprintf("\"code\":%d", -32022))
 	require.Contains(t, string(observedResp), "access list out of bounds")
-	require.Equal(t, len(validatingBackend1.requests), 0) // no request was sent to the validating backend (supervisor) because the number of entries to be passed were found to be more than the size limit of 4
+	require.Equal(t, len(validatingBackend1.requests), 0) // no request was sent to the validating backend (interop filter) because the number of entries to be passed were found to be more than the size limit of 4
 
 	shutdown()
 	firstShutdownAlreadyCalled = true
@@ -503,7 +503,7 @@ func TestInteropValidation_Deduplication(t *testing.T) {
 	_, observedCode, err = client.SendRequest(sendRawTransaction)
 	require.NoError(t, err)
 	require.Equal(t, 200, observedCode, "the request should have succeeded because of the expectation of the deduplicated entries being 5")
-	require.Equal(t, len(validatingBackend1.requests), 1) // the success is represented by the fact that the request was sent to the validating backend (supervisor)
+	require.Equal(t, len(validatingBackend1.requests), 1) // the success is represented by the fact that the request was sent to the validating backend (interop filter)
 }
 
 func TestInteropValidation_StaticParseAccessPrevalidationCheck(t *testing.T) {
@@ -530,7 +530,7 @@ func TestInteropValidation_StaticParseAccessPrevalidationCheck(t *testing.T) {
 
 	// subroutine for checking the bad path
 	// i.e. a request with an invalid access list that is rejected by the ParseAccess check itself
-	// without needing to reach the validating backend (supervisor)
+	// without needing to reach the validating backend (interop filter)
 	{
 		wrongTx := fakeTxBuilder(func(tx *types.AccessListTx) {
 			// make the access list's storage keys invalid enough to be failed by the ParseAccess check itself
@@ -549,13 +549,13 @@ func TestInteropValidation_StaticParseAccessPrevalidationCheck(t *testing.T) {
 		require.Equal(t, 400, observedCode)
 		require.Contains(t, string(observedResp), fmt.Sprintf("\"code\":%d", -32602))
 
-		// request failed aptly without needing to reach the validating backend (supervisor)
+		// request failed aptly without needing to reach the validating backend (interop filter)
 		require.Equal(t, len(validatingBackend1.requests), 0)
 	}
 
 	// subroutine for checking the good path
 	// i.e. a request with a valid access list that is validated by the ParseAccess check itself
-	// is allowed to the validating backend (supervisor) for potentially other validation checks which can only be performed by the supervisor
+	// is allowed to the validating backend (interop filter) for potentially other validation checks which can only be performed by the interop filter
 	{
 		rightTx := fakeTxBuilder()
 		rightInteropReqParams, err := convertTxToReqParams(rightTx)
@@ -623,7 +623,7 @@ func TestInteropValidation_SenderRateLimit(t *testing.T) {
 	require.Contains(t, string(observedResp2), "sender is over rate limit")
 	require.Contains(t, string(observedResp2), fmt.Sprintf("\"code\":%d", -32017))
 
-	// ensuring that the second call didn't contribute to additional validating backend (supervisor) requests
+	// ensuring that the second call didn't contribute to additional validating backend (interop filter) requests
 	require.Equal(t, len(validatingBackend1.requests), 1)
 
 	// make a non-interop request to ensure that it succeeds despite the breaked rate limit depicting that the rate limit is not applied to non-interop requests
@@ -650,7 +650,7 @@ func TestInteropValidation_SenderRateLimit(t *testing.T) {
 	require.NoError(t, err3)
 	require.Equal(t, 200, observedCode3)
 
-	// ensuring that this call did contribute to additional validating backend (supervisor) requests due to being within the rate limit
+	// ensuring that this call did contribute to additional validating backend (interop filter) requests due to being within the rate limit
 	require.Equal(t, len(validatingBackend1.requests), 2)
 }
 
@@ -905,7 +905,7 @@ func TestInteropValidation_HealthAwareLoadBalancingStrategy_NoHealthyBackends_Cu
 	require.NoError(t, err)
 	defer shutdown()
 
-	expectedResp := `{"jsonrpc":"2.0","error":{"code":-32000,"message":"no healthy supervisor backends found"},"id":1}`
+	expectedResp := `{"jsonrpc":"2.0","error":{"code":-32000,"message":"no healthy interop filter backends found"},"id":1}`
 
 	client := NewProxydClient("http://127.0.0.1:8545")
 

--- a/proxyd/integration_tests/testdata/interop_validation.toml
+++ b/proxyd/integration_tests/testdata/interop_validation.toml
@@ -23,7 +23,7 @@ urls = [
 "$VALIDATING_BACKEND_RPC_URL_1",
 "$VALIDATING_BACKEND_RPC_URL_2"
 ]
-strategy = "first-supervisor"
+strategy = "first-interop-filter"
 req_params_size_limit = 131072 ## 128KB
 access_list_size_limit = 1000000
 

--- a/proxyd/integration_tests/testdata/interop_validation.toml
+++ b/proxyd/integration_tests/testdata/interop_validation.toml
@@ -23,7 +23,7 @@ urls = [
 "$VALIDATING_BACKEND_RPC_URL_1",
 "$VALIDATING_BACKEND_RPC_URL_2"
 ]
-strategy = "first-interop-filter"
+strategy = "first-filter"
 req_params_size_limit = 131072 ## 128KB
 access_list_size_limit = 1000000
 

--- a/proxyd/interop.go
+++ b/proxyd/interop.go
@@ -19,7 +19,7 @@ func accessObjectToKey(accessObject messages.Access) string {
 // validateAndDeduplicateInteropAccessList
 // - validates all the interop access list entries by trying to successfully parse them on a per "Access" basis
 // - discard any successfully parsed yet duplicate "Access" objects along the way.
-// This is because op-supervisor does the same for the incoming inbox entries and validates them against its DB on a per "Access" basis.
+// This is because op-interop-filter does the same for the incoming inbox entries and validates them against its DB on a per "Access" basis.
 // So it makes sense to recognise and discard duplicate "Access" objects early.
 func validateAndDeduplicateInteropAccessList(entriesToParse []common.Hash) ([]common.Hash, error) {
 	if len(entriesToParse) == 0 {

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -126,17 +126,17 @@ func (s *commonInteropStrategy) preflightChecksAndCleanupAccessList(ctx context.
 	return interopAccessList, true, nil
 }
 
-type firstInteropFilterStrategyImpl struct {
+type firstFilterStrategyImpl struct {
 	*commonInteropStrategy
 }
 
-func NewFirstInteropFilterStrategy(urls []string, opts ...commonStrategyOpt) *firstInteropFilterStrategyImpl {
-	return &firstInteropFilterStrategyImpl{
+func NewFirstFilterStrategy(urls []string, opts ...commonStrategyOpt) *firstFilterStrategyImpl {
+	return &firstFilterStrategyImpl{
 		commonInteropStrategy: NewCommonInteropStrategy(urls, opts...),
 	}
 }
 
-func (s *firstInteropFilterStrategyImpl) ValidateAccessList(ctx context.Context, interopAccessList []common.Hash) error {
+func (s *firstFilterStrategyImpl) ValidateAccessList(ctx context.Context, interopAccessList []common.Hash) error {
 	accessListToValidate, proceedFurther, err := s.preflightChecksAndCleanupAccessList(ctx, interopAccessList)
 	if err != nil {
 		return err
@@ -146,10 +146,10 @@ func (s *firstInteropFilterStrategyImpl) ValidateAccessList(ctx context.Context,
 		return nil
 	}
 
-	firstInteropFilterUrl := s.urls[0]
+	firstFilterUrl := s.urls[0]
 
-	ctx = context.WithValue(ctx, ContextKeyInteropValidationStrategy, FirstInteropFilterStrategy) // nolint:staticcheck
-	_, _, err = performCheckAccessListOp(ctx, accessListToValidate, firstInteropFilterUrl, s.chainID)
+	ctx = context.WithValue(ctx, ContextKeyInteropValidationStrategy, FirstFilterStrategy) // nolint:staticcheck
+	_, _, err = performCheckAccessListOp(ctx, accessListToValidate, firstFilterUrl, s.chainID)
 	return err
 }
 

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -30,7 +30,7 @@ type commonInteropStrategy struct {
 	accessListSizeLimit                     int
 	reqSizeLimit                            int
 	validateAndDeduplicateInteropAccessList bool
-	skipOnNoSupervisorBackend               bool
+	skipOnNoInteropFilterBackend            bool
 }
 
 func NewCommonInteropStrategy(urls []string, opts ...commonStrategyOpt) *commonInteropStrategy {
@@ -39,7 +39,7 @@ func NewCommonInteropStrategy(urls []string, opts ...commonStrategyOpt) *commonI
 		accessListSizeLimit:                     0,
 		reqSizeLimit:                            0,
 		validateAndDeduplicateInteropAccessList: true,
-		skipOnNoSupervisorBackend:               false,
+		skipOnNoInteropFilterBackend:            false,
 	}
 
 	for _, opt := range opts {
@@ -73,9 +73,9 @@ var WithValidateAndDeduplicateInteropAccessList = func(validateAndDeduplicateInt
 	}
 }
 
-var WithSkipOnNoSupervisorBackend = func(skipOnNoSupervisorBackend bool) commonStrategyOpt {
+var WithSkipOnNoInteropFilterBackend = func(skipOnNoInteropFilterBackend bool) commonStrategyOpt {
 	return func(s *commonInteropStrategy) {
-		s.skipOnNoSupervisorBackend = skipOnNoSupervisorBackend
+		s.skipOnNoInteropFilterBackend = skipOnNoInteropFilterBackend
 	}
 }
 
@@ -87,7 +87,7 @@ var WithChainID = func(chainID uint64) commonStrategyOpt {
 
 func (s *commonInteropStrategy) preflightChecksAndCleanupAccessList(ctx context.Context, interopAccessList []common.Hash) ([]common.Hash, bool, error) {
 	if len(s.urls) == 0 {
-		if s.skipOnNoSupervisorBackend {
+		if s.skipOnNoInteropFilterBackend {
 			log.Info(
 				"no validating backends found for an interop transaction, skipping",
 				"req_id", GetReqID(ctx),
@@ -126,17 +126,17 @@ func (s *commonInteropStrategy) preflightChecksAndCleanupAccessList(ctx context.
 	return interopAccessList, true, nil
 }
 
-type firstSupervisorStrategyImpl struct {
+type firstInteropFilterStrategyImpl struct {
 	*commonInteropStrategy
 }
 
-func NewFirstSupervisorStrategy(urls []string, opts ...commonStrategyOpt) *firstSupervisorStrategyImpl {
-	return &firstSupervisorStrategyImpl{
+func NewFirstInteropFilterStrategy(urls []string, opts ...commonStrategyOpt) *firstInteropFilterStrategyImpl {
+	return &firstInteropFilterStrategyImpl{
 		commonInteropStrategy: NewCommonInteropStrategy(urls, opts...),
 	}
 }
 
-func (s *firstSupervisorStrategyImpl) ValidateAccessList(ctx context.Context, interopAccessList []common.Hash) error {
+func (s *firstInteropFilterStrategyImpl) ValidateAccessList(ctx context.Context, interopAccessList []common.Hash) error {
 	accessListToValidate, proceedFurther, err := s.preflightChecksAndCleanupAccessList(ctx, interopAccessList)
 	if err != nil {
 		return err
@@ -146,10 +146,10 @@ func (s *firstSupervisorStrategyImpl) ValidateAccessList(ctx context.Context, in
 		return nil
 	}
 
-	firstSupervisorUrl := s.urls[0]
+	firstInteropFilterUrl := s.urls[0]
 
-	ctx = context.WithValue(ctx, ContextKeyInteropValidationStrategy, FirstSupervisorStrategy) // nolint:staticcheck
-	_, _, err = performCheckAccessListOp(ctx, accessListToValidate, firstSupervisorUrl, s.chainID)
+	ctx = context.WithValue(ctx, ContextKeyInteropValidationStrategy, FirstInteropFilterStrategy) // nolint:staticcheck
+	_, _, err = performCheckAccessListOp(ctx, accessListToValidate, firstInteropFilterUrl, s.chainID)
 	return err
 }
 
@@ -215,7 +215,7 @@ func (s *multicallStrategyImpl) ValidateAccessList(ctx context.Context, interopA
 
 // agreementStrategyImpl fans every check out to all configured urls
 // concurrently and combines the verdicts by quorum agreement. A "definitive
-// verdict" is either a successful validation (valid) or a known supervisor
+// verdict" is either a successful validation (valid) or a known interop filter
 // validation rejection (invalid); transport errors, timeouts, 5xx and
 // cancellations are non-responses and never count.
 //
@@ -280,7 +280,7 @@ func (s *agreementStrategyImpl) ValidateAccessList(ctx context.Context, interopA
 	cctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// start measures the supervisor fan-out latency: how long the strategy waits
+	// start measures the interop filter fan-out latency: how long the strategy waits
 	// on the interop filters to reach a verdict. Recorded against the outcome.
 	start := time.Now()
 
@@ -307,7 +307,7 @@ func (s *agreementStrategyImpl) ValidateAccessList(ctx context.Context, interopA
 		log.Error(
 			"interop endpoint reported failsafe enabled; rejecting",
 			"req_id", GetReqID(ctx),
-			"supervisor_url", url,
+			"interop_filter_url", url,
 			"err", err,
 		)
 		recordAgreementOutcome(ctx, valid, invalid, s.minResponses, true, start)
@@ -400,7 +400,7 @@ func formatRejections(rejections []rejection) string {
 	return strings.Join(parts, "; ")
 }
 
-// isFailsafeError reports whether err is a supervisor failsafe rejection.
+// isFailsafeError reports whether err is an interop filter failsafe rejection.
 // op-interop-filter emits the dedicated code -320602 for failsafe, so detection
 // keys on the code and is immune to message wording or HTTP status. Failsafe on
 // any endpoint is a hard rejection handled before the quorum logic.
@@ -425,8 +425,8 @@ func isSoftInteropFailure(err error) bool {
 // isDefinitiveInteropRejection reports whether err is a definitive INVALID
 // verdict from the filter. A definitive INVALID is ANY filter JSON-RPC
 // rejection — the generic invalid-params code (-32602, e.g. a malformed or
-// fabricated access list) as well as the supervisor verdict codes
-// (-3204xx..-3215xx) — not just the known supervisor set. Both sides (proxyd and
+// fabricated access list) as well as the interop filter verdict codes
+// (-3204xx..-3215xx) — not just the known interop filter set. Both sides (proxyd and
 // op-reth) must treat a -32602 parse rejection as a real INVALID so it produces
 // reject_agreed rather than falling through to quorum-not-reached.
 //
@@ -509,7 +509,7 @@ func (s *healthAwareLoadBalancingStrategyImpl) ValidateAccessList(ctx context.Co
 	}
 
 	// retries exhausted
-	return ParseInteropError(fmt.Errorf("no healthy supervisor backends found"))
+	return ParseInteropError(fmt.Errorf("no healthy interop filter backends found"))
 }
 
 type healthAwareBackend struct {
@@ -587,14 +587,14 @@ func performCheckAccessListOp(ctx context.Context, accessList []common.Hash, url
 
 	log.Debug(
 		"an interop validating backend has responded",
-		"supervisor_url", url,
+		"interop_filter_url", url,
 		"strategy", strategy,
 		"req_id", GetReqID(ctx),
 		"method", "eth_sendRawTransaction",
 		"error", err,
 	)
 
-	rpcSupervisorChecksTotal.WithLabelValues(
+	rpcInteropFilterChecksTotal.WithLabelValues(
 		url,
 		strconv.Itoa(httpCode),
 		rpcErrorCode,

--- a/proxyd/interop_strategy_test.go
+++ b/proxyd/interop_strategy_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	validSupervisorResponse = `{"jsonrpc":"2.0","id":1,"result":null}`
+	validInteropFilterResponse = `{"jsonrpc":"2.0","id":1,"result":null}`
 	// failsafeRPCCode is the dedicated failsafe code emitted by op-interop-filter.
 	failsafeRPCCode = -320602
 	// futureDataRPCCode and uninitializedRPCCode are the soft out-of-sync codes.
@@ -22,16 +22,16 @@ const (
 	uninitializedRPCCode = -320400
 )
 
-// supervisorErrorResponse builds a JSON-RPC error body whose message matches an
+// interopFilterErrorResponse builds a JSON-RPC error body whose message matches an
 // interop error so ParseInteropError maps it to the corresponding code.
-func supervisorErrorResponse(rpcCode int, message string) string {
+func interopFilterErrorResponse(rpcCode int, message string) string {
 	return fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"error":{"code":%d,"message":%q}}`, rpcCode, message)
 }
 
-// newSupervisorServer starts an httptest server that responds to every
+// newInteropFilterServer starts an httptest server that responds to every
 // interop_checkAccessList call with the given HTTP code and body after an
 // optional delay. It returns the server URL.
-func newSupervisorServer(t *testing.T, httpCode int, body string, delay time.Duration) string {
+func newInteropFilterServer(t *testing.T, httpCode int, body string, delay time.Duration) string {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if delay > 0 {
@@ -49,9 +49,9 @@ func newSupervisorServer(t *testing.T, httpCode int, body string, delay time.Dur
 	return srv.URL
 }
 
-// newSignalingSupervisorServer is like newSupervisorServer but closes done once
+// newSignalingInteropFilterServer is like newInteropFilterServer but closes done once
 // it has written its response, letting another endpoint sequence after it.
-func newSignalingSupervisorServer(t *testing.T, httpCode int, body string, done chan<- struct{}) string {
+func newSignalingInteropFilterServer(t *testing.T, httpCode int, body string, done chan<- struct{}) string {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -63,11 +63,11 @@ func newSignalingSupervisorServer(t *testing.T, httpCode int, body string, done 
 	return srv.URL
 }
 
-// newGatedSupervisorServer responds only after gate is closed, then waits an
+// newGatedInteropFilterServer responds only after gate is closed, then waits an
 // additional settle period. The settle gives an endpoint that signalled the
 // gate time to have its verdict fully parsed and buffered by the strategy before
 // this endpoint's verdict arrives, making ordering deterministic.
-func newGatedSupervisorServer(t *testing.T, httpCode int, body string, gate <-chan struct{}, settle time.Duration) string {
+func newGatedInteropFilterServer(t *testing.T, httpCode int, body string, gate <-chan struct{}, settle time.Duration) string {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
@@ -101,18 +101,18 @@ var testAccessList = []common.Hash{common.HexToHash("0x01")}
 
 func TestAgreement_AllValid_Accepts(t *testing.T) {
 	urls := []string{
-		newSupervisorServer(t, 200, validSupervisorResponse, 0),
-		newSupervisorServer(t, 200, validSupervisorResponse, 0),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
 	}
 	s := newAgreementStrategy(urls, 2)
 	require.NoError(t, s.ValidateAccessList(context.Background(), testAccessList))
 }
 
 func TestAgreement_AllInvalid_RejectsWithRealError(t *testing.T) {
-	body := supervisorErrorResponse(-32000, interopErrors.ErrConflict.Error())
+	body := interopFilterErrorResponse(-32000, interopErrors.ErrConflict.Error())
 	urls := []string{
-		newSupervisorServer(t, 409, body, 0),
-		newSupervisorServer(t, 409, body, 0),
+		newInteropFilterServer(t, 409, body, 0),
+		newInteropFilterServer(t, 409, body, 0),
 	}
 	s := newAgreementStrategy(urls, 2)
 	err := s.ValidateAccessList(context.Background(), testAccessList)
@@ -123,10 +123,10 @@ func TestAgreement_AllInvalid_RejectsWithRealError(t *testing.T) {
 }
 
 func TestAgreement_Disagreement_RejectsAndLogs(t *testing.T) {
-	invalidBody := supervisorErrorResponse(-32000, interopErrors.ErrConflict.Error())
+	invalidBody := interopFilterErrorResponse(-32000, interopErrors.ErrConflict.Error())
 	urls := []string{
-		newSupervisorServer(t, 200, validSupervisorResponse, 0),
-		newSupervisorServer(t, 409, invalidBody, 0),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
+		newInteropFilterServer(t, 409, invalidBody, 0),
 	}
 	s := newAgreementStrategy(urls, 2)
 	err := s.ValidateAccessList(context.Background(), testAccessList)
@@ -139,10 +139,10 @@ func TestAgreement_Disagreement_RejectsAndLogs(t *testing.T) {
 func TestAgreement_FailsafeShortCircuitsSlowBackend(t *testing.T) {
 	// Failsafe is a hard reject that short-circuits: a fast failsafe verdict ends
 	// the check immediately without awaiting a slow endpoint.
-	failsafeBody := supervisorErrorResponse(failsafeRPCCode, interopErrors.ErrFailsafeEnabled.Error())
+	failsafeBody := interopFilterErrorResponse(failsafeRPCCode, interopErrors.ErrFailsafeEnabled.Error())
 	urls := []string{
-		newSupervisorServer(t, 503, failsafeBody, 0),
-		newSupervisorServer(t, 200, validSupervisorResponse, 1500*time.Millisecond),
+		newInteropFilterServer(t, 503, failsafeBody, 0),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 1500*time.Millisecond),
 	}
 	s := newAgreementStrategy(urls, 2)
 
@@ -156,9 +156,9 @@ func TestAgreement_IgnoresSlowBackend(t *testing.T) {
 	// A slow non-failsafe endpoint must not delay an accept once the quorum of
 	// fast valid verdicts is in.
 	urls := []string{
-		newSupervisorServer(t, 200, validSupervisorResponse, 0),
-		newSupervisorServer(t, 200, validSupervisorResponse, 0),
-		newSupervisorServer(t, 200, validSupervisorResponse, 1500*time.Millisecond),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 1500*time.Millisecond),
 	}
 	s := newAgreementStrategy(urls, 2)
 
@@ -169,8 +169,8 @@ func TestAgreement_IgnoresSlowBackend(t *testing.T) {
 
 func TestAgreement_5xxNotCounted_FailClosed(t *testing.T) {
 	urls := []string{
-		newSupervisorServer(t, 200, validSupervisorResponse, 0),
-		newSupervisorServer(t, 500, `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"boom"}}`, 0),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
+		newInteropFilterServer(t, 500, `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"boom"}}`, 0),
 	}
 	s := newAgreementStrategy(urls, 2)
 	err := s.ValidateAccessList(context.Background(), testAccessList)
@@ -180,8 +180,8 @@ func TestAgreement_5xxNotCounted_FailClosed(t *testing.T) {
 
 func TestAgreement_TimeoutNotCounted_FailClosed(t *testing.T) {
 	urls := []string{
-		newSupervisorServer(t, 200, validSupervisorResponse, 0),
-		newSupervisorServer(t, 200, validSupervisorResponse, 1500*time.Millisecond),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 1500*time.Millisecond),
 	}
 	s := newAgreementStrategy(urls, 2)
 
@@ -193,10 +193,10 @@ func TestAgreement_TimeoutNotCounted_FailClosed(t *testing.T) {
 }
 
 func TestAgreement_FailsafeHardRejects(t *testing.T) {
-	failsafeBody := supervisorErrorResponse(failsafeRPCCode, interopErrors.ErrFailsafeEnabled.Error())
+	failsafeBody := interopFilterErrorResponse(failsafeRPCCode, interopErrors.ErrFailsafeEnabled.Error())
 	urls := []string{
-		newSupervisorServer(t, 503, failsafeBody, 0),
-		newSupervisorServer(t, 503, failsafeBody, 0),
+		newInteropFilterServer(t, 503, failsafeBody, 0),
+		newInteropFilterServer(t, 503, failsafeBody, 0),
 	}
 	s := newAgreementStrategy(urls, 1)
 	err := s.ValidateAccessList(context.Background(), testAccessList)
@@ -210,13 +210,13 @@ func TestAgreement_FailsafeOnAnyEndpoint_HardRejects(t *testing.T) {
 	// valid endpoints are gated to respond only after the failsafe has landed
 	// (plus a settle), so the failsafe verdict is observed before the accepts and
 	// the test is deterministic.
-	failsafeBody := supervisorErrorResponse(failsafeRPCCode, interopErrors.ErrFailsafeEnabled.Error())
+	failsafeBody := interopFilterErrorResponse(failsafeRPCCode, interopErrors.ErrFailsafeEnabled.Error())
 	failsafeDone := make(chan struct{})
 	const settle = 100 * time.Millisecond
 	urls := []string{
-		newSignalingSupervisorServer(t, 503, failsafeBody, failsafeDone),
-		newGatedSupervisorServer(t, 200, validSupervisorResponse, failsafeDone, settle),
-		newGatedSupervisorServer(t, 200, validSupervisorResponse, failsafeDone, settle),
+		newSignalingInteropFilterServer(t, 503, failsafeBody, failsafeDone),
+		newGatedInteropFilterServer(t, 200, validInteropFilterResponse, failsafeDone, settle),
+		newGatedInteropFilterServer(t, 200, validInteropFilterResponse, failsafeDone, settle),
 	}
 	s := newAgreementStrategy(urls, 2)
 	err := s.ValidateAccessList(context.Background(), testAccessList)
@@ -246,7 +246,7 @@ func TestAgreement_CancelledRequestNotCounted(t *testing.T) {
 	require.False(t, isDefinitiveInteropRejection(wrapped),
 		"a context.Canceled error must not count")
 
-	// A supervisor verdict counts.
+	// An interop filter verdict counts.
 	require.True(t, isDefinitiveInteropRejection(&RPCErr{Code: -320600, HTTPErrorCode: 409}))
 	// A generic invalid-params rejection (-32602) is a real INVALID and counts.
 	require.True(t, isDefinitiveInteropRejection(&RPCErr{Code: -32602, HTTPErrorCode: 400}))
@@ -256,14 +256,14 @@ func TestAgreement_CancelledRequestNotCounted(t *testing.T) {
 
 func TestAgreement_SingleUrl_MinOne(t *testing.T) {
 	t.Run("valid accepts", func(t *testing.T) {
-		urls := []string{newSupervisorServer(t, 200, validSupervisorResponse, 0)}
+		urls := []string{newInteropFilterServer(t, 200, validInteropFilterResponse, 0)}
 		s := newAgreementStrategy(urls, 1)
 		require.NoError(t, s.ValidateAccessList(context.Background(), testAccessList))
 	})
 
 	t.Run("invalid rejects with real error", func(t *testing.T) {
-		body := supervisorErrorResponse(-32000, interopErrors.ErrConflict.Error())
-		urls := []string{newSupervisorServer(t, 409, body, 0)}
+		body := interopFilterErrorResponse(-32000, interopErrors.ErrConflict.Error())
+		urls := []string{newInteropFilterServer(t, 409, body, 0)}
 		s := newAgreementStrategy(urls, 1)
 		err := s.ValidateAccessList(context.Background(), testAccessList)
 		require.Error(t, err)
@@ -278,10 +278,10 @@ func TestAgreement_GenericParseRejection_CountsAsInvalid(t *testing.T) {
 	// -32602 ("failed to parse access entry"). That is a real definitive INVALID:
 	// all endpoints rejecting must produce a clean reject (reject_agreed), NOT
 	// quorum-not-reached.
-	parseRejectBody := supervisorErrorResponse(-32602, "failed to parse access entry")
+	parseRejectBody := interopFilterErrorResponse(-32602, "failed to parse access entry")
 	urls := []string{
-		newSupervisorServer(t, 400, parseRejectBody, 0),
-		newSupervisorServer(t, 400, parseRejectBody, 0),
+		newInteropFilterServer(t, 400, parseRejectBody, 0),
+		newInteropFilterServer(t, 400, parseRejectBody, 0),
 	}
 	s := newAgreementStrategy(urls, 2)
 	err := s.ValidateAccessList(context.Background(), testAccessList)
@@ -308,11 +308,11 @@ func TestAgreement_OutOfSyncEndpointIsSoft(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			softBody := supervisorErrorResponse(c.code, c.msg)
+			softBody := interopFilterErrorResponse(c.code, c.msg)
 			urls := []string{
-				newSupervisorServer(t, c.http, softBody, 0),
-				newSupervisorServer(t, 200, validSupervisorResponse, 0),
-				newSupervisorServer(t, 200, validSupervisorResponse, 0),
+				newInteropFilterServer(t, c.http, softBody, 0),
+				newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
+				newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
 			}
 			s := newAgreementStrategy(urls, 2)
 			require.NoError(t, s.ValidateAccessList(context.Background(), testAccessList),
@@ -324,10 +324,10 @@ func TestAgreement_OutOfSyncEndpointIsSoft(t *testing.T) {
 func TestAgreement_AllOutOfSyncFailClosed(t *testing.T) {
 	// If every node is out-of-sync, no definitive verdicts are collected and the
 	// strategy fails closed with quorum-not-reached.
-	softBody := supervisorErrorResponse(futureDataRPCCode, interopErrors.ErrFuture.Error())
+	softBody := interopFilterErrorResponse(futureDataRPCCode, interopErrors.ErrFuture.Error())
 	urls := []string{
-		newSupervisorServer(t, 422, softBody, 0),
-		newSupervisorServer(t, 422, softBody, 0),
+		newInteropFilterServer(t, 422, softBody, 0),
+		newInteropFilterServer(t, 422, softBody, 0),
 	}
 	s := newAgreementStrategy(urls, 2)
 	err := s.ValidateAccessList(context.Background(), testAccessList)
@@ -339,7 +339,7 @@ func TestSoftInteropFailure_Detection(t *testing.T) {
 	require.True(t, isSoftInteropFailure(&RPCErr{Code: futureDataRPCCode, HTTPErrorCode: 422}))
 	require.True(t, isSoftInteropFailure(&RPCErr{Code: uninitializedRPCCode, HTTPErrorCode: 400}))
 	require.False(t, isSoftInteropFailure(&RPCErr{Code: -320600, HTTPErrorCode: 409}),
-		"a real supervisor verdict is not soft")
+		"a real interop filter verdict is not soft")
 	require.False(t, isSoftInteropFailure(&RPCErr{Code: -32602, HTTPErrorCode: 400}),
 		"a generic parse rejection is not soft")
 	require.False(t, isSoftInteropFailure(fmt.Errorf("plain error")))
@@ -348,9 +348,9 @@ func TestSoftInteropFailure_Detection(t *testing.T) {
 func TestDefinitiveInteropRejection_Classification(t *testing.T) {
 	// Any filter rejection counts as a definitive INVALID...
 	require.True(t, isDefinitiveInteropRejection(&RPCErr{Code: -320600, HTTPErrorCode: 409}),
-		"a supervisor verdict counts")
+		"an interop filter verdict counts")
 	require.True(t, isDefinitiveInteropRejection(&RPCErr{Code: -321501, HTTPErrorCode: 422}),
-		"a supervisor verdict counts")
+		"an interop filter verdict counts")
 	require.True(t, isDefinitiveInteropRejection(&RPCErr{Code: -32602, HTTPErrorCode: 400}),
 		"a generic invalid-params parse rejection counts")
 

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -67,12 +67,12 @@ var (
 		"batched",
 	})
 
-	rpcSupervisorChecksTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	rpcInteropFilterChecksTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
-		Name:      "rpc_supervisor_checks_total",
-		Help:      "Count of total supervisor checks.",
+		Name:      "rpc_interop_filter_checks_total",
+		Help:      "Count of total interop filter checks.",
 	}, []string{
-		"supervisor_url",
+		"interop_filter_url",
 		"http_code",
 		"rpc_error_code",
 		"strategy",
@@ -961,7 +961,7 @@ const (
 // recordAgreementOutcome classifies an agreement-strategy decision and records
 // the corresponding outcome counter and verdict duration. A failsafe
 // short-circuit is recorded as reject_failsafe regardless of the verdict tallies
-// collected so far. start marks the beginning of the supervisor fan-out, so the
+// collected so far. start marks the beginning of the interop filter fan-out, so the
 // recorded duration is the time spent fanning out to and waiting on the endpoints.
 func recordAgreementOutcome(ctx context.Context, valid, invalid, minResponses int, failsafe bool, start time.Time) {
 	duration := time.Since(start)

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -472,8 +472,8 @@ func Start(config *Config) (*Server, func(), error) {
 	)
 
 	switch config.InteropValidationConfig.Strategy {
-	case FirstInteropFilterStrategy, EmptyStrategy:
-		interopStrategy = NewFirstInteropFilterStrategy(
+	case FirstFilterStrategy, EmptyStrategy:
+		interopStrategy = NewFirstFilterStrategy(
 			config.InteropValidationConfig.Urls,
 			opts...,
 		)

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -472,8 +472,8 @@ func Start(config *Config) (*Server, func(), error) {
 	)
 
 	switch config.InteropValidationConfig.Strategy {
-	case FirstSupervisorStrategy, EmptyStrategy:
-		interopStrategy = NewFirstSupervisorStrategy(
+	case FirstInteropFilterStrategy, EmptyStrategy:
+		interopStrategy = NewFirstInteropFilterStrategy(
 			config.InteropValidationConfig.Urls,
 			opts...,
 		)

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -290,6 +290,11 @@ func Start(config *Config) (*Server, func(), error) {
 		config.InteropValidationConfig.Strategy = defaultInteropValidationStrategy
 	}
 
+	if config.InteropValidationConfig.Strategy == LegacyFirstSupervisorStrategy {
+		log.Warn("interop validation strategy \"first-supervisor\" is deprecated; use \"first-filter\"")
+		config.InteropValidationConfig.Strategy = FirstFilterStrategy
+	}
+
 	if config.TxValidationMiddlewareConfig.Enabled && config.TxValidationMiddlewareConfig.Endpoint == "" {
 		return nil, nil, errors.New("tx_validation_middleware is enabled but no endpoint is configured")
 	}

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -51,7 +51,7 @@ const (
 	maxRequestBodyLogLen                            = 2000
 	defaultMaxUpstreamBatchSize                     = 10
 	defaultRateLimitHeader                          = "X-Forwarded-For"
-	defaultInteropValidationStrategy                = FirstInteropFilterStrategy
+	defaultInteropValidationStrategy                = FirstFilterStrategy
 	defaultInteropReqSizeLimit                      = 128 * opt.KiB
 	defaultInteropAccessListSizeLimit               = 1000
 	defaultInteropLoadBalancingUnhealthinessTimeout = 10 * time.Second

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -51,7 +51,7 @@ const (
 	maxRequestBodyLogLen                            = 2000
 	defaultMaxUpstreamBatchSize                     = 10
 	defaultRateLimitHeader                          = "X-Forwarded-For"
-	defaultInteropValidationStrategy                = FirstSupervisorStrategy
+	defaultInteropValidationStrategy                = FirstInteropFilterStrategy
 	defaultInteropReqSizeLimit                      = 128 * opt.KiB
 	defaultInteropAccessListSizeLimit               = 1000
 	defaultInteropLoadBalancingUnhealthinessTimeout = 10 * time.Second


### PR DESCRIPTION
Pre-production rename of all supervisor → interop-filter terminology: code, the `first-interop-filter` strategy value, the `rpc_interop_filter_checks_total` metric and `interop_filter_url` label, comments, and tests. No behavior change.