### PR TITLE
feat(proxyd): fail-closed-by-default interop filtering

### DIFF
--- a/proxyd/integration_tests/interop_validation_test.go
+++ b/proxyd/integration_tests/interop_validation_test.go
@@ -140,9 +140,11 @@ func TestInteropValidation_NormalFlow(t *testing.T) {
 			},
 		},
 		{
-			name:     "default strategy with first url returning success",
+			// The default (empty) strategy now resolves to agreement with unanimity,
+			// so every configured url must accept for the tx to pass.
+			name:     "default strategy with all urls returning success",
 			strategy: proxyd.EmptyStrategy,
-			urls:     []string{goodInteropFilterUrl, badInteropFilterUrl1},
+			urls:     []string{goodInteropFilterUrl, goodInteropFilterUrl},
 			expectedResp: respDetails{
 				code:         200,
 				jsonResponse: []byte(dummyHealthyRes),
@@ -1176,4 +1178,64 @@ func TestInteropValidation_AgreementMinResponsesConfig(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid interop validation min_responses")
 	})
+}
+
+// TestInteropValidation_DefaultStrategyIsAgreement asserts that leaving the
+// strategy unset resolves to the agreement strategy (the safest default).
+func TestInteropValidation_DefaultStrategyIsAgreement(t *testing.T) {
+	goodBackend := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer goodBackend.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	v1 := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer v1.Close()
+
+	config := ReadConfig("interop_validation")
+	config.SenderRateLimit.Limit = math.MaxInt
+	config.InteropValidationConfig.Strategy = proxyd.EmptyStrategy
+	config.InteropValidationConfig.Urls = []string{v1.URL()}
+
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	require.Equal(t, proxyd.AgreementStrategy, config.InteropValidationConfig.Strategy)
+}
+
+// TestInteropValidation_FailClosedWithNoUrls asserts the fail-closed posture
+// when zero interop-filter urls are configured: proxyd starts successfully and
+// serves non-interop traffic, but every interop executing-message transaction is
+// rejected at runtime rather than forwarded.
+func TestInteropValidation_FailClosedWithNoUrls(t *testing.T) {
+	goodBackend := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer goodBackend.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	config := ReadConfig("interop_validation")
+	config.SenderRateLimit.Limit = math.MaxInt
+	config.InteropValidationConfig.Strategy = proxyd.AgreementStrategy
+	config.InteropValidationConfig.Urls = nil
+
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err, "proxyd must start with zero interop-filter urls")
+	defer shutdown()
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+
+	nonInteropReqParams, err := convertTxToReqParams(fakeTxBuilder(func(tx *types.AccessListTx) {
+		tx.AccessList = nil
+	}))
+	require.NoError(t, err)
+	_, observedCode, err := client.SendRequest(makeSendRawTransaction(nonInteropReqParams))
+	require.NoError(t, err)
+	require.Equal(t, 200, observedCode, "non-interop tx must be forwarded normally")
+	require.Equal(t, 1, len(goodBackend.requests), "non-interop tx must reach the backend")
+
+	interopReqParams, err := convertTxToReqParams(fakeTxBuilder())
+	require.NoError(t, err)
+	observedResp, observedCode, err := client.SendRequest(makeSendRawTransaction(interopReqParams))
+	require.NoError(t, err)
+	require.Contains(t, string(observedResp), interopErrors.ErrNoRPCSource.Error(),
+		"interop tx must be rejected fail-closed when no interop-filter urls are configured")
+	require.Equal(t, 1, len(goodBackend.requests), "rejected interop tx must not be forwarded to the backend")
 }

--- a/proxyd/integration_tests/interop_validation_test.go
+++ b/proxyd/integration_tests/interop_validation_test.go
@@ -1233,7 +1233,7 @@ func TestInteropValidation_FailClosedWithNoUrls(t *testing.T) {
 
 	interopReqParams, err := convertTxToReqParams(fakeTxBuilder())
 	require.NoError(t, err)
-	observedResp, observedCode, err := client.SendRequest(makeSendRawTransaction(interopReqParams))
+	observedResp, _, err := client.SendRequest(makeSendRawTransaction(interopReqParams))
 	require.NoError(t, err)
 	require.Contains(t, string(observedResp), interopErrors.ErrNoRPCSource.Error(),
 		"interop tx must be rejected fail-closed when no interop-filter urls are configured")

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -30,7 +30,6 @@ type commonInteropStrategy struct {
 	accessListSizeLimit                     int
 	reqSizeLimit                            int
 	validateAndDeduplicateInteropAccessList bool
-	skipOnNoInteropFilterBackend            bool
 }
 
 func NewCommonInteropStrategy(urls []string, opts ...commonStrategyOpt) *commonInteropStrategy {
@@ -39,7 +38,6 @@ func NewCommonInteropStrategy(urls []string, opts ...commonStrategyOpt) *commonI
 		accessListSizeLimit:                     0,
 		reqSizeLimit:                            0,
 		validateAndDeduplicateInteropAccessList: true,
-		skipOnNoInteropFilterBackend:            false,
 	}
 
 	for _, opt := range opts {
@@ -73,12 +71,6 @@ var WithValidateAndDeduplicateInteropAccessList = func(validateAndDeduplicateInt
 	}
 }
 
-var WithSkipOnNoInteropFilterBackend = func(skipOnNoInteropFilterBackend bool) commonStrategyOpt {
-	return func(s *commonInteropStrategy) {
-		s.skipOnNoInteropFilterBackend = skipOnNoInteropFilterBackend
-	}
-}
-
 var WithChainID = func(chainID uint64) commonStrategyOpt {
 	return func(s *commonInteropStrategy) {
 		s.chainID = eth.ChainIDFromUInt64(chainID)
@@ -87,16 +79,8 @@ var WithChainID = func(chainID uint64) commonStrategyOpt {
 
 func (s *commonInteropStrategy) preflightChecksAndCleanupAccessList(ctx context.Context, interopAccessList []common.Hash) ([]common.Hash, bool, error) {
 	if len(s.urls) == 0 {
-		if s.skipOnNoInteropFilterBackend {
-			log.Info(
-				"no validating backends found for an interop transaction, skipping",
-				"req_id", GetReqID(ctx),
-				"method", "eth_sendRawTransaction",
-			)
-			return nil, false, nil
-		}
 		log.Error(
-			"no validating backends found for an interop transaction",
+			"no validating backends found for an interop transaction, rejecting (fail closed)",
 			"req_id", GetReqID(ctx),
 			"method", "eth_sendRawTransaction",
 		)

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -328,14 +328,18 @@ func Start(config *Config) (*Server, func(), error) {
 	if config.InteropValidationConfig.Strategy == AgreementStrategy {
 		urlCount := len(config.InteropValidationConfig.Urls)
 		if urlCount == 0 {
-			return nil, nil, errors.New("agreement interop validation strategy requires at least one url")
-		}
-		if config.InteropValidationConfig.MinResponses == 0 {
-			log.Warn("no interop validation min_responses provided for agreement strategy, defaulting to unanimity", "min_responses", urlCount)
-			config.InteropValidationConfig.MinResponses = urlCount
-		}
-		if config.InteropValidationConfig.MinResponses < 1 || config.InteropValidationConfig.MinResponses > urlCount {
-			return nil, nil, fmt.Errorf("invalid interop validation min_responses: %d (must be between 1 and %d)", config.InteropValidationConfig.MinResponses, urlCount)
+			// proxyd starts with zero interop-filter urls so it can serve non-interop
+			// traffic; any interop executing-message tx is rejected at runtime by the
+			// fail-closed preflight check. min_responses is only meaningful with urls.
+			log.Warn("agreement interop validation strategy configured with no urls; interop transactions will be rejected (fail closed)")
+		} else {
+			if config.InteropValidationConfig.MinResponses == 0 {
+				log.Warn("no interop validation min_responses provided for agreement strategy, defaulting to unanimity", "min_responses", urlCount)
+				config.InteropValidationConfig.MinResponses = urlCount
+			}
+			if config.InteropValidationConfig.MinResponses < 1 || config.InteropValidationConfig.MinResponses > urlCount {
+				return nil, nil, fmt.Errorf("invalid interop validation min_responses: %d (must be between 1 and %d)", config.InteropValidationConfig.MinResponses, urlCount)
+			}
 		}
 	}
 

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -51,7 +51,7 @@ const (
 	maxRequestBodyLogLen                            = 2000
 	defaultMaxUpstreamBatchSize                     = 10
 	defaultRateLimitHeader                          = "X-Forwarded-For"
-	defaultInteropValidationStrategy                = FirstFilterStrategy
+	defaultInteropValidationStrategy                = AgreementStrategy
 	defaultInteropReqSizeLimit                      = 128 * opt.KiB
 	defaultInteropAccessListSizeLimit               = 1000
 	defaultInteropLoadBalancingUnhealthinessTimeout = 10 * time.Second


### PR DESCRIPTION
Makes interop filtering fail closed by default. Stacked on #648 (the supervisor → interop-filter rename); retarget the base to `main` once #648 merges.

- **Default strategy is now `agreement`** (the safest): unset strategy resolves to agreement, and `min_responses` still defaults to unanimity (= number of configured urls) when unset.
- **Removed the skip-on-no-backend option entirely** (`skipOnNoInteropFilterBackend` field, its `With...` option, and wiring). It was unused dead config and the wrong default posture.
- **Always fail closed with no urls:** `preflightChecksAndCleanupAccessList` always rejects (no-RPC-source error) when zero interop-filter urls are configured — there is no skip path.

**Startup vs. runtime posture (please confirm):** previously the agreement strategy hard-errored at startup with zero urls. Since agreement is now the default, that would block proxyd from starting whenever no interop urls are set. Instead, proxyd now **starts successfully with zero interop-filter urls** (a startup WARNING is logged), serves non-interop traffic normally, and **rejects any interop executing-message tx at runtime** via the always-reject preflight. The `min_responses` range validation (1..len(urls)) is kept but only applies when urls exist.