### PR TITLE
chore(proxyd): run golangci-lint in make lint target to match CI

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -183,7 +183,11 @@ jobs:
       - run:
           name: run lint
           command: |
-            golangci-lint run ./...
+            if [ "<<parameters.module>>" = "proxyd" ]; then
+              make lint
+            else
+              golangci-lint run ./...
+            fi
           working_directory: <<parameters.module>>
 
   go-test:

--- a/proxyd/Makefile
+++ b/proxyd/Makefile
@@ -26,9 +26,8 @@ test:
 .PHONY: test
 
 lint:
-	go vet ./...
-	goimports -w .
-.PHONY: test
+	golangci-lint run ./...
+.PHONY: lint
 
 test-%:
 	go test -v ./... -test.run ^Test$*$$

--- a/proxyd/mise.toml
+++ b/proxyd/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+golangci-lint = "2.11.4"


### PR DESCRIPTION
proxyd's `make lint` only ran `go vet` + `goimports`, but CI's `proxyd-lint` job ran `golangci-lint run ./...` — so local lint passed while CI failed on golangci-lint-only checks (e.g. `ineffassign`).

This makes the two equivalent and collapses them to a single source of truth:
- `proxyd/Makefile` `lint` target → `golangci-lint run ./...` (matching op-signer/op-txproxy/op-conductor-mon); formatting stays in `fmt`. Also fixes the mislabeled `.PHONY: test` → `.PHONY: lint`.
- `proxyd/mise.toml` pins golangci-lint (Go 1.26-compatible) so it's available out of the box, following the op-acceptor convention.
- CI `go-lint` job now runs `make lint` for proxyd (like op-acceptor) instead of inline `golangci-lint run ./...`.

`make lint` verified locally: runs `golangci-lint run ./...`, 0 issues.