### PR TITLE
refactor(proxyd): unified transaction filter on the submission path

### DIFF
--- a/proxyd/integration_tests/testdata/tx_filter.toml
+++ b/proxyd/integration_tests/testdata/tx_filter.toml
@@ -1,0 +1,41 @@
+[server]
+
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 1
+
+[backends]
+[backends.good]
+rpc_url = "$GOOD_BACKEND_RPC_URL"
+ws_url = "$GOOD_BACKEND_RPC_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["good"]
+
+[rpc_method_mappings]
+eth_chainId = "main"
+eth_sendRawTransaction = "main"
+eth_sendRawTransactionConditional = "main"
+eth_sendBundle = "main"
+
+[interop_validation]
+urls = [
+"$VALIDATING_BACKEND_RPC_URL_1",
+]
+strategy = "first-filter"
+req_params_size_limit = 131072 ## 128KB
+access_list_size_limit = 1000000
+
+[interop_validation.sender_rate_limit]
+allowed_chain_ids = [0, 420120003]
+enabled = true
+interval = "1s"
+limit = 99999
+
+[sender_rate_limit]
+allowed_chain_ids = [0, 420120003]
+enabled = false
+interval = "1s"
+limit = 1

--- a/proxyd/integration_tests/tx_filter_test.go
+++ b/proxyd/integration_tests/tx_filter_test.go
@@ -1,0 +1,332 @@
+package integration_tests
+
+import (
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/ethereum-optimism/infra/proxyd"
+	interopErrors "github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+const filterChainID = 420120003
+
+func newSigner(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	return key
+}
+
+// interopAccessListEntries builds a parseable interop access list so the
+// interop module reaches the strategy (rather than failing to parse).
+func interopAccessListEntries() []common.Hash {
+	checksumArgs := messages.ChecksumArgs{
+		BlockNumber: 3519561,
+		Timestamp:   1746536469,
+		LogIndex:    1,
+		ChainID:     eth.ChainIDFromUInt64(filterChainID),
+		LogHash: messages.PayloadHashToLogHash(
+			crypto.Keccak256Hash([]byte("Hello, World!")),
+			common.HexToAddress("0x7A23c3fC3dA9a5364b97E0e4c47E7777BaE5C8Cd"),
+		),
+	}
+	return messages.EncodeAccessList([]messages.Access{checksumArgs.Access()})
+}
+
+// filterInteropTx builds a signed tx carrying an interop access list, so the
+// filter's interop module validates it against the interop-filter backend.
+func filterInteropTx(t *testing.T, key *ecdsa.PrivateKey, chainID int64, nonce uint64) *types.Transaction {
+	t.Helper()
+	to := common.HexToAddress("0x8f3Ddd0FBf3e78CA1D6cd17379eD88E261249B53")
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   big.NewInt(chainID),
+		Nonce:     nonce,
+		GasFeeCap: big.NewInt(1000000000),
+		GasTipCap: big.NewInt(1000000000),
+		Gas:       21000,
+		To:        &to,
+		Value:     big.NewInt(0),
+		AccessList: types.AccessList{
+			{
+				Address:     params.InteropCrossL2InboxAddress,
+				StorageKeys: interopAccessListEntries(),
+			},
+		},
+	})
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(big.NewInt(chainID)), key)
+	require.NoError(t, err)
+	return signed
+}
+
+// filterPlainTx builds a signed non-interop tx (no access list).
+func filterPlainTx(t *testing.T, key *ecdsa.PrivateKey, chainID int64, nonce uint64) *types.Transaction {
+	t.Helper()
+	to := common.HexToAddress("0x0987654321098765432109876543210987654321")
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   big.NewInt(chainID),
+		Nonce:     nonce,
+		GasFeeCap: big.NewInt(1000000000),
+		GasTipCap: big.NewInt(1000000000),
+		Gas:       21000,
+		To:        &to,
+		Value:     big.NewInt(1),
+	})
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(big.NewInt(chainID)), key)
+	require.NoError(t, err)
+	return signed
+}
+
+func txHex(t *testing.T, tx *types.Transaction) string {
+	t.Helper()
+	raw, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	return hexutil.Encode(raw)
+}
+
+func makeSendBundle(t *testing.T, txs ...*types.Transaction) []byte {
+	t.Helper()
+	hexes := make([]string, len(txs))
+	for i, tx := range txs {
+		hexes[i] = txHex(t, tx)
+	}
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "eth_sendBundle",
+		"params":  []any{map[string]any{"txs": hexes}},
+		"id":      1,
+	})
+	require.NoError(t, err)
+	return body
+}
+
+func startFilterProxyd(t *testing.T, config *proxyd.Config) func() {
+	t.Helper()
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	return shutdown
+}
+
+// TestTxFilter_Bundle_InteropEnforced proves the bundle->interop gap is closed:
+// a bundle with one interop tx the filter rejects is rejected whole, and the
+// backend is never called. (B1)
+func TestTxFilter_Bundle_InteropEnforced(t *testing.T) {
+	goodBackend := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer goodBackend.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	errResp := fmt.Sprintf(errResTmpl, -32000, interopErrors.ErrConflict.Error())
+	rejectingFilter := NewMockBackend(SingleResponseHandler(409, errResp))
+	defer rejectingFilter.Close()
+
+	config := ReadConfig("tx_filter")
+	config.InteropValidationConfig.Urls = []string{rejectingFilter.URL()}
+
+	shutdown := startFilterProxyd(t, config)
+	defer shutdown()
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+	key := newSigner(t)
+	bundle := makeSendBundle(t,
+		filterPlainTx(t, key, filterChainID, 0),
+		filterInteropTx(t, key, filterChainID, 1),
+	)
+	resp, _, err := client.SendRequest(bundle)
+	require.NoError(t, err)
+	require.Contains(t, string(resp), interopErrors.ErrConflict.Error(), "bundle rejected by interop: %s", string(resp))
+	require.Empty(t, goodBackend.Requests(), "rejected bundle must not reach the backend")
+}
+
+// TestTxFilter_Bundle_InteropEnforced_MiddlewareDisabled proves interop runs on
+// bundles even with the tx-validation middleware disabled, and that the bundle
+// size cap is enforced regardless. (B1 + cap)
+func TestTxFilter_Bundle_InteropEnforced_MiddlewareDisabled(t *testing.T) {
+	goodBackend := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer goodBackend.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	errResp := fmt.Sprintf(errResTmpl, -32000, interopErrors.ErrConflict.Error())
+	rejectingFilter := NewMockBackend(SingleResponseHandler(409, errResp))
+	defer rejectingFilter.Close()
+
+	config := ReadConfig("tx_filter")
+	config.InteropValidationConfig.Urls = []string{rejectingFilter.URL()}
+	require.False(t, config.TxValidationMiddlewareConfig.Enabled, "middleware must be disabled in this config")
+
+	shutdown := startFilterProxyd(t, config)
+	defer shutdown()
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+	key := newSigner(t)
+
+	// Interop still enforced with middleware off.
+	bundle := makeSendBundle(t, filterInteropTx(t, key, filterChainID, 0))
+	resp, _, err := client.SendRequest(bundle)
+	require.NoError(t, err)
+	require.Contains(t, string(resp), interopErrors.ErrConflict.Error(), "interop still enforced with middleware off: %s", string(resp))
+	require.Empty(t, goodBackend.Requests())
+
+	// Bundle over the size cap is rejected even with middleware off.
+	bigTxs := make([]*types.Transaction, 101)
+	for i := range bigTxs {
+		bigTxs[i] = filterPlainTx(t, key, filterChainID, uint64(i))
+	}
+	resp, _, err = client.SendRequest(makeSendBundle(t, bigTxs...))
+	require.NoError(t, err)
+	require.Contains(t, string(resp), "maximum allowed")
+	require.Empty(t, goodBackend.Requests())
+}
+
+// TestTxFilter_Bundle_ChainIDAndSenderRateLimit proves chain-ID and sender
+// rate-limiting apply per-bundle-tx. (B2)
+func TestTxFilter_Bundle_ChainIDAndSenderRateLimit(t *testing.T) {
+	goodBackend := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer goodBackend.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	goodFilter := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer goodFilter.Close()
+
+	config := ReadConfig("tx_filter")
+	config.InteropValidationConfig.Urls = []string{goodFilter.URL()}
+
+	t.Run("wrong chain id in bundle rejected", func(t *testing.T) {
+		shutdown := startFilterProxyd(t, config)
+		defer shutdown()
+		client := NewProxydClient("http://127.0.0.1:8545")
+		key := newSigner(t)
+		bundle := makeSendBundle(t,
+			filterPlainTx(t, key, filterChainID, 0),
+			filterPlainTx(t, key, 9999, 1), // not in allowed_chain_ids
+		)
+		resp, _, err := client.SendRequest(bundle)
+		require.NoError(t, err)
+		require.Contains(t, string(resp), "invalid sender", "wrong-chain bundle must be rejected: %s", string(resp))
+		require.Empty(t, goodBackend.Requests())
+	})
+
+	t.Run("per-tx sender rate limit applies across bundle", func(t *testing.T) {
+		rlConfig := ReadConfig("tx_filter")
+		rlConfig.InteropValidationConfig.Urls = []string{goodFilter.URL()}
+		rlConfig.SenderRateLimit.Enabled = true
+		rlConfig.SenderRateLimit.Limit = 1
+		shutdown := startFilterProxyd(t, rlConfig)
+		defer shutdown()
+		client := NewProxydClient("http://127.0.0.1:8545")
+		key := newSigner(t)
+		// Same sender:nonce twice in one bundle, limit of 1 -> the second tx
+		// trips the per-sender:nonce limit and the whole bundle is rejected.
+		dup := filterPlainTx(t, key, filterChainID, 0)
+		bundle := makeSendBundle(t, dup, dup)
+		resp, _, err := client.SendRequest(bundle)
+		require.NoError(t, err)
+		require.Contains(t, string(resp), "sender is over rate limit", "second tx in bundle over sender limit: %s", string(resp))
+	})
+}
+
+// TestTxFilter_Order_ShortCircuit proves a chain-ID failure short-circuits the
+// pipeline: interop is never consulted, so the interop backend gets no request.
+func TestTxFilter_Order_ShortCircuit(t *testing.T) {
+	goodBackend := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer goodBackend.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	interopFilter := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer interopFilter.Close()
+
+	config := ReadConfig("tx_filter")
+	config.InteropValidationConfig.Urls = []string{interopFilter.URL()}
+
+	shutdown := startFilterProxyd(t, config)
+	defer shutdown()
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+	key := newSigner(t)
+	// Interop tx but on a disallowed chain id: chain-ID module rejects first.
+	tx := filterInteropTx(t, key, 9999, 0)
+	resp, _, err := client.SendRequest(makeSendRawTransaction(txHex(t, tx)))
+	require.NoError(t, err)
+	require.Contains(t, string(resp), "invalid sender", "chain-id rejection expected: %s", string(resp))
+	require.Empty(t, interopFilter.Requests(), "interop must not run after chain-id reject")
+	require.Empty(t, goodBackend.Requests())
+}
+
+// TestTxFilter_ChainIDEnforcedWithoutRateLimiter proves chain-ID enforcement is
+// independent of the sender rate limiter. (B3)
+func TestTxFilter_ChainIDEnforcedWithoutRateLimiter(t *testing.T) {
+	goodBackend := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer goodBackend.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	goodFilter := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer goodFilter.Close()
+
+	config := ReadConfig("tx_filter")
+	config.InteropValidationConfig.Urls = []string{goodFilter.URL()}
+	// Disable BOTH rate limiters; chain-ID must still be enforced.
+	config.SenderRateLimit.Enabled = false
+	config.InteropValidationConfig.RateLimit.Enabled = false
+	require.NotEmpty(t, config.SenderRateLimit.AllowedChainIds)
+
+	shutdown := startFilterProxyd(t, config)
+	defer shutdown()
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+	key := newSigner(t)
+	tx := filterPlainTx(t, key, 9999, 0) // disallowed chain id
+	resp, _, err := client.SendRequest(makeSendRawTransaction(txHex(t, tx)))
+	require.NoError(t, err)
+	require.Contains(t, string(resp), "invalid sender", "wrong-chain tx must be rejected with rate limiters off: %s", string(resp))
+	require.Empty(t, goodBackend.Requests())
+}
+
+// TestTxFilter_Middleware_RespectsMethodConfig proves the configurable
+// tx_validation.methods set still gates the middleware module: a method not in
+// the set skips the middleware but still runs interop/chain-ID. This is the
+// first server-path integration test for the middleware.
+func TestTxFilter_Middleware_RespectsMethodConfig(t *testing.T) {
+	goodBackend := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer goodBackend.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", goodBackend.URL()))
+
+	goodFilter := NewMockBackend(SingleResponseHandler(200, dummyHealthyRes))
+	defer goodFilter.Close()
+
+	// Middleware that rejects everything it sees.
+	middleware := NewMockBackend(SingleResponseHandler(200, `{"unauthorized":{}}`))
+	defer middleware.Close()
+
+	config := ReadConfig("tx_filter")
+	config.InteropValidationConfig.Urls = []string{goodFilter.URL()}
+	config.InteropValidationConfig.RateLimit.Limit = math.MaxInt
+	config.TxValidationMiddlewareConfig.Enabled = true
+	config.TxValidationMiddlewareConfig.Endpoint = middleware.URL()
+	// Only gate eth_sendRawTransaction; eth_sendBundle should skip middleware.
+	config.TxValidationMiddlewareConfig.Methods = []string{"eth_sendRawTransaction"}
+
+	shutdown := startFilterProxyd(t, config)
+	defer shutdown()
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+	key := newSigner(t)
+
+	// eth_sendBundle is not in Methods -> middleware skipped -> reaches backend.
+	bundle := makeSendBundle(t, filterPlainTx(t, key, filterChainID, 0))
+	resp, code, err := client.SendRequest(bundle)
+	require.NoError(t, err)
+	require.Equal(t, 200, code, "bundle should skip middleware and forward: %s", string(resp))
+	require.Empty(t, middleware.Requests(), "middleware must not be consulted for a non-configured method")
+	require.NotEmpty(t, goodBackend.Requests())
+}

--- a/proxyd/interop.go
+++ b/proxyd/interop.go
@@ -1,15 +1,12 @@
 package proxyd
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 func accessObjectToKey(accessObject messages.Access) string {
@@ -54,12 +51,4 @@ func validateAndDeduplicateInteropAccessList(entriesToParse []common.Hash) ([]co
 func getInteropExecutingDescriptorTimestamp() uint64 {
 	// intentionally kept to be slightly in the future (but within the expiryAt of the associated message) to proceed through the access-list time-checks
 	return uint64(time.Now().Unix() + 1000)
-}
-
-func (s *Server) rateLimitInteropSender(ctx context.Context, tx *types.Transaction) error {
-	if s.interopSenderLim == nil {
-		log.Warn("interop sender rate limiter is not enabled, skipping", "req_id", GetReqID(ctx))
-		return nil
-	}
-	return s.genericRateLimitSender(ctx, tx, s.interopSenderLim)
 }

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/log"
@@ -98,6 +97,7 @@ type Server struct {
 	txValidationMethods      TxValidationMethodSet
 	txValidationClient       *TxValidationClient
 	txValidationFailOpen     bool
+	txFilter                 *TxFilter
 	isDraining               atomic.Bool
 	gracefulShutdownDuration time.Duration
 }
@@ -221,7 +221,7 @@ func NewServer(
 		txValidationFailOpen = *txValidationConfig.FailOpen
 	}
 
-	return &Server{
+	srv := &Server{
 		BackendGroups:        backendGroups,
 		wsBackendGroup:       wsBackendGroup,
 		wsMethodWhitelist:    wsMethodWhitelist,
@@ -259,7 +259,31 @@ func NewServer(
 		txValidationClient:       txValidationClient,
 		txValidationFailOpen:     txValidationFailOpen,
 		gracefulShutdownDuration: gracefulShutdownDuration,
-	}, nil
+	}
+
+	var modules []TxFilterModule
+	if len(srv.allowedChainIds) > 0 { // B3: independent of the rate limiter
+		modules = append(modules, &chainIDModule{allowedChainIds: srv.allowedChainIds})
+	}
+	if srv.senderLim != nil {
+		modules = append(modules, &senderRateLimitModule{lim: srv.senderLim})
+	}
+	modules = append(modules, &interopModule{ // strategy always set post-#649
+		strategy:         srv.interopStrategy,
+		interopSenderLim: srv.interopSenderLim,
+		validatingCfg:    srv.interopValidatingConfig,
+	})
+	if srv.enableTxValidation {
+		modules = append(modules, &txMiddlewareModule{
+			endpoint: srv.txValidationEndpoint,
+			fn:       srv.txValidationFn,
+			failOpen: srv.txValidationFailOpen,
+			methods:  srv.txValidationMethods,
+		})
+	}
+	srv.txFilter = NewTxFilter(srv, modules...)
+
+	return srv, nil
 }
 
 func (s *Server) RPCListenAndServe(host string, port int) error {
@@ -520,45 +544,6 @@ func checkInteropAndReturnAccessList(ctx context.Context, tx *types.Transaction)
 	return interopAccessList, true, nil
 }
 
-func (s *Server) validateInteropSendRpcRequest(ctx context.Context, tx *types.Transaction) error {
-	interopAccessList, isInterop, err := checkInteropAndReturnAccessList(ctx, tx)
-	if err != nil {
-		return err
-	}
-	if !isInterop {
-		return nil
-	}
-	// at this point, we know it's an interop transaction worthy of being validated
-	log.Info(
-		"validating interop access list",
-		"source", "rpc",
-		"req_id", GetReqID(ctx),
-		"strategy", s.interopValidatingConfig.Strategy,
-		"tx_hash", tx.Hash(),
-	)
-	if err := s.rateLimitInteropSender(ctx, tx); err != nil {
-		return err
-	}
-	if err := reqSizeLimitCheck(ctx, tx, s.interopValidatingConfig.ReqSizeLimit); err != nil {
-		return err
-	}
-
-	finalErr := s.interopStrategy.ValidateAccessList(ctx, interopAccessList)
-
-	rpcInteropValidationsTotal.WithLabelValues(
-		interopValidationResult(finalErr),
-		interopValidationReason(finalErr),
-		string(s.interopValidatingConfig.Strategy),
-	).Inc()
-
-	if finalErr == nil {
-		log.Info("interop access list validated successfully", "req_id", GetReqID(ctx), "tx_hash", tx.Hash())
-	} else {
-		log.Info("interop access list validation failed", "req_id", GetReqID(ctx), "tx_hash", tx.Hash(), "error", finalErr)
-	}
-	return finalErr
-}
-
 // interopValidationResult classifies the outcome of an interop access list
 // validation for metrics purposes. It keys on the same helpers the validation
 // strategies use, rather than the raw HTTP status, so the buckets match how the
@@ -701,32 +686,20 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			continue
 		}
 
-		// Apply a sender-based rate limit if it is enabled. Note that sender-based rate
-		// limits apply regardless of origin or user-agent. As such, they don't use the
-		// isLimited method.
-		if parsedReq.Method == "eth_sendRawTransaction" || parsedReq.Method == "eth_sendRawTransactionConditional" {
-			tx, err := s.convertSendReqToSendTx(ctx, parsedReq)
+		// Run the unified transaction-submission filter. Sender-based rate
+		// limits apply regardless of origin or user-agent, so they don't use
+		// the isLimited method.
+		if s.txFilter.IsSubmissionMethod(parsedReq.Method) {
+			sub, err := s.txFilter.Build(ctx, parsedReq, bypassLimit)
 			if err != nil {
 				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)
 				responses[i] = NewRPCErrorRes(parsedReq.ID, err)
 				continue
 			}
-			txHashes[i] = tx.Hash()
-			if err := s.rateLimitSender(ctx, tx, bypassLimit); err != nil {
-				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)
-				responses[i] = NewRPCErrorRes(parsedReq.ID, err)
-				continue
+			if len(sub.Txs) == 1 {
+				txHashes[i] = sub.Txs[0].Hash() // preserve single-tx hash tracking
 			}
-			if err := s.validateInteropSendRpcRequest(ctx, tx); err != nil {
-				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)
-				responses[i] = NewRPCErrorRes(parsedReq.ID, err)
-				continue
-			}
-		}
-
-		// Apply transaction validation middleware if enabled and method is configured.
-		if s.enableTxValidation && s.txValidationMethods.Contains(parsedReq.Method) {
-			if err := s.applyTxValidation(ctx, parsedReq); err != nil {
+			if err := s.txFilter.Apply(ctx, sub); err != nil {
 				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)
 				responses[i] = NewRPCErrorRes(parsedReq.ID, err)
 				continue
@@ -1020,57 +993,11 @@ func (s *Server) convertSendReqToSendTx(ctx context.Context, req *RPCReq) (*type
 	return tx, nil
 }
 
-func (s *Server) genericRateLimitSender(ctx context.Context, tx *types.Transaction, lim FrontendRateLimiter) error {
-	// Check if the transaction is for the expected chain,
-	// otherwise reject before rate limiting to avoid replay attacks.
-	if !s.isAllowedChainId(tx.ChainId()) {
-		log.Debug("chain id is not allowed", "req_id", GetReqID(ctx))
-		return txpool.ErrInvalidSender
-	}
-
-	var signer types.Signer
-	// If you pass in a zero chain ID, types.LatestSignerForChainID panics. So we need to handle that case
-	// manually.
-	if tx.ChainId().Sign() == 0 {
-		signer = new(types.HomesteadSigner)
-	} else {
-		signer = types.LatestSignerForChainID(tx.ChainId())
-	}
-
-	from, err := types.Sender(signer, tx)
-	if err != nil {
-		log.Debug("could not get sender from transaction", "err", err, "req_id", GetReqID(ctx))
-		return ErrInvalidParams(err.Error())
-	}
-	ok, err := lim.Take(ctx, fmt.Sprintf("%s:%d", from.Hex(), tx.Nonce()))
-	if err != nil {
-		log.Error("error taking from sender limiter", "err", err, "req_id", GetReqID(ctx))
-		return ErrInternal
-	}
-	if !ok {
-		log.Debug("sender rate limit exceeded", "sender", from.Hex(), "req_id", GetReqID(ctx))
-		return ErrOverSenderRateLimit
-	}
-
-	return nil
-}
-
-func (s *Server) rateLimitSender(ctx context.Context, tx *types.Transaction, bypassLimit bool) error {
-	if s.senderLim == nil {
-		log.Warn("sender rate limiter is not enabled, skipping", "req_id", GetReqID(ctx))
-		return nil
-	}
-	if bypassLimit {
-		return nil
-	}
-	return s.genericRateLimitSender(ctx, tx, s.senderLim)
-}
-
-func (s *Server) isAllowedChainId(chainId *big.Int) bool {
-	if len(s.allowedChainIds) == 0 {
+func isAllowedChainId(allowedChainIds []*big.Int, chainId *big.Int) bool {
+	if len(allowedChainIds) == 0 {
 		return true
 	}
-	for _, id := range s.allowedChainIds {
+	for _, id := range allowedChainIds {
 		if chainId.Cmp(id) == 0 {
 			return true
 		}
@@ -1200,37 +1127,6 @@ func truncate(str string, maxLen int) string {
 	} else {
 		return str
 	}
-}
-
-// applyTxValidation validates transactions using the configured validation middleware.
-// It supports both single transaction methods (eth_sendRawTransaction) and bundle methods (eth_sendBundle).
-func (s *Server) applyTxValidation(ctx context.Context, req *RPCReq) error {
-	var txs []*types.Transaction
-	var err error
-
-	switch req.Method {
-	case "eth_sendRawTransaction", "eth_sendRawTransactionConditional":
-		tx, err := s.convertSendReqToSendTx(ctx, req)
-		if err != nil {
-			return err
-		}
-		txs = []*types.Transaction{tx}
-	case "eth_sendBundle":
-		txs, err = transactionsFromBundleReq(ctx, req)
-		if err != nil {
-			return err
-		}
-	default:
-		log.Debug("unsupported method for tx validation", "method", req.Method, "req_id", GetReqID(ctx))
-		return nil
-	}
-
-	return validateTransactions(ctx, txs, s.txValidationEndpoint, s.txValidationFn, s.txValidationFailOpen)
-}
-
-// SetTxValidationFn allows overriding the transaction validation function for testing.
-func (s *Server) SetTxValidationFn(fn TxValidationFunc) {
-	s.txValidationFn = fn
 }
 
 type batchElem struct {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -261,29 +261,36 @@ func NewServer(
 		gracefulShutdownDuration: gracefulShutdownDuration,
 	}
 
-	var modules []TxFilterModule
-	if len(srv.allowedChainIds) > 0 { // B3: independent of the rate limiter
-		modules = append(modules, &chainIDModule{allowedChainIds: srv.allowedChainIds})
-	}
-	if srv.senderLim != nil {
-		modules = append(modules, &senderRateLimitModule{lim: srv.senderLim})
-	}
-	modules = append(modules, &interopModule{ // strategy always set post-#649
-		strategy:         srv.interopStrategy,
-		interopSenderLim: srv.interopSenderLim,
-		validatingCfg:    srv.interopValidatingConfig,
-	})
-	if srv.enableTxValidation {
-		modules = append(modules, &txMiddlewareModule{
-			endpoint: srv.txValidationEndpoint,
-			fn:       srv.txValidationFn,
-			failOpen: srv.txValidationFailOpen,
-			methods:  srv.txValidationMethods,
-		})
-	}
-	srv.txFilter = NewTxFilter(srv, modules...)
+	srv.txFilter = NewTxFilter(srv.convertSendReqToSendTx, srv.txFilterModules()...)
 
 	return srv, nil
+}
+
+// txFilterModules assembles the ordered submission-filter pipeline:
+// ChainID → SenderRateLimit → Interop → TxMiddleware. The order is fixed here
+// and is the single source of truth for module sequencing.
+func (s *Server) txFilterModules() []TxFilterModule {
+	var modules []TxFilterModule
+	if len(s.allowedChainIds) > 0 { // B3: independent of the rate limiter
+		modules = append(modules, &chainIDModule{allowedChainIds: s.allowedChainIds})
+	}
+	if s.senderLim != nil {
+		modules = append(modules, &senderRateLimitModule{lim: s.senderLim})
+	}
+	modules = append(modules, &interopModule{ // strategy always set post-#649
+		strategy:         s.interopStrategy,
+		interopSenderLim: s.interopSenderLim,
+		validatingCfg:    s.interopValidatingConfig,
+	})
+	if s.enableTxValidation {
+		modules = append(modules, &txMiddlewareModule{
+			endpoint: s.txValidationEndpoint,
+			fn:       s.txValidationFn,
+			failOpen: s.txValidationFailOpen,
+			methods:  s.txValidationMethods,
+		})
+	}
+	return modules
 }
 
 func (s *Server) RPCListenAndServe(host string, port int) error {
@@ -696,8 +703,8 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				responses[i] = NewRPCErrorRes(parsedReq.ID, err)
 				continue
 			}
-			if len(sub.Txs) == 1 {
-				txHashes[i] = sub.Txs[0].Hash() // preserve single-tx hash tracking
+			if sub.Method == "eth_sendRawTransaction" || sub.Method == "eth_sendRawTransactionConditional" {
+				txHashes[i] = sub.Txs[0].Hash() // preserve single-tx forwarding log; bundles aren't sendRawTransaction
 			}
 			if err := s.txFilter.Apply(ctx, sub); err != nil {
 				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -271,13 +271,13 @@ func NewServer(
 // and is the single source of truth for module sequencing.
 func (s *Server) txFilterModules() []TxFilterModule {
 	var modules []TxFilterModule
-	if len(s.allowedChainIds) > 0 { // B3: independent of the rate limiter
+	if len(s.allowedChainIds) > 0 { // chain-ID enforcement is independent of either rate limiter
 		modules = append(modules, &chainIDModule{allowedChainIds: s.allowedChainIds})
 	}
 	if s.senderLim != nil {
 		modules = append(modules, &senderRateLimitModule{lim: s.senderLim})
 	}
-	modules = append(modules, &interopModule{ // strategy always set post-#649
+	modules = append(modules, &interopModule{ // interopStrategy is always non-nil
 		strategy:         s.interopStrategy,
 		interopSenderLim: s.interopSenderLim,
 		validatingCfg:    s.interopValidatingConfig,

--- a/proxyd/tx_filter.go
+++ b/proxyd/tx_filter.go
@@ -14,6 +14,8 @@ import (
 // The submission is decoded once and the recovered sender for each tx is
 // memoized so that the chain-ID, sender-rate-limit, and interop modules can all
 // share a single ecrecover per transaction.
+//
+// Not safe for concurrent use.
 type TxSubmission struct {
 	Method          string
 	Req             *RPCReq
@@ -79,41 +81,51 @@ func NewTxFilter(decode txDecodeFunc, modules ...TxFilterModule) *TxFilter {
 	return &TxFilter{decode: decode, modules: modules}
 }
 
+// submissionDecoder decodes a submission request into its transactions.
+type submissionDecoder func(ctx context.Context, f *TxFilter, req *RPCReq) ([]*types.Transaction, error)
+
+// submissionMethods is the single source of truth for the submission-method
+// set: both membership (IsSubmissionMethod) and decoding (Build) read it, so
+// they cannot drift. This set gates chain-ID, rate-limit, and interop, so
+// adding a method here enrolls it in all three.
+var submissionMethods = map[string]submissionDecoder{
+	"eth_sendRawTransaction":            decodeSingleTx,
+	"eth_sendRawTransactionConditional": decodeSingleTx,
+	"eth_sendBundle":                    decodeBundle,
+}
+
+func decodeSingleTx(ctx context.Context, f *TxFilter, req *RPCReq) ([]*types.Transaction, error) {
+	tx, err := f.decode(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return []*types.Transaction{tx}, nil
+}
+
+func decodeBundle(ctx context.Context, _ *TxFilter, req *RPCReq) ([]*types.Transaction, error) {
+	return transactionsFromBundleReq(ctx, req)
+}
+
 // IsSubmissionMethod reports the static set of submission methods the filter
 // handles. Per-method middleware opt-out is enforced inside the middleware
 // module, not here — chain-ID/rate-limit/interop always apply.
 func (f *TxFilter) IsSubmissionMethod(method string) bool {
-	switch method {
-	case "eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle":
-		return true
-	default:
-		return false
-	}
+	_, ok := submissionMethods[method]
+	return ok
 }
 
-// Build decodes a submission request into a TxSubmission, method-aware:
-//   - single-tx methods use convertSendReqToSendTx
-//   - eth_sendBundle uses transactionsFromBundleReq
-//
-// It propagates those decoders' errors and enforces maxBundleTransactions here
-// so the cap applies to every bundle regardless of middleware enablement.
+// Build decodes a submission request into a TxSubmission using the decoder
+// registered for its method, propagating that decoder's errors and enforcing
+// maxBundleTransactions here so the cap applies to every bundle regardless of
+// middleware enablement.
 func (f *TxFilter) Build(ctx context.Context, req *RPCReq, bypassRateLimit bool) (*TxSubmission, error) {
-	var txs []*types.Transaction
-	switch req.Method {
-	case "eth_sendRawTransaction", "eth_sendRawTransactionConditional":
-		tx, err := f.decode(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		txs = []*types.Transaction{tx}
-	case "eth_sendBundle":
-		bundleTxs, err := transactionsFromBundleReq(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		txs = bundleTxs
-	default:
+	decode, ok := submissionMethods[req.Method]
+	if !ok {
 		return nil, fmt.Errorf("not a submission method: %s", req.Method)
+	}
+	txs, err := decode(ctx, f, req)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(txs) > maxBundleTransactions {

--- a/proxyd/tx_filter.go
+++ b/proxyd/tx_filter.go
@@ -42,9 +42,26 @@ func (s *TxSubmission) Sender(i int) (common.Address, error) {
 	return s.senders[i], s.senderErr[i]
 }
 
-// TxFilterModule is a single check in the submission filter pipeline. Apply
-// returns nil to accept (allowing the pipeline to continue) or an error to
-// reject the whole submission. Each module owns its own failure policy.
+// txDecodeFunc decodes a single-tx submission request into a transaction. It is
+// injected into TxFilter so the filter does not hold a back-reference to the
+// Server (Server.convertSendReqToSendTx is passed in).
+type txDecodeFunc func(ctx context.Context, req *RPCReq) (*types.Transaction, error)
+
+// TxFilterModule is a single check in the submission filter pipeline.
+//
+// Apply returns nil to accept (allowing the pipeline to continue) or an error
+// to reject the whole submission. The contract:
+//
+//   - Apply runs for EVERY submission method the filter handles. Per-method
+//     scoping is the module's own responsibility — see txMiddlewareModule, which
+//     opts out of methods not in its configured set.
+//   - Modules MUST treat sub.Txs as immutable. TxSubmission.Sender memoizes
+//     ecrecover per index keyed by position in sub.Txs; mutating or reordering
+//     the slice would corrupt that memo.
+//   - The default failure policy is fail-CLOSED: returning an error rejects the
+//     submission. Fail-open (returning nil despite an internal failure) must be
+//     an explicit, operator-gated decision, as txMiddlewareModule does via its
+//     failOpen flag — never a silent default.
 type TxFilterModule interface {
 	Name() string
 	Apply(ctx context.Context, sub *TxSubmission) error
@@ -54,12 +71,12 @@ type TxFilterModule interface {
 // owns an ordered list of modules and runs them in order, short-circuiting on
 // the first rejection (logical AND).
 type TxFilter struct {
-	srv     *Server
+	decode  txDecodeFunc
 	modules []TxFilterModule
 }
 
-func NewTxFilter(srv *Server, modules ...TxFilterModule) *TxFilter {
-	return &TxFilter{srv: srv, modules: modules}
+func NewTxFilter(decode txDecodeFunc, modules ...TxFilterModule) *TxFilter {
+	return &TxFilter{decode: decode, modules: modules}
 }
 
 // IsSubmissionMethod reports the static set of submission methods the filter
@@ -85,7 +102,7 @@ func (f *TxFilter) Build(ctx context.Context, req *RPCReq, bypassRateLimit bool)
 	var txs []*types.Transaction
 	switch req.Method {
 	case "eth_sendRawTransaction", "eth_sendRawTransactionConditional":
-		tx, err := f.srv.convertSendReqToSendTx(ctx, req)
+		tx, err := f.decode(ctx, req)
 		if err != nil {
 			return nil, err
 		}

--- a/proxyd/tx_filter.go
+++ b/proxyd/tx_filter.go
@@ -92,12 +92,11 @@ func (f *TxFilter) IsSubmissionMethod(method string) bool {
 }
 
 // Build decodes a submission request into a TxSubmission, method-aware:
-//   - single-tx methods reuse convertSendReqToSendTx
-//   - eth_sendBundle reuses transactionsFromBundleReq
+//   - single-tx methods use convertSendReqToSendTx
+//   - eth_sendBundle uses transactionsFromBundleReq
 //
-// It returns the same decode errors those return today and enforces
-// maxBundleTransactions here so the cap applies to every bundle regardless of
-// middleware enablement.
+// It propagates those decoders' errors and enforces maxBundleTransactions here
+// so the cap applies to every bundle regardless of middleware enablement.
 func (f *TxFilter) Build(ctx context.Context, req *RPCReq, bypassRateLimit bool) (*TxSubmission, error) {
 	var txs []*types.Transaction
 	switch req.Method {

--- a/proxyd/tx_filter.go
+++ b/proxyd/tx_filter.go
@@ -1,0 +1,127 @@
+package proxyd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// TxSubmission is the decoded form of a single transaction-submission request
+// (eth_sendRawTransaction, eth_sendRawTransactionConditional, eth_sendBundle).
+// The submission is decoded once and the recovered sender for each tx is
+// memoized so that the chain-ID, sender-rate-limit, and interop modules can all
+// share a single ecrecover per transaction.
+type TxSubmission struct {
+	Method          string
+	Req             *RPCReq
+	Txs             []*types.Transaction
+	BypassRateLimit bool
+
+	senders   []common.Address
+	senderErr []error
+	recovered []bool
+}
+
+// Sender returns the recovered sender for Txs[i], computing it at most once.
+// Recovery uses the same signer selection as getSender (HomesteadSigner for
+// chainID 0, else LatestSignerForChainID) and memoizes both value and error. A
+// recovery error is returned to the caller; modules treat it as a hard reject.
+func (s *TxSubmission) Sender(i int) (common.Address, error) {
+	if s.recovered == nil {
+		s.senders = make([]common.Address, len(s.Txs))
+		s.senderErr = make([]error, len(s.Txs))
+		s.recovered = make([]bool, len(s.Txs))
+	}
+	if !s.recovered[i] {
+		s.senders[i], s.senderErr[i] = getSender(s.Txs[i])
+		s.recovered[i] = true
+	}
+	return s.senders[i], s.senderErr[i]
+}
+
+// TxFilterModule is a single check in the submission filter pipeline. Apply
+// returns nil to accept (allowing the pipeline to continue) or an error to
+// reject the whole submission. Each module owns its own failure policy.
+type TxFilterModule interface {
+	Name() string
+	Apply(ctx context.Context, sub *TxSubmission) error
+}
+
+// TxFilter is the single chokepoint for transaction-submission filtering. It
+// owns an ordered list of modules and runs them in order, short-circuiting on
+// the first rejection (logical AND).
+type TxFilter struct {
+	srv     *Server
+	modules []TxFilterModule
+}
+
+func NewTxFilter(srv *Server, modules ...TxFilterModule) *TxFilter {
+	return &TxFilter{srv: srv, modules: modules}
+}
+
+// IsSubmissionMethod reports the static set of submission methods the filter
+// handles. Per-method middleware opt-out is enforced inside the middleware
+// module, not here — chain-ID/rate-limit/interop always apply.
+func (f *TxFilter) IsSubmissionMethod(method string) bool {
+	switch method {
+	case "eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle":
+		return true
+	default:
+		return false
+	}
+}
+
+// Build decodes a submission request into a TxSubmission, method-aware:
+//   - single-tx methods reuse convertSendReqToSendTx
+//   - eth_sendBundle reuses transactionsFromBundleReq
+//
+// It returns the same decode errors those return today and enforces
+// maxBundleTransactions here so the cap applies to every bundle regardless of
+// middleware enablement.
+func (f *TxFilter) Build(ctx context.Context, req *RPCReq, bypassRateLimit bool) (*TxSubmission, error) {
+	var txs []*types.Transaction
+	switch req.Method {
+	case "eth_sendRawTransaction", "eth_sendRawTransactionConditional":
+		tx, err := f.srv.convertSendReqToSendTx(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		txs = []*types.Transaction{tx}
+	case "eth_sendBundle":
+		bundleTxs, err := transactionsFromBundleReq(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		txs = bundleTxs
+	default:
+		return nil, fmt.Errorf("not a submission method: %s", req.Method)
+	}
+
+	if len(txs) > maxBundleTransactions {
+		log.Warn("bundle contains too many transactions",
+			"req_id", GetReqID(ctx),
+			"tx_count", len(txs),
+			"max_allowed", maxBundleTransactions)
+		return nil, ErrInvalidParams(fmt.Sprintf("bundle contains %d transactions, maximum allowed is %d", len(txs), maxBundleTransactions))
+	}
+
+	return &TxSubmission{
+		Method:          req.Method,
+		Req:             req,
+		Txs:             txs,
+		BypassRateLimit: bypassRateLimit,
+	}, nil
+}
+
+// Apply runs every module in order, returning the first module's rejection.
+func (f *TxFilter) Apply(ctx context.Context, sub *TxSubmission) error {
+	for _, m := range f.modules {
+		if err := m.Apply(ctx, sub); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/proxyd/tx_filter_modules.go
+++ b/proxyd/tx_filter_modules.go
@@ -1,0 +1,152 @@
+package proxyd
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// chainIDModule rejects any transaction whose chain ID is not in the allowed
+// set. It is wired whenever allowedChainIds is non-empty, independent of either
+// rate limiter (decoupling chain-ID/replay protection from the rate limiter).
+type chainIDModule struct {
+	allowedChainIds []*big.Int
+}
+
+func (m *chainIDModule) Name() string { return "chain_id" }
+
+func (m *chainIDModule) Apply(ctx context.Context, sub *TxSubmission) error {
+	for _, tx := range sub.Txs {
+		if !isAllowedChainId(m.allowedChainIds, tx.ChainId()) {
+			log.Debug("chain id is not allowed", "req_id", GetReqID(ctx))
+			return txpool.ErrInvalidSender
+		}
+	}
+	return nil
+}
+
+// senderRateLimitModule applies the per-sender:nonce rate limit. It is skipped
+// for API-key-bypassed submissions, matching the previous rateLimitSender
+// behavior.
+type senderRateLimitModule struct {
+	lim FrontendRateLimiter
+}
+
+func (m *senderRateLimitModule) Name() string { return "sender_rate_limit" }
+
+func (m *senderRateLimitModule) Apply(ctx context.Context, sub *TxSubmission) error {
+	if sub.BypassRateLimit {
+		return nil
+	}
+	for i, tx := range sub.Txs {
+		from, err := sub.Sender(i)
+		if err != nil {
+			log.Debug("could not get sender from transaction", "err", err, "req_id", GetReqID(ctx))
+			return ErrInvalidParams(err.Error())
+		}
+		ok, err := m.lim.Take(ctx, fmt.Sprintf("%s:%d", from.Hex(), tx.Nonce()))
+		if err != nil {
+			log.Error("error taking from sender limiter", "err", err, "req_id", GetReqID(ctx))
+			return ErrInternal
+		}
+		if !ok {
+			log.Debug("sender rate limit exceeded", "sender", from.Hex(), "req_id", GetReqID(ctx))
+			return ErrOverSenderRateLimit
+		}
+	}
+	return nil
+}
+
+// interopModule validates every transaction in a submission against the
+// op-interop-filter. Each tx carrying an interop access list is rate-limited
+// (via the interop sender limiter, without a chain-ID re-check — chain-ID
+// already ran as its own module), size-checked, and validated by the strategy.
+// Fail-closed behavior lives in the strategy and the #649 no-URL preflight.
+type interopModule struct {
+	strategy         InteropStrategy
+	interopSenderLim FrontendRateLimiter
+	validatingCfg    InteropValidationConfig
+}
+
+func (m *interopModule) Name() string { return "interop" }
+
+func (m *interopModule) Apply(ctx context.Context, sub *TxSubmission) error {
+	for i, tx := range sub.Txs {
+		interopAccessList, isInterop, err := checkInteropAndReturnAccessList(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if !isInterop {
+			continue
+		}
+
+		log.Info(
+			"validating interop access list",
+			"source", "rpc",
+			"req_id", GetReqID(ctx),
+			"strategy", m.validatingCfg.Strategy,
+			"tx_hash", tx.Hash(),
+		)
+
+		if m.interopSenderLim != nil {
+			from, err := sub.Sender(i)
+			if err != nil {
+				log.Debug("could not get sender from transaction", "err", err, "req_id", GetReqID(ctx))
+				return ErrInvalidParams(err.Error())
+			}
+			ok, err := m.interopSenderLim.Take(ctx, fmt.Sprintf("%s:%d", from.Hex(), tx.Nonce()))
+			if err != nil {
+				log.Error("error taking from sender limiter", "err", err, "req_id", GetReqID(ctx))
+				return ErrInternal
+			}
+			if !ok {
+				log.Debug("sender rate limit exceeded", "sender", from.Hex(), "req_id", GetReqID(ctx))
+				return ErrOverSenderRateLimit
+			}
+		} else {
+			log.Warn("interop sender rate limiter is not enabled, skipping", "req_id", GetReqID(ctx))
+		}
+
+		if err := reqSizeLimitCheck(ctx, tx, m.validatingCfg.ReqSizeLimit); err != nil {
+			return err
+		}
+
+		finalErr := m.strategy.ValidateAccessList(ctx, interopAccessList)
+
+		rpcInteropValidationsTotal.WithLabelValues(
+			interopValidationResult(finalErr),
+			interopValidationReason(finalErr),
+			string(m.validatingCfg.Strategy),
+		).Inc()
+
+		if finalErr == nil {
+			log.Info("interop access list validated successfully", "req_id", GetReqID(ctx), "tx_hash", tx.Hash())
+		} else {
+			log.Info("interop access list validation failed", "req_id", GetReqID(ctx), "tx_hash", tx.Hash(), "error", finalErr)
+			return finalErr
+		}
+	}
+	return nil
+}
+
+// txMiddlewareModule applies the configurable transaction-validation
+// middleware. It honors the configurable per-method opt-out and the
+// fail-open policy, delegating to validateTransactions.
+type txMiddlewareModule struct {
+	endpoint string
+	fn       TxValidationFunc
+	failOpen bool
+	methods  TxValidationMethodSet
+}
+
+func (m *txMiddlewareModule) Name() string { return "tx_middleware" }
+
+func (m *txMiddlewareModule) Apply(ctx context.Context, sub *TxSubmission) error {
+	if !m.methods.Contains(sub.Method) {
+		return nil
+	}
+	return validateTransactions(ctx, sub.Txs, m.endpoint, m.fn, m.failOpen)
+}

--- a/proxyd/tx_filter_modules.go
+++ b/proxyd/tx_filter_modules.go
@@ -75,7 +75,7 @@ func (m *senderRateLimitModule) Apply(ctx context.Context, sub *TxSubmission) er
 // op-interop-filter. Each tx carrying an interop access list is rate-limited
 // (via the interop sender limiter, without a chain-ID re-check — chain-ID
 // already ran as its own module), size-checked, and validated by the strategy.
-// Fail-closed behavior lives in the strategy and the #649 no-URL preflight.
+// Fail-closed behavior lives in the strategy and the no-URL preflight check.
 type interopModule struct {
 	strategy         InteropStrategy
 	interopSenderLim FrontendRateLimiter

--- a/proxyd/tx_filter_modules.go
+++ b/proxyd/tx_filter_modules.go
@@ -5,9 +5,26 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/log"
 )
+
+// takeSenderLimit applies a per-sender:nonce rate limit, mapping a limiter
+// error to ErrInternal and an exhausted limit to ErrOverSenderRateLimit. Shared
+// by every sender limiter so their semantics stay in lockstep.
+func takeSenderLimit(ctx context.Context, lim FrontendRateLimiter, from common.Address, nonce uint64) error {
+	ok, err := lim.Take(ctx, fmt.Sprintf("%s:%d", from.Hex(), nonce))
+	if err != nil {
+		log.Error("error taking from sender limiter", "err", err, "req_id", GetReqID(ctx))
+		return ErrInternal
+	}
+	if !ok {
+		log.Debug("sender rate limit exceeded", "sender", from.Hex(), "req_id", GetReqID(ctx))
+		return ErrOverSenderRateLimit
+	}
+	return nil
+}
 
 // chainIDModule rejects any transaction whose chain ID is not in the allowed
 // set. It is wired whenever allowedChainIds is non-empty, independent of either
@@ -47,14 +64,8 @@ func (m *senderRateLimitModule) Apply(ctx context.Context, sub *TxSubmission) er
 			log.Debug("could not get sender from transaction", "err", err, "req_id", GetReqID(ctx))
 			return ErrInvalidParams(err.Error())
 		}
-		ok, err := m.lim.Take(ctx, fmt.Sprintf("%s:%d", from.Hex(), tx.Nonce()))
-		if err != nil {
-			log.Error("error taking from sender limiter", "err", err, "req_id", GetReqID(ctx))
-			return ErrInternal
-		}
-		if !ok {
-			log.Debug("sender rate limit exceeded", "sender", from.Hex(), "req_id", GetReqID(ctx))
-			return ErrOverSenderRateLimit
+		if err := takeSenderLimit(ctx, m.lim, from, tx.Nonce()); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -91,20 +102,16 @@ func (m *interopModule) Apply(ctx context.Context, sub *TxSubmission) error {
 			"tx_hash", tx.Hash(),
 		)
 
+		// The interop sender limit is not bypassed by API key (matches prior
+		// rateLimitInteropSender behavior), unlike senderRateLimitModule.
 		if m.interopSenderLim != nil {
 			from, err := sub.Sender(i)
 			if err != nil {
 				log.Debug("could not get sender from transaction", "err", err, "req_id", GetReqID(ctx))
 				return ErrInvalidParams(err.Error())
 			}
-			ok, err := m.interopSenderLim.Take(ctx, fmt.Sprintf("%s:%d", from.Hex(), tx.Nonce()))
-			if err != nil {
-				log.Error("error taking from sender limiter", "err", err, "req_id", GetReqID(ctx))
-				return ErrInternal
-			}
-			if !ok {
-				log.Debug("sender rate limit exceeded", "sender", from.Hex(), "req_id", GetReqID(ctx))
-				return ErrOverSenderRateLimit
+			if err := takeSenderLimit(ctx, m.interopSenderLim, from, tx.Nonce()); err != nil {
+				return err
 			}
 		} else {
 			log.Warn("interop sender rate limiter is not enabled, skipping", "req_id", GetReqID(ctx))

--- a/proxyd/tx_filter_modules.go
+++ b/proxyd/tx_filter_modules.go
@@ -46,8 +46,7 @@ func (m *chainIDModule) Apply(ctx context.Context, sub *TxSubmission) error {
 }
 
 // senderRateLimitModule applies the per-sender:nonce rate limit. It is skipped
-// for API-key-bypassed submissions, matching the previous rateLimitSender
-// behavior.
+// for API-key-bypassed submissions.
 type senderRateLimitModule struct {
 	lim FrontendRateLimiter
 }
@@ -73,9 +72,9 @@ func (m *senderRateLimitModule) Apply(ctx context.Context, sub *TxSubmission) er
 
 // interopModule validates every transaction in a submission against the
 // op-interop-filter. Each tx carrying an interop access list is rate-limited
-// (via the interop sender limiter, without a chain-ID re-check — chain-ID
-// already ran as its own module), size-checked, and validated by the strategy.
-// Fail-closed behavior lives in the strategy and the no-URL preflight check.
+// (via the interop sender limiter; chain-ID enforcement is the chainIDModule's
+// responsibility), size-checked, and validated by the strategy. Fail-closed
+// behavior lives in the strategy and the no-URL preflight check.
 type interopModule struct {
 	strategy         InteropStrategy
 	interopSenderLim FrontendRateLimiter
@@ -102,8 +101,8 @@ func (m *interopModule) Apply(ctx context.Context, sub *TxSubmission) error {
 			"tx_hash", tx.Hash(),
 		)
 
-		// The interop sender limit is not bypassed by API key (matches prior
-		// rateLimitInteropSender behavior), unlike senderRateLimitModule.
+		// The interop sender limit is not bypassed by API key, unlike
+		// senderRateLimitModule.
 		if m.interopSenderLim != nil {
 			from, err := sub.Sender(i)
 			if err != nil {

--- a/proxyd/tx_filter_modules_test.go
+++ b/proxyd/tx_filter_modules_test.go
@@ -2,6 +2,7 @@ package proxyd
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"testing"
 
@@ -109,6 +110,16 @@ func TestSenderRateLimitModule(t *testing.T) {
 		sub := &TxSubmission{Txs: []*types.Transaction{signedTxWithChainID(t, big.NewInt(1), 0)}}
 		require.ErrorIs(t, m.Apply(context.Background(), sub), ErrOverSenderRateLimit)
 	})
+}
+
+// TestSenderRateLimitModule_FailsClosedOnLimiterError documents the fail-closed
+// contract: a backing-limiter error rejects the submission (ErrInternal), it
+// does not silently allow the tx through.
+func TestSenderRateLimitModule_FailsClosedOnLimiterError(t *testing.T) {
+	lim := &fakeRateLimiter{allowFunc: func(string) (bool, error) { return false, errors.New("limiter unavailable") }}
+	m := &senderRateLimitModule{lim: lim}
+	sub := &TxSubmission{Txs: []*types.Transaction{signedTxWithChainID(t, big.NewInt(1), 0)}}
+	require.ErrorIs(t, m.Apply(context.Background(), sub), ErrInternal)
 }
 
 func TestInteropModule_SkipsNonInteropTxs(t *testing.T) {

--- a/proxyd/tx_filter_modules_test.go
+++ b/proxyd/tx_filter_modules_test.go
@@ -1,0 +1,166 @@
+package proxyd
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/interoptypes"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRateLimiter records the keys it is asked to take and can be configured to
+// reject after a number of successful takes.
+type fakeRateLimiter struct {
+	keys      []string
+	allowFunc func(key string) (bool, error)
+}
+
+func (f *fakeRateLimiter) Take(ctx context.Context, key string) (bool, error) {
+	f.keys = append(f.keys, key)
+	if f.allowFunc != nil {
+		return f.allowFunc(key)
+	}
+	return true, nil
+}
+
+type fakeInteropStrategy struct {
+	calls int
+	err   error
+}
+
+func (f *fakeInteropStrategy) ValidateAccessList(ctx context.Context, _ []common.Hash) error {
+	f.calls++
+	return f.err
+}
+
+// interopTx builds a signed tx carrying an interop access list so
+// checkInteropAndReturnAccessList treats it as an interop submission.
+func interopTx(t *testing.T, chainID *big.Int, nonce uint64) *types.Transaction {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	to := common.HexToAddress("0x8f3Ddd0FBf3e78CA1D6cd17379eD88E261249B53")
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasFeeCap: big.NewInt(1000000000),
+		GasTipCap: big.NewInt(1000000000),
+		Gas:       21000,
+		To:        &to,
+		Value:     big.NewInt(0),
+		AccessList: types.AccessList{
+			{
+				Address:     params.InteropCrossL2InboxAddress,
+				StorageKeys: []common.Hash{common.HexToHash("0x01")},
+			},
+		},
+	})
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), key)
+	require.NoError(t, err)
+	return signed
+}
+
+func TestChainIDModule(t *testing.T) {
+	m := &chainIDModule{allowedChainIds: []*big.Int{big.NewInt(10)}}
+
+	t.Run("accept", func(t *testing.T) {
+		sub := &TxSubmission{Txs: []*types.Transaction{signedTxWithChainID(t, big.NewInt(10), 0)}}
+		require.NoError(t, m.Apply(context.Background(), sub))
+	})
+
+	t.Run("reject wrong chain", func(t *testing.T) {
+		sub := &TxSubmission{Txs: []*types.Transaction{
+			signedTxWithChainID(t, big.NewInt(10), 0),
+			signedTxWithChainID(t, big.NewInt(99), 1),
+		}}
+		require.ErrorIs(t, m.Apply(context.Background(), sub), txpool.ErrInvalidSender)
+	})
+}
+
+func TestSenderRateLimitModule(t *testing.T) {
+	t.Run("bypass skips limiter", func(t *testing.T) {
+		lim := &fakeRateLimiter{}
+		m := &senderRateLimitModule{lim: lim}
+		sub := &TxSubmission{Txs: []*types.Transaction{signedTxWithChainID(t, big.NewInt(1), 0)}, BypassRateLimit: true}
+		require.NoError(t, m.Apply(context.Background(), sub))
+		require.Empty(t, lim.keys)
+	})
+
+	t.Run("accept consumes per tx", func(t *testing.T) {
+		lim := &fakeRateLimiter{}
+		m := &senderRateLimitModule{lim: lim}
+		sub := &TxSubmission{Txs: []*types.Transaction{
+			signedTxWithChainID(t, big.NewInt(1), 0),
+			signedTxWithChainID(t, big.NewInt(1), 1),
+		}}
+		require.NoError(t, m.Apply(context.Background(), sub))
+		require.Len(t, lim.keys, 2)
+	})
+
+	t.Run("over limit rejects", func(t *testing.T) {
+		lim := &fakeRateLimiter{allowFunc: func(string) (bool, error) { return false, nil }}
+		m := &senderRateLimitModule{lim: lim}
+		sub := &TxSubmission{Txs: []*types.Transaction{signedTxWithChainID(t, big.NewInt(1), 0)}}
+		require.ErrorIs(t, m.Apply(context.Background(), sub), ErrOverSenderRateLimit)
+	})
+}
+
+func TestInteropModule_SkipsNonInteropTxs(t *testing.T) {
+	strategy := &fakeInteropStrategy{}
+	m := &interopModule{strategy: strategy, validatingCfg: InteropValidationConfig{}}
+
+	plainTx := signedTxWithChainID(t, big.NewInt(1), 0)
+	interop := interopTx(t, big.NewInt(1), 1)
+	sub := &TxSubmission{Txs: []*types.Transaction{plainTx, interop}}
+
+	require.NoError(t, m.Apply(context.Background(), sub))
+	require.Equal(t, 1, strategy.calls, "only the interop tx should reach the strategy")
+
+	// Sanity: the plain tx really carries no interop access list.
+	require.Empty(t, interoptypes.TxToInteropAccessList(plainTx))
+	require.NotEmpty(t, interoptypes.TxToInteropAccessList(interop))
+}
+
+func TestInteropModule_RejectsOnStrategyError(t *testing.T) {
+	strategy := &fakeInteropStrategy{err: ErrInternal}
+	m := &interopModule{strategy: strategy, validatingCfg: InteropValidationConfig{}}
+	sub := &TxSubmission{Txs: []*types.Transaction{interopTx(t, big.NewInt(1), 0)}}
+	require.ErrorIs(t, m.Apply(context.Background(), sub), ErrInternal)
+}
+
+func TestInteropModule_SenderRateLimit(t *testing.T) {
+	lim := &fakeRateLimiter{allowFunc: func(string) (bool, error) { return false, nil }}
+	m := &interopModule{strategy: &fakeInteropStrategy{}, interopSenderLim: lim, validatingCfg: InteropValidationConfig{}}
+	sub := &TxSubmission{Txs: []*types.Transaction{interopTx(t, big.NewInt(1), 0)}}
+	require.ErrorIs(t, m.Apply(context.Background(), sub), ErrOverSenderRateLimit)
+}
+
+func TestTxMiddlewareModule_RespectsMethodConfig(t *testing.T) {
+	called := false
+	fn := func(ctx context.Context, endpoint string, payload []byte) (map[string]bool, error) {
+		called = true
+		return map[string]bool{}, nil
+	}
+	methods := NewTxValidationMethodSet([]string{"eth_sendRawTransaction"})
+	m := &txMiddlewareModule{endpoint: "http://test", fn: fn, failOpen: true, methods: methods}
+
+	t.Run("method not configured is skipped", func(t *testing.T) {
+		called = false
+		sub := &TxSubmission{Method: "eth_sendBundle", Txs: []*types.Transaction{signedTxWithChainID(t, big.NewInt(1), 0)}}
+		require.NoError(t, m.Apply(context.Background(), sub))
+		require.False(t, called)
+	})
+
+	t.Run("configured method runs validation", func(t *testing.T) {
+		called = false
+		sub := &TxSubmission{Method: "eth_sendRawTransaction", Txs: []*types.Transaction{signedTxWithChainID(t, big.NewInt(1), 0)}}
+		require.NoError(t, m.Apply(context.Background(), sub))
+		require.True(t, called)
+	})
+}

--- a/proxyd/tx_filter_modules_test.go
+++ b/proxyd/tx_filter_modules_test.go
@@ -145,6 +145,37 @@ func TestInteropModule_RejectsOnStrategyError(t *testing.T) {
 	require.ErrorIs(t, m.Apply(context.Background(), sub), ErrInternal)
 }
 
+// failOnNthStrategy rejects the failCall-th interop tx it validates (1-based)
+// and accepts the rest, counting calls.
+type failOnNthStrategy struct {
+	failCall int
+	calls    int
+}
+
+func (s *failOnNthStrategy) ValidateAccessList(ctx context.Context, _ []common.Hash) error {
+	s.calls++
+	if s.calls == s.failCall {
+		return ErrInternal
+	}
+	return nil
+}
+
+// TestInteropModule_BundleShortCircuit proves the first failing interop tx in a
+// bundle rejects the whole submission and no later tx is validated (so its
+// metric increment never happens).
+func TestInteropModule_BundleShortCircuit(t *testing.T) {
+	strategy := &failOnNthStrategy{failCall: 2}
+	m := &interopModule{strategy: strategy, validatingCfg: InteropValidationConfig{}}
+	sub := &TxSubmission{Txs: []*types.Transaction{
+		interopTx(t, big.NewInt(1), 0), // call 1: passes
+		interopTx(t, big.NewInt(1), 1), // call 2: fails -> reject
+		interopTx(t, big.NewInt(1), 2), // never validated
+	}}
+
+	require.ErrorIs(t, m.Apply(context.Background(), sub), ErrInternal)
+	require.Equal(t, 2, strategy.calls, "validation must stop at the first failing tx")
+}
+
 func TestInteropModule_SenderRateLimit(t *testing.T) {
 	lim := &fakeRateLimiter{allowFunc: func(string) (bool, error) { return false, nil }}
 	m := &interopModule{strategy: &fakeInteropStrategy{}, interopSenderLim: lim, validatingCfg: InteropValidationConfig{}}

--- a/proxyd/tx_filter_test.go
+++ b/proxyd/tx_filter_test.go
@@ -93,7 +93,7 @@ func TestTxFilter_Apply_FirstRejectShortCircuits(t *testing.T) {
 
 func TestTxFilter_Build_SingleTx(t *testing.T) {
 	srv := &Server{}
-	f := NewTxFilter(srv)
+	f := NewTxFilter(srv.convertSendReqToSendTx)
 	tx := signedTxWithChainID(t, big.NewInt(1), 0)
 	sub, err := f.Build(context.Background(), rawTxReq(t, tx), false)
 	require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestTxFilter_Build_SingleTx(t *testing.T) {
 
 func TestTxFilter_Build_Bundle(t *testing.T) {
 	srv := &Server{}
-	f := NewTxFilter(srv)
+	f := NewTxFilter(srv.convertSendReqToSendTx)
 	tx1 := signedTxWithChainID(t, big.NewInt(1), 0)
 	tx2 := signedTxWithChainID(t, big.NewInt(1), 1)
 	sub, err := f.Build(context.Background(), bundleReq(t, tx1, tx2), false)
@@ -113,7 +113,7 @@ func TestTxFilter_Build_Bundle(t *testing.T) {
 
 func TestTxFilter_Build_DecodeErrors(t *testing.T) {
 	srv := &Server{}
-	f := NewTxFilter(srv)
+	f := NewTxFilter(srv.convertSendReqToSendTx)
 
 	t.Run("bad json", func(t *testing.T) {
 		req := &RPCReq{Method: "eth_sendRawTransaction", Params: json.RawMessage(`not-json`), ID: json.RawMessage("1")}
@@ -149,7 +149,7 @@ func TestTxFilter_Build_DecodeErrors(t *testing.T) {
 
 func TestTxFilter_Build_BundleSizeCap(t *testing.T) {
 	srv := &Server{}
-	f := NewTxFilter(srv)
+	f := NewTxFilter(srv.convertSendReqToSendTx)
 	txs := make([]*types.Transaction, maxBundleTransactions+1)
 	for i := range txs {
 		txs[i] = signedTxWithChainID(t, big.NewInt(1), uint64(i))
@@ -193,4 +193,41 @@ func TestTxSubmission_Sender_RecoveryError(t *testing.T) {
 	sub := &TxSubmission{Txs: []*types.Transaction{tx}}
 	_, err := sub.Sender(0)
 	require.Error(t, err)
+}
+
+func TestTxFilter_ModuleOrder(t *testing.T) {
+	moduleNames := func(modules []TxFilterModule) []string {
+		names := make([]string, len(modules))
+		for i, m := range modules {
+			names[i] = m.Name()
+		}
+		return names
+	}
+
+	t.Run("all modules enabled", func(t *testing.T) {
+		srv := &Server{
+			allowedChainIds:    []*big.Int{big.NewInt(1)},
+			senderLim:          &fakeRateLimiter{},
+			interopStrategy:    &fakeInteropStrategy{},
+			interopSenderLim:   &fakeRateLimiter{},
+			enableTxValidation: true,
+		}
+		require.Equal(t,
+			[]string{"chain_id", "sender_rate_limit", "interop", "tx_middleware"},
+			moduleNames(srv.txFilterModules()),
+		)
+	})
+
+	t.Run("rate limiter and middleware disabled", func(t *testing.T) {
+		srv := &Server{
+			allowedChainIds:    []*big.Int{big.NewInt(1)},
+			senderLim:          nil,
+			interopStrategy:    &fakeInteropStrategy{},
+			enableTxValidation: false,
+		}
+		require.Equal(t,
+			[]string{"chain_id", "interop"},
+			moduleNames(srv.txFilterModules()),
+		)
+	})
 }

--- a/proxyd/tx_filter_test.go
+++ b/proxyd/tx_filter_test.go
@@ -1,0 +1,196 @@
+package proxyd
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingModule records whether Apply was invoked and optionally rejects.
+type recordingModule struct {
+	name       string
+	called     *[]string
+	rejectWith error
+}
+
+func (m *recordingModule) Name() string { return m.name }
+
+func (m *recordingModule) Apply(ctx context.Context, sub *TxSubmission) error {
+	*m.called = append(*m.called, m.name)
+	return m.rejectWith
+}
+
+func signedTxWithChainID(t *testing.T, chainID *big.Int, nonce uint64) *types.Transaction {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	to := common.HexToAddress("0x0987654321098765432109876543210987654321")
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasFeeCap: big.NewInt(1000000000),
+		GasTipCap: big.NewInt(1000000000),
+		Gas:       21000,
+		To:        &to,
+		Value:     big.NewInt(1),
+	})
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), key)
+	require.NoError(t, err)
+	return signed
+}
+
+func rawTxReq(t *testing.T, tx *types.Transaction) *RPCReq {
+	t.Helper()
+	raw, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	params, err := json.Marshal([]any{hexutil.Encode(raw)})
+	require.NoError(t, err)
+	return &RPCReq{Method: "eth_sendRawTransaction", Params: params, ID: json.RawMessage("1")}
+}
+
+func bundleReq(t *testing.T, txs ...*types.Transaction) *RPCReq {
+	t.Helper()
+	hexes := make([]string, len(txs))
+	for i, tx := range txs {
+		raw, err := tx.MarshalBinary()
+		require.NoError(t, err)
+		hexes[i] = hexutil.Encode(raw)
+	}
+	bundle, err := json.Marshal([]any{map[string]any{"txs": hexes}})
+	require.NoError(t, err)
+	return &RPCReq{Method: "eth_sendBundle", Params: bundle, ID: json.RawMessage("1")}
+}
+
+func TestTxFilter_Apply_AllAcceptPasses(t *testing.T) {
+	var called []string
+	f := NewTxFilter(nil,
+		&recordingModule{name: "a", called: &called},
+		&recordingModule{name: "b", called: &called},
+	)
+	require.NoError(t, f.Apply(context.Background(), &TxSubmission{}))
+	require.Equal(t, []string{"a", "b"}, called)
+}
+
+func TestTxFilter_Apply_FirstRejectShortCircuits(t *testing.T) {
+	var called []string
+	rejectErr := ErrInternal
+	f := NewTxFilter(nil,
+		&recordingModule{name: "a", called: &called},
+		&recordingModule{name: "b", called: &called, rejectWith: rejectErr},
+		&recordingModule{name: "c", called: &called},
+	)
+	err := f.Apply(context.Background(), &TxSubmission{})
+	require.ErrorIs(t, err, rejectErr)
+	require.Equal(t, []string{"a", "b"}, called, "modules after the rejecter must not run")
+}
+
+func TestTxFilter_Build_SingleTx(t *testing.T) {
+	srv := &Server{}
+	f := NewTxFilter(srv)
+	tx := signedTxWithChainID(t, big.NewInt(1), 0)
+	sub, err := f.Build(context.Background(), rawTxReq(t, tx), false)
+	require.NoError(t, err)
+	require.Len(t, sub.Txs, 1)
+	require.Equal(t, tx.Hash(), sub.Txs[0].Hash())
+}
+
+func TestTxFilter_Build_Bundle(t *testing.T) {
+	srv := &Server{}
+	f := NewTxFilter(srv)
+	tx1 := signedTxWithChainID(t, big.NewInt(1), 0)
+	tx2 := signedTxWithChainID(t, big.NewInt(1), 1)
+	sub, err := f.Build(context.Background(), bundleReq(t, tx1, tx2), false)
+	require.NoError(t, err)
+	require.Len(t, sub.Txs, 2)
+}
+
+func TestTxFilter_Build_DecodeErrors(t *testing.T) {
+	srv := &Server{}
+	f := NewTxFilter(srv)
+
+	t.Run("bad json", func(t *testing.T) {
+		req := &RPCReq{Method: "eth_sendRawTransaction", Params: json.RawMessage(`not-json`), ID: json.RawMessage("1")}
+		_, err := f.Build(context.Background(), req, false)
+		require.ErrorIs(t, err, ErrParseErr)
+	})
+
+	t.Run("wrong arg count", func(t *testing.T) {
+		params, _ := json.Marshal([]any{})
+		req := &RPCReq{Method: "eth_sendRawTransaction", Params: params, ID: json.RawMessage("1")}
+		_, err := f.Build(context.Background(), req, false)
+		var rpcErr *RPCErr
+		require.ErrorAs(t, err, &rpcErr)
+		require.Equal(t, ErrInvalidParams("missing value for required argument 0").Code, rpcErr.Code)
+	})
+
+	t.Run("bad hex", func(t *testing.T) {
+		params, _ := json.Marshal([]any{"0xZZ"})
+		req := &RPCReq{Method: "eth_sendRawTransaction", Params: params, ID: json.RawMessage("1")}
+		_, err := f.Build(context.Background(), req, false)
+		var rpcErr *RPCErr
+		require.ErrorAs(t, err, &rpcErr)
+		require.Equal(t, ErrInvalidParams("").Code, rpcErr.Code)
+	})
+
+	t.Run("empty bundle", func(t *testing.T) {
+		bundle, _ := json.Marshal([]any{map[string]any{"txs": []string{}}})
+		req := &RPCReq{Method: "eth_sendBundle", Params: bundle, ID: json.RawMessage("1")}
+		_, err := f.Build(context.Background(), req, false)
+		require.EqualError(t, err, ErrInvalidParams("bundle has no txs").Error())
+	})
+}
+
+func TestTxFilter_Build_BundleSizeCap(t *testing.T) {
+	srv := &Server{}
+	f := NewTxFilter(srv)
+	txs := make([]*types.Transaction, maxBundleTransactions+1)
+	for i := range txs {
+		txs[i] = signedTxWithChainID(t, big.NewInt(1), uint64(i))
+	}
+	_, err := f.Build(context.Background(), bundleReq(t, txs...), false)
+	var rpcErr *RPCErr
+	require.ErrorAs(t, err, &rpcErr)
+	require.Equal(t, ErrInvalidParams("").Code, rpcErr.Code)
+	require.Contains(t, rpcErr.Message, "maximum allowed")
+}
+
+// countingSigner-style memoization check: Sender recovers each index at most once.
+func TestTxSubmission_Sender_MemoizedOnce(t *testing.T) {
+	tx := signedTxWithChainID(t, big.NewInt(1), 0)
+	sub := &TxSubmission{Txs: []*types.Transaction{tx}}
+
+	from1, err := sub.Sender(0)
+	require.NoError(t, err)
+	require.True(t, sub.recovered[0])
+
+	from2, err := sub.Sender(0)
+	require.NoError(t, err)
+	require.Equal(t, from1, from2)
+}
+
+func TestTxSubmission_Sender_RecoveryError(t *testing.T) {
+	// A transaction with a zero/invalid signature fails ecrecover.
+	to := common.HexToAddress("0x0987654321098765432109876543210987654321")
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   big.NewInt(1),
+		Nonce:     0,
+		GasFeeCap: big.NewInt(1),
+		GasTipCap: big.NewInt(1),
+		Gas:       21000,
+		To:        &to,
+		Value:     big.NewInt(1),
+		V:         big.NewInt(0),
+		R:         big.NewInt(0),
+		S:         big.NewInt(0),
+	})
+	sub := &TxSubmission{Txs: []*types.Transaction{tx}}
+	_, err := sub.Sender(0)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Replaces the method-string `if` branches in `handleBatchRPC` with a single `TxFilter` chokepoint that decodes each submission once and runs an ordered module pipeline: **ChainID → SenderRateLimit → Interop → TxMiddleware**, short-circuiting on the first reject. Sender recovery is memoized in `TxSubmission.Sender` and shared across modules.

The four modules (`proxyd/tx_filter_modules.go`) each wrap logic that existed before; the interop module inlines the interop sender rate-limit (no chain-ID re-check, since chain-ID is now its own module) and preserves the `rpcInteropValidationsTotal` metric. The configurable `tx_validation.methods` gate is retained on the middleware module. The `maxBundleTransactions` cap moves into `TxFilter.Build` so it always runs.

Closes the bundle→interop gap: every tx in an `eth_sendBundle` now flows through the same filter as single-tx submissions.

### Behavior changes (intentional)
- **B1** — Bundles now get interop validation, and are decoded + size-capped even when the middleware is disabled. A malformed bundle that previously passed undecoded is now rejected at proxyd; the bundle-size cap applies to every bundle.
- **B2** — Bundles now get the chain-ID check and per-`sender:nonce` rate-limit. Per-tx quota consumed before a later tx rejects is not rolled back (same model as the prior single-tx path).
- **B3** — Chain-ID enforcement is decoupled from the rate limiter: the ChainID module is active whenever `allowed_chain_ids` is non-empty, independent of either rate limiter.

Deleted: the two inline `handleBatchRPC` blocks, `applyTxValidation`, `validateInteropSendRpcRequest`, `rateLimitSender`, `genericRateLimitSender`, `rateLimitInteropSender` (as a \*Server method), and the dead `SetTxValidationFn`. `isAllowedChainId` is now a package function used by the ChainID module.

Plan: `op-claude/plans/2026-06-09-refactor-proxyd-unified-tx-filter-plan.md`.

### Test plan
- `go build ./...`, `golangci-lint run ./...` (0 issues), `go test ./...` (unit + integration) all pass.
- New unit tests cover filter ordering/short-circuit, decode errors, the bundle-size cap, sender memoization/recovery-error, and each module.
- New integration tests (`tx_filter_test.go`): bundle→interop enforcement (incl. middleware-disabled + cap), bundle chain-ID + per-tx sender rate-limit, order short-circuit, chain-ID enforced with rate limiters off, and middleware method-config gating.