### PR TITLE
test(proxyd): fix race in TestMulticall request-count assertion

### DIFF
--- a/proxyd/integration_tests/multicall_test.go
+++ b/proxyd/integration_tests/multicall_test.go
@@ -148,9 +148,15 @@ func TestMulticall(t *testing.T) {
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(rpcRes))
 		require.False(t, rpcRes.IsError())
 
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node3"))
+		// Multicall fans out to every backend and returns as soon as it has a
+		// winning response, leaving the losing backends' requests in flight on a
+		// non-cancelable context. Poll until all three have recorded their single
+		// request rather than asserting immediately after HandleRPC returns.
+		require.Eventually(t, func() bool {
+			return nodeBackendRequestCount(nodes, "node1") == 1 &&
+				nodeBackendRequestCount(nodes, "node2") == 1 &&
+				nodeBackendRequestCount(nodes, "node3") == 1
+		}, 5*time.Second, 10*time.Millisecond)
 	})
 
 	t.Run("When all of the backends return non 200, multicall should return 503", func(t *testing.T) {


### PR DESCRIPTION
`TestMulticall/Multicall_will_request_all_backends` is flaky (reproducible on main under `-race -count=20`; it failed CI on an unrelated proxyd PR).

**Root cause (test, not production):** multicall routing fans out to all backends on a non-cancelable context and returns as soon as it has a winning 200 response, leaving the losing backends' requests in flight. The test asserted each backend received exactly 1 request *immediately* after `HandleRPC` returned, racing the in-flight requests.

**Fix:** wait for the counts with `require.Eventually` (5s timeout, 10ms poll) instead of asserting immediately. No production change.

**Evidence:** repro fails at `-count=20 -race` (expected 1, actual 0); after the fix `-count=200 -race` passes with zero failures; full `go test ./...` green; lint 0 issues.

Note: a separate pre-existing production data race in `AvgSlidingWindow` (surfaced under `-race` from `Test_with_many_multi-calls`) is out of scope here and is being fixed in a follow-up PR.