### PR TITLE
fix(proxyd): synchronize AvgSlidingWindow access

### DIFF
--- a/proxyd/pkg/avg-sliding-window/sliding.go
+++ b/proxyd/pkg/avg-sliding-window/sliding.go
@@ -112,10 +112,9 @@ func (sw *AvgSlidingWindow) Incr() {
 
 // AddWithTime inserts a new data point into the window, with value `val` and time `t`
 func (sw *AvgSlidingWindow) AddWithTime(t time.Time, val float64) {
-	sw.advance()
-
-	defer sw.mux.Unlock()
 	sw.mux.Lock()
+	defer sw.mux.Unlock()
+	sw.advance()
 
 	key := t.Round(sw.bucketSize)
 	if !sw.inWindow(key) {
@@ -142,10 +141,8 @@ func (sw *AvgSlidingWindow) AddWithTime(t time.Time, val float64) {
 	sw.buckets.Put(key, b)
 }
 
-// advance evicts old data points
+// advance evicts old data points. The caller must hold sw.mux.
 func (sw *AvgSlidingWindow) advance() {
-	defer sw.mux.Unlock()
-	sw.mux.Lock()
 	now := sw.clock.Now().Round(sw.bucketSize)
 	windowStart := now.Add(-sw.windowLength)
 	keys := sw.buckets.Keys()
@@ -168,6 +165,8 @@ func (sw *AvgSlidingWindow) advance() {
 
 // Avg retrieves the current average for the sliding window
 func (sw *AvgSlidingWindow) Avg() float64 {
+	sw.mux.Lock()
+	defer sw.mux.Unlock()
 	sw.advance()
 	if sw.qty == 0 {
 		return 0
@@ -177,20 +176,24 @@ func (sw *AvgSlidingWindow) Avg() float64 {
 
 // Sum retrieves the current sum for the sliding window
 func (sw *AvgSlidingWindow) Sum() float64 {
+	sw.mux.Lock()
+	defer sw.mux.Unlock()
 	sw.advance()
 	return sw.sum
 }
 
 // Count retrieves the data point count for the sliding window
 func (sw *AvgSlidingWindow) Count() uint {
+	sw.mux.Lock()
+	defer sw.mux.Unlock()
 	sw.advance()
 	return sw.qty
 }
 
-// advance evicts old data points
+// Clear resets the sliding window to empty
 func (sw *AvgSlidingWindow) Clear() {
-	defer sw.mux.Unlock()
 	sw.mux.Lock()
+	defer sw.mux.Unlock()
 	sw.qty = 0
 	sw.sum = 0.0
 }

--- a/proxyd/pkg/avg-sliding-window/sliding_test.go
+++ b/proxyd/pkg/avg-sliding-window/sliding_test.go
@@ -1,11 +1,50 @@
 package avg_sliding_window
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestSlidingWindow_ConcurrentAccess hammers the window with concurrent writers
+// (Add/AddWithTime/Incr) and readers (Sum/Avg/Count) from many goroutines. It is
+// a regression guard for the data race between AddWithTime's write to sw.sum and
+// Sum's read of it. Run with -race; without proper synchronization the race
+// detector flags it.
+func TestSlidingWindow_ConcurrentAccess(t *testing.T) {
+	sw := NewSlidingWindow(
+		WithWindowLength(10*time.Second),
+		WithBucketSize(time.Second))
+
+	const goroutines = 16
+	const iterations = 500
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				sw.Add(1)
+				sw.Incr()
+				sw.AddWithTime(time.Now(), 2)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = sw.Sum()
+				_ = sw.Avg()
+				_ = sw.Count()
+			}
+		}()
+	}
+
+	wg.Wait()
+}
 
 func TestSlidingWindow_AddWithTime_Single(t *testing.T) {
 	now := ts("2023-04-21 15:04:05")


### PR DESCRIPTION
`AvgSlidingWindow` was accessed concurrently without full synchronization. Under proxyd multicall fan-out, multiple backend goroutines touch the same backend's sliding window at once, and the Go race detector flags a real data race.

**Race:** a write to `sw.sum`/`sw.qty` in `AddWithTime` (`sliding.go:141`, reached via `Backend.doForward` → `Incr`) races a read in `Sum` (`sliding.go:181`, reached via `Backend.ErrorRate`). `Avg` and `Count` had the same problem.

**Root cause:** locking was partial. `advance()` and the body of `AddWithTime` each took the mutex independently, but `Sum`/`Avg`/`Count` called `advance()` (locked) and then read `sw.sum`/`sw.qty` *outside* any lock — racing concurrent writers.

**Fix:** `advance()` is now an internal helper that assumes the lock is held, and every public method (`AddWithTime`, `Sum`, `Avg`, `Count`, `Clear`) acquires the mutex once for its full read/mutate. No nested locking, no lock-ordering changes.

**Red/green evidence (`-race`):**
- New `TestSlidingWindow_ConcurrentAccess` regression guard fails (DATA RACE in `AddWithTime`/`Sum`/`Count`) on the unmodified code.
- After the fix: `go test ./pkg/avg-sliding-window/ -run TestSlidingWindow_ConcurrentAccess -race -count=100` → clean.
- `go test ./integration_tests/ -run 'TestMulticall/Test_with_many_multi-calls' -race -count=10` → clean (was reproducing the race before).
- Full `go test ./...` (no race) passes; `go build ./...` and golangci-lint (v2) clean.