### PR TITLE
fix(proxyd): route websocket txs through filters

### DIFF
--- a/proxyd/README.md
+++ b/proxyd/README.md
@@ -21,6 +21,18 @@ To configure `proxyd` for use, you'll need to create a configuration file to def
 Once you have a config file, start the daemon via `proxyd <path-to-config>.toml`.
 
 
+## WebSockets
+
+WebSocket support is enabled with `ws_port`, `ws_backend_group`, and `ws_method_whitelist`. The whitelist controls which
+methods are accepted on the WS endpoint. By default, accepted WS methods are proxied directly to the selected upstream
+WS backend connection, which is the expected behavior for stateful methods such as `eth_subscribe`.
+
+To enable a WS method to run through the intelligent filtering/load-balancing described below, also add it to
+`rpc_method_mappings`. Mapped WS methods use backend-group forwarding, so they can receive transaction filtering, rate
+limiting, retries, and consensus-aware routing. Transaction submission or validation methods that are whitelisted but
+unmapped are rejected instead of being forwarded directly over WS.
+
+
 ## Consensus awareness
 
 Starting on v4.0.0, `proxyd` is aware of the consensus state of its backends. This helps minimize chain reorgs experienced by clients.

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1444,7 +1444,9 @@ type WSProxier struct {
 	writeTimeout     time.Duration
 	onClose          func()
 	closeOnce        sync.Once
-	requestProcessor func(context.Context, *RPCReq) (*RPCRes, bool)
+	requestHandler   func(*RPCReq) bool
+	requestProcessor func(context.Context, *RPCReq) *RPCRes
+	requestSem       *semaphore.Weighted
 }
 
 func NewWSProxier(backend *Backend, clientConn, backendConn *websocket.Conn, methodWhitelist *StringSet, onClose func()) *WSProxier {
@@ -1456,6 +1458,7 @@ func NewWSProxier(backend *Backend, clientConn, backendConn *websocket.Conn, met
 		readTimeout:     defaultWSReadTimeout,
 		writeTimeout:    defaultWSWriteTimeout,
 		onClose:         onClose,
+		requestSem:      semaphore.NewWeighted(defaultMaxConcurrentWSRPCs),
 	}
 }
 
@@ -1535,10 +1538,10 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 			continue
 		}
 
-		if w.requestProcessor != nil {
-			res, handled := w.requestProcessor(ctx, req)
-			if handled {
-				msg = mustMarshalJSON(res)
+		if w.requestHandler != nil && w.requestHandler(req) {
+			if !w.acquireRequestSlot() {
+				msg = mustMarshalJSON(NewRPCErrorRes(req.ID, ErrTooManyRequests))
+				RecordRPCError(ctx, BackendProxyd, req.Method, ErrTooManyRequests)
 				err = w.writeClientConn(msgType, msg)
 				if err != nil {
 					errC <- err
@@ -1546,6 +1549,8 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 				}
 				continue
 			}
+			go w.processClientRPC(ctx, msgType, req, errC)
+			continue
 		}
 
 		RecordRPCForward(ctx, w.backend.Name, req.Method, RPCRequestSourceWS)
@@ -1560,6 +1565,46 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 		if err != nil {
 			errC <- err
 			return
+		}
+	}
+}
+
+func (w *WSProxier) acquireRequestSlot() bool {
+	if w.requestSem == nil {
+		return true
+	}
+	return w.requestSem.TryAcquire(1)
+}
+
+func (w *WSProxier) releaseRequestSlot() {
+	if w.requestSem != nil {
+		w.requestSem.Release(1)
+	}
+}
+
+func (w *WSProxier) processClientRPC(ctx context.Context, msgType int, req *RPCReq, errC chan error) {
+	defer w.releaseRequestSlot()
+
+	var res *RPCRes
+	if w.requestProcessor == nil {
+		res = NewRPCErrorRes(req.ID, ErrInternal)
+	} else {
+		res = w.requestProcessor(ctx, req)
+	}
+	if res == nil {
+		res = NewRPCErrorRes(req.ID, ErrInternal)
+	}
+	if err := w.writeClientConn(msgType, mustMarshalJSON(res)); err != nil {
+		log.Error(
+			"error writing async WS RPC response",
+			"method", req.Method,
+			"auth", GetAuthCtx(ctx),
+			"req_id", GetReqID(ctx),
+			"err", err,
+		)
+		select {
+		case errC <- err:
+		default:
 		}
 	}
 }

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -749,6 +749,7 @@ func (b *Backend) ProxyWS(clientConn *websocket.Conn, methodWhitelist *StringSet
 		if acquiredWSConn {
 			b.wsSem.Release(1)
 		}
+		log.Warn("error dialing websocket backend", "backend", b.Name, "err", err)
 		return nil, wrapErr(err, "error dialing backend")
 	}
 	if b.maxResponseSize != 0 {
@@ -1434,35 +1435,42 @@ func calcBackoff(i int) time.Duration {
 }
 
 type WSProxier struct {
-	backend          *Backend
-	clientConn       *websocket.Conn
-	clientConnMu     sync.Mutex
-	backendConn      *websocket.Conn
-	backendConnMu    sync.Mutex
-	methodWhitelist  *StringSet
-	readTimeout      time.Duration
-	writeTimeout     time.Duration
-	onClose          func()
-	closeOnce        sync.Once
-	requestHandler   func(*RPCReq) bool
-	requestProcessor func(context.Context, *RPCReq) *RPCRes
-	requestSem       *semaphore.Weighted
+	backend               *Backend
+	clientConn            *websocket.Conn
+	clientConnMu          sync.Mutex
+	backendConn           *websocket.Conn
+	backendConnMu         sync.Mutex
+	methodWhitelist       *StringSet
+	readTimeout           time.Duration
+	writeTimeout          time.Duration
+	onClose               func()
+	closeOnce             sync.Once
+	requestHandler        func(*RPCReq) bool
+	requestProcessor      func(context.Context, *RPCReq) *RPCRes
+	requestSem            *semaphore.Weighted
+	cancel                context.CancelFunc
+	maxConcurrentRequests int64
 }
 
 func NewWSProxier(backend *Backend, clientConn, backendConn *websocket.Conn, methodWhitelist *StringSet, onClose func()) *WSProxier {
 	return &WSProxier{
-		backend:         backend,
-		clientConn:      clientConn,
-		backendConn:     backendConn,
-		methodWhitelist: methodWhitelist,
-		readTimeout:     defaultWSReadTimeout,
-		writeTimeout:    defaultWSWriteTimeout,
-		onClose:         onClose,
-		requestSem:      semaphore.NewWeighted(defaultMaxConcurrentWSRPCs),
+		backend:               backend,
+		clientConn:            clientConn,
+		backendConn:           backendConn,
+		methodWhitelist:       methodWhitelist,
+		readTimeout:           defaultWSReadTimeout,
+		writeTimeout:          defaultWSWriteTimeout,
+		onClose:               onClose,
+		maxConcurrentRequests: defaultMaxConcurrentWSRPCs,
 	}
 }
 
 func (w *WSProxier) Proxy(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	if w.maxConcurrentRequests > 0 {
+		w.requestSem = semaphore.NewWeighted(w.maxConcurrentRequests)
+	}
 	errC := make(chan error, 2)
 	go w.clientPump(ctx, errC)
 	go w.backendPump(ctx, errC)
@@ -1481,6 +1489,8 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 				errC <- err
 				return
 			}
+			errC <- err
+			return
 		}
 
 		RecordWSMessage(ctx, w.backend.Name, SourceClient)
@@ -1619,6 +1629,8 @@ func (w *WSProxier) backendPump(ctx context.Context, errC chan error) {
 				errC <- err
 				return
 			}
+			errC <- err
+			return
 		}
 
 		RecordWSMessage(ctx, w.backend.Name, SourceBackend)
@@ -1671,6 +1683,9 @@ func (w *WSProxier) backendPump(ctx context.Context, errC chan error) {
 
 func (w *WSProxier) close() {
 	w.closeOnce.Do(func() {
+		if w.cancel != nil {
+			w.cancel()
+		}
 		w.clientConn.Close()
 		w.backendConn.Close()
 		activeBackendWsConnsGauge.WithLabelValues(w.backend.Name).Dec()

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -364,6 +364,7 @@ type Backend struct {
 	maxResponseSize      int64
 	maxRPS               int
 	maxWSConns           int
+	wsSem                *semaphore.Weighted
 	outOfServiceInterval time.Duration
 	stripTrailingXFF     bool
 	proxydIP             string
@@ -445,6 +446,7 @@ func WithMaxRPS(maxRPS int) BackendOpt {
 func WithMaxWSConns(maxConns int) BackendOpt {
 	return func(b *Backend) {
 		b.maxWSConns = maxConns
+		b.wsSem = semaphore.NewWeighted(int64(maxConns))
 	}
 }
 
@@ -634,11 +636,15 @@ func (b *Backend) Override(opts ...BackendOpt) {
 }
 
 func (b *Backend) Forward(ctx context.Context, reqs []*RPCReq, isBatch bool) ([]*RPCRes, error) {
+	return b.ForwardWithSource(ctx, reqs, isBatch, RPCRequestSourceHTTP)
+}
+
+func (b *Backend) ForwardWithSource(ctx context.Context, reqs []*RPCReq, isBatch bool, source string) ([]*RPCRes, error) {
 	var lastError error
 	// <= to account for the first attempt not technically being
 	// a retry
 	for i := 0; i <= b.maxRetries; i++ {
-		RecordBatchRPCForward(ctx, b.Name, reqs, RPCRequestSourceHTTP)
+		RecordBatchRPCForward(ctx, b.Name, reqs, source)
 		metricLabelMethod := reqs[0].Method
 		if isBatch {
 			metricLabelMethod = "<batch>"
@@ -733,8 +739,16 @@ func (b *Backend) Forward(ctx context.Context, reqs []*RPCReq, isBatch bool) ([]
 }
 
 func (b *Backend) ProxyWS(clientConn *websocket.Conn, methodWhitelist *StringSet, serverReadLimit int64) (*WSProxier, error) {
+	if b.wsSem != nil && !b.wsSem.TryAcquire(1) {
+		return nil, ErrBackendOverCapacity
+	}
+	acquiredWSConn := b.wsSem != nil
+
 	backendConn, _, err := b.dialer.Dial(b.wsURL, nil) // nolint:bodyclose
 	if err != nil {
+		if acquiredWSConn {
+			b.wsSem.Release(1)
+		}
 		return nil, wrapErr(err, "error dialing backend")
 	}
 	if b.maxResponseSize != 0 {
@@ -744,7 +758,11 @@ func (b *Backend) ProxyWS(clientConn *websocket.Conn, methodWhitelist *StringSet
 	}
 
 	activeBackendWsConnsGauge.WithLabelValues(b.Name).Inc()
-	return NewWSProxier(b, clientConn, backendConn, methodWhitelist), nil
+	return NewWSProxier(b, clientConn, backendConn, methodWhitelist, func() {
+		if acquiredWSConn {
+			b.wsSem.Release(1)
+		}
+	}), nil
 }
 
 // ForwardRPC makes a call directly to a backend and populate the response into `res`
@@ -1084,6 +1102,10 @@ func (bg *BackendGroup) Primaries() []*Backend {
 
 // NOTE: BackendGroup Forward contains the log for balancing with consensus aware
 func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool) ([]*RPCRes, string, error) {
+	return bg.ForwardWithSource(ctx, rpcReqs, isBatch, RPCRequestSourceHTTP)
+}
+
+func (bg *BackendGroup) ForwardWithSource(ctx context.Context, rpcReqs []*RPCReq, isBatch bool, source string) ([]*RPCRes, string, error) {
 	if len(rpcReqs) == 0 {
 		return nil, "", nil
 	}
@@ -1112,16 +1134,16 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 	// When routing_strategy is set to 'multicall' the request will be forward to all backends
 	// and return the first successful response
 	if bg.GetRoutingStrategy() == MulticallRoutingStrategy && isValidMulticallTx(rpcReqs) && !isBatch {
-		backendResp := bg.ExecuteMulticall(ctx, rpcReqs)
+		backendResp := bg.ExecuteMulticall(ctx, rpcReqs, source)
 		return backendResp.RPCRes, backendResp.ServedBy, backendResp.error
 	}
 
 	ch := make(chan BackendGroupRPCResponse)
 	go func() {
 		defer close(ch)
-		backendResp := bg.ForwardRequestToBackendGroup(rpcReqs, backends, ctx, isBatch)
+		backendResp := bg.ForwardRequestToBackendGroup(rpcReqs, backends, ctx, isBatch, source)
 		if backendResp.error != nil && errors.Is(backendResp.error, ErrNoBackends) {
-			RecordUnserviceableRequest(ctx, RPCRequestSourceHTTP)
+			RecordUnserviceableRequest(ctx, source)
 		}
 		ch <- *backendResp
 	}()
@@ -1161,7 +1183,7 @@ type multicallTuple struct {
 }
 
 // Note: rpcReqs should only contain 1 request of 'sendRawTransactions'
-func (bg *BackendGroup) ExecuteMulticall(ctx context.Context, rpcReqs []*RPCReq) *BackendGroupRPCResponse {
+func (bg *BackendGroup) ExecuteMulticall(ctx context.Context, rpcReqs []*RPCReq, source string) *BackendGroupRPCResponse {
 	// Create ctx without cancel so background tasks process
 	// after original request returns
 	bgCtx := context.WithoutCancel(ctx)
@@ -1174,7 +1196,7 @@ func (bg *BackendGroup) ExecuteMulticall(ctx context.Context, rpcReqs []*RPCReq)
 	ch := make(chan *multicallTuple, len(bg.Backends))
 	for _, backend := range bg.Backends {
 		wg.Add(1)
-		go bg.MulticallRequest(backend, rpcReqs, &wg, bgCtx, ch)
+		go bg.MulticallRequest(backend, rpcReqs, &wg, bgCtx, ch, source)
 	}
 
 	go func() {
@@ -1189,12 +1211,12 @@ func (bg *BackendGroup) ExecuteMulticall(ctx context.Context, rpcReqs []*RPCReq)
 	resp, unserviceable := bg.ProcessMulticallResponses(ch, bgCtx)
 	// resp.error != nil is kinda redundant (but still kept it as a fail safe) as unserviceable can only be true for a negative response
 	if resp.error != nil && unserviceable {
-		RecordUnserviceableRequest(bgCtx, RPCRequestSourceHTTP)
+		RecordUnserviceableRequest(bgCtx, source)
 	}
 	return resp
 }
 
-func (bg *BackendGroup) MulticallRequest(backend *Backend, rpcReqs []*RPCReq, wg *sync.WaitGroup, ctx context.Context, ch chan *multicallTuple) {
+func (bg *BackendGroup) MulticallRequest(backend *Backend, rpcReqs []*RPCReq, wg *sync.WaitGroup, ctx context.Context, ch chan *multicallTuple, source string) {
 	defer wg.Done()
 	log.Debug("forwarding multicall request to backend",
 		"req_id", GetReqID(ctx),
@@ -1203,7 +1225,7 @@ func (bg *BackendGroup) MulticallRequest(backend *Backend, rpcReqs []*RPCReq, wg
 	)
 
 	RecordBackendGroupMulticallRequest(bg, backend.Name)
-	backendResp := bg.ForwardRequestToBackendGroup(rpcReqs, []*Backend{backend}, ctx, false)
+	backendResp := bg.ForwardRequestToBackendGroup(rpcReqs, []*Backend{backend}, ctx, false, source)
 
 	multicallResp := &multicallTuple{
 		response:    backendResp,
@@ -1296,7 +1318,7 @@ func (bg *BackendGroup) ProcessMulticallResponses(ch chan *multicallTuple, ctx c
 }
 
 func (bg *BackendGroup) ProxyWS(ctx context.Context, clientConn *websocket.Conn, methodWhitelist *StringSet, serverReadLimit int64) (*WSProxier, error) {
-	for _, back := range bg.Backends {
+	for _, back := range bg.orderedBackendsForRequest() {
 		proxier, err := back.ProxyWS(clientConn, methodWhitelist, serverReadLimit)
 		if errors.Is(err, ErrBackendOffline) {
 			log.Warn(
@@ -1412,17 +1434,20 @@ func calcBackoff(i int) time.Duration {
 }
 
 type WSProxier struct {
-	backend         *Backend
-	clientConn      *websocket.Conn
-	clientConnMu    sync.Mutex
-	backendConn     *websocket.Conn
-	backendConnMu   sync.Mutex
-	methodWhitelist *StringSet
-	readTimeout     time.Duration
-	writeTimeout    time.Duration
+	backend          *Backend
+	clientConn       *websocket.Conn
+	clientConnMu     sync.Mutex
+	backendConn      *websocket.Conn
+	backendConnMu    sync.Mutex
+	methodWhitelist  *StringSet
+	readTimeout      time.Duration
+	writeTimeout     time.Duration
+	onClose          func()
+	closeOnce        sync.Once
+	requestProcessor func(context.Context, *RPCReq) (*RPCRes, bool)
 }
 
-func NewWSProxier(backend *Backend, clientConn, backendConn *websocket.Conn, methodWhitelist *StringSet) *WSProxier {
+func NewWSProxier(backend *Backend, clientConn, backendConn *websocket.Conn, methodWhitelist *StringSet, onClose func()) *WSProxier {
 	return &WSProxier{
 		backend:         backend,
 		clientConn:      clientConn,
@@ -1430,6 +1455,7 @@ func NewWSProxier(backend *Backend, clientConn, backendConn *websocket.Conn, met
 		methodWhitelist: methodWhitelist,
 		readTimeout:     defaultWSReadTimeout,
 		writeTimeout:    defaultWSWriteTimeout,
+		onClose:         onClose,
 	}
 }
 
@@ -1509,6 +1535,19 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 			continue
 		}
 
+		if w.requestProcessor != nil {
+			res, handled := w.requestProcessor(ctx, req)
+			if handled {
+				msg = mustMarshalJSON(res)
+				err = w.writeClientConn(msgType, msg)
+				if err != nil {
+					errC <- err
+					return
+				}
+				continue
+			}
+		}
+
 		RecordRPCForward(ctx, w.backend.Name, req.Method, RPCRequestSourceWS)
 		log.Info(
 			"forwarded WS message to backend",
@@ -1586,9 +1625,14 @@ func (w *WSProxier) backendPump(ctx context.Context, errC chan error) {
 }
 
 func (w *WSProxier) close() {
-	w.clientConn.Close()
-	w.backendConn.Close()
-	activeBackendWsConnsGauge.WithLabelValues(w.backend.Name).Dec()
+	w.closeOnce.Do(func() {
+		w.clientConn.Close()
+		w.backendConn.Close()
+		activeBackendWsConnsGauge.WithLabelValues(w.backend.Name).Dec()
+		if w.onClose != nil {
+			w.onClose()
+		}
+	})
 }
 
 func (w *WSProxier) prepareClientMsg(msg []byte) (*RPCReq, error) {
@@ -1744,6 +1788,7 @@ func (bg *BackendGroup) ForwardRequestToBackendGroup(
 	backends []*Backend,
 	ctx context.Context,
 	isBatch bool,
+	source string,
 ) *BackendGroupRPCResponse {
 	for _, back := range backends {
 		res := make([]*RPCRes, 0)
@@ -1753,7 +1798,7 @@ func (bg *BackendGroup) ForwardRequestToBackendGroup(
 
 		if len(rpcReqs) > 0 {
 
-			res, err = back.Forward(ctx, rpcReqs, isBatch)
+			res, err = back.ForwardWithSource(ctx, rpcReqs, isBatch, source)
 
 			// below are errors that we explicitly handle so that we don't
 			// mark this request as unserviceable (unserviceable requests

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -98,6 +99,29 @@ func TestWSProxierRequestSlotLimit(t *testing.T) {
 	w.releaseRequestSlot()
 }
 
+func TestBackendProxyWSReleasesSlotOnDialFailure(t *testing.T) {
+	b := &Backend{
+		Name:   "bad-ws",
+		wsURL:  "://invalid",
+		dialer: websocket.DefaultDialer,
+		wsSem:  semaphore.NewWeighted(1),
+	}
+
+	_, err := b.ProxyWS(nil, NewStringSetFromStrings([]string{"eth_subscribe"}), 0)
+	require.Error(t, err)
+	require.True(t, b.wsSem.TryAcquire(1))
+	b.wsSem.Release(1)
+}
+
+func TestShouldHandleWSRPCTxValidationOnlyMethod(t *testing.T) {
+	srv := &Server{
+		enableTxValidation:  true,
+		txValidationMethods: NewTxValidationMethodSet([]string{"eth_call"}),
+	}
+
+	require.True(t, srv.shouldHandleWSRPC(&RPCReq{Method: "eth_call"}))
+}
+
 func TestClientDisconnectionFlow499(t *testing.T) {
 	initialCount := getHttpResponseCodeCount("499")
 
@@ -151,6 +175,7 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 		nil,                                // limExemptKeys
 		TxValidationMiddlewareConfig{},     // txValidationConfig
 		10*time.Second,                     // gracefulShutdownDuration
+		defaultMaxConcurrentWSRPCs,         // maxConcurrentWSRPCs
 	)
 	require.NoError(t, err)
 

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -87,6 +87,17 @@ func TestLimitedHTTPClientDoLimited(t *testing.T) {
 	})
 }
 
+func TestWSProxierRequestSlotLimit(t *testing.T) {
+	w := &WSProxier{requestSem: semaphore.NewWeighted(1)}
+
+	require.True(t, w.acquireRequestSlot())
+	require.False(t, w.acquireRequestSlot())
+
+	w.releaseRequestSlot()
+	require.True(t, w.acquireRequestSlot())
+	w.releaseRequestSlot()
+}
+
 func TestClientDisconnectionFlow499(t *testing.T) {
 	initialCount := getHttpResponseCodeCount("499")
 

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -17,6 +17,8 @@ type ServerConfig struct {
 	WSPort            int    `toml:"ws_port"`
 	MaxBodySizeBytes  int64  `toml:"max_body_size_bytes"`
 	MaxConcurrentRPCs int64  `toml:"max_concurrent_rpcs"`
+	// MaxConcurrentWSRPCs limits concurrent mapped RPCs handled over a single WS connection.
+	MaxConcurrentWSRPCs int64 `toml:"max_concurrent_ws_rpcs"`
 	// DisableConcurrentRequestSemaphore=true allows unlimited concurrent RPC requests. This takes precedence over MaxConcurrentRPCs.
 	DisableConcurrentRequestSemaphore bool   `toml:"disable_concurrent_request_semaphore"`
 	LogLevel                          string `toml:"log_level"`

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -21,6 +21,8 @@ ws_port = 8085
 # Maximum client body size, in bytes, that the server will accept.
 max_body_size_bytes = 10485760
 max_concurrent_rpcs = 1000
+# Maximum mapped RPC requests handled concurrently per WS connection.
+max_concurrent_ws_rpcs = 100
 # Server log level
 log_level = "info"
 # Allow both authenticated and unauthenticated requests when authentication is configured

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -1,9 +1,10 @@
-# List of WS methods to whitelist.
-ws_method_whitelist = [
-  "eth_subscribe",
-  "eth_call",
-  "eth_chainId"
-]
+# List of WS methods to whitelist. Whitelisted WS methods are accepted by the
+# WS endpoint, but by default they are passed straight through to the pinned
+# upstream WS backend connection. To apply proxyd's intelligent request handling
+# to a WS method, such as transaction filtering, rate limiting, retries, or
+# consensus-aware backend-group routing, also add the method to
+# [rpc_method_mappings].
+ws_method_whitelist = ["eth_subscribe", "eth_call", "eth_chainId"]
 # Enable WS on this backend group. There can only be one WS-enabled backend group.
 ws_backend_group = "main"
 
@@ -141,7 +142,11 @@ enabled = true
 endpoint = "https://your-validation-service.example.com/validate"
 # List of RPC methods to apply validation to.
 # Defaults to ["eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle"]
-methods = ["eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle"]
+methods = [
+  "eth_sendRawTransaction",
+  "eth_sendRawTransactionConditional",
+  "eth_sendBundle",
+]
 # Timeout in seconds for validation HTTP requests, default 5
 timeout_seconds = 5
 # Whether to allow transactions through if the validation service returns an error.

--- a/proxyd/integration_tests/ws_test.go
+++ b/proxyd/integration_tests/ws_test.go
@@ -260,6 +260,167 @@ func TestWSWhitelistedUnmappedSubscriptionUsesWSBackend(t *testing.T) {
 	require.Equal(t, int64(1), wsBackendMessages.Load())
 }
 
+func TestWSBackendMaxConnsFallsBackAndReleases(t *testing.T) {
+	rpcBackend := NewMockBackend(SingleResponseHandler(200, dummyRes))
+	defer rpcBackend.Close()
+
+	var firstConnections atomic.Int64
+	var firstClosed sync.Once
+	firstClosedCh := make(chan struct{})
+	firstWSBackend := NewMockWSBackend(func(conn *websocket.Conn) {
+		firstConnections.Add(1)
+	}, func(conn *websocket.Conn, msgType int, data []byte) {
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":1,"result":"first"}`)))
+	}, func(conn *websocket.Conn, err error) {
+		firstClosed.Do(func() {
+			close(firstClosedCh)
+		})
+	})
+	defer firstWSBackend.Close()
+
+	var secondConnections atomic.Int64
+	secondWSBackend := NewMockWSBackend(func(conn *websocket.Conn) {
+		secondConnections.Add(1)
+	}, func(conn *websocket.Conn, msgType int, data []byte) {
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":1,"result":"second"}`)))
+	}, nil)
+	defer secondWSBackend.Close()
+
+	config := ReadConfig("ws")
+	config.Server.RPCPort = 0
+	config.Backends["good"].RPCURL = rpcBackend.URL()
+	config.Backends["good"].WSURL = firstWSBackend.URL()
+	config.Backends["good"].MaxWSConns = 1
+	config.Backends["next"] = &proxyd.BackendConfig{
+		RPCURL: rpcBackend.URL(),
+		WSURL:  secondWSBackend.URL(),
+	}
+	config.BackendGroups["main"].Backends = []string{"good", "next"}
+	config.WSMethodWhitelist = []string{"eth_subscribe"}
+
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	dial := func() (*websocket.Conn, error) {
+		conn, _, err := websocket.DefaultDialer.Dial("ws://127.0.0.1:8546", nil) // nolint:bodyclose
+		if err != nil {
+			return nil, err
+		}
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+		return conn, nil
+	}
+	sendSubscribe := func(conn *websocket.Conn) ([]byte, error) {
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newHeads"]}`)); err != nil {
+			return nil, err
+		}
+		_, res, err := conn.ReadMessage()
+		return res, err
+	}
+
+	firstConn, err := dial()
+	require.NoError(t, err)
+	defer firstConn.Close()
+	res, err := sendSubscribe(firstConn)
+	require.NoError(t, err)
+	RequireEqualJSON(t, []byte(`{"jsonrpc":"2.0","id":1,"result":"first"}`), res)
+
+	secondConn, err := dial()
+	require.NoError(t, err)
+	defer secondConn.Close()
+	res, err = sendSubscribe(secondConn)
+	require.NoError(t, err)
+	RequireEqualJSON(t, []byte(`{"jsonrpc":"2.0","id":1,"result":"second"}`), res)
+
+	require.NoError(t, firstConn.Close())
+	require.Eventually(t, func() bool {
+		select {
+		case <-firstClosedCh:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	var thirdConn *websocket.Conn
+	require.Eventually(t, func() bool {
+		conn, err := dial()
+		if err != nil {
+			return false
+		}
+		res, err := sendSubscribe(conn)
+		if err == nil && string(res) == `{"jsonrpc":"2.0","id":1,"result":"first"}` {
+			thirdConn = conn
+			return true
+		}
+		conn.Close()
+		return false
+	}, time.Second, 10*time.Millisecond)
+	defer thirdConn.Close()
+
+	require.Equal(t, int64(2), firstConnections.Load())
+	require.Equal(t, int64(1), secondConnections.Load())
+}
+
+func TestWSMappedRequestLimitReturnsTooManyRequests(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() {
+		close(release)
+	})
+	httpBackend := NewMockBackend(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startedOnce.Do(func() {
+			close(started)
+		})
+		<-release
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x123"}`))
+	}))
+	defer httpBackend.Close()
+
+	wsBackend := NewMockWSBackend(nil, nil, nil)
+	defer wsBackend.Close()
+
+	config := ReadConfig("ws")
+	config.Server.RPCPort = 0
+	config.Server.MaxConcurrentWSRPCs = 1
+	config.Backends["good"].RPCURL = httpBackend.URL()
+	config.Backends["good"].WSURL = wsBackend.URL()
+	config.WSMethodWhitelist = []string{"eth_chainId"}
+
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://127.0.0.1:8546", nil) // nolint:bodyclose
+	require.NoError(t, err)
+	defer conn.Close()
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}`)))
+	require.Eventually(t, func() bool {
+		select {
+		case <-started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":2,"method":"eth_chainId","params":[]}`)))
+	_, res, err := conn.ReadMessage()
+	require.NoError(t, err)
+	RequireEqualJSON(t, []byte(`{"jsonrpc":"2.0","error":{"code":-32024,"message":"too many requests"},"id":2}`), res)
+
+	releaseOnce.Do(func() {
+		close(release)
+	})
+	_, res, err = conn.ReadMessage()
+	require.NoError(t, err)
+	RequireEqualJSON(t, []byte(`{"jsonrpc":"2.0","id":1,"result":"0x123"}`), res)
+}
+
 func TestWSMappedRequestDoesNotBlockSubscriptionTraffic(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})

--- a/proxyd/integration_tests/ws_test.go
+++ b/proxyd/integration_tests/ws_test.go
@@ -148,6 +148,116 @@ func TestWS(t *testing.T) {
 	}
 }
 
+func TestWSMappedTransactionUsesHTTPPipeline(t *testing.T) {
+	var wsBackendMessages atomic.Int64
+	wsBackend := NewMockWSBackend(nil, func(conn *websocket.Conn, msgType int, data []byte) {
+		wsBackendMessages.Add(1)
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":1,"result":"ws-backend"}`)))
+	}, nil)
+	defer wsBackend.Close()
+
+	httpBackend := NewMockBackend(SingleResponseHandler(200, dummyRes))
+	defer httpBackend.Close()
+
+	config := ReadConfig("sender_rate_limit")
+	config.Server.RPCPort = 0
+	config.Server.WSPort = 8546
+	config.WSBackendGroup = "main"
+	config.WSMethodWhitelist = []string{"eth_sendRawTransaction"}
+	config.Backends["good"].RPCURL = httpBackend.URL()
+	config.Backends["good"].WSURL = wsBackend.URL()
+
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://127.0.0.1:8546", nil) // nolint:bodyclose
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, makeSendRawTransaction(txHex1)))
+	_, res, err := conn.ReadMessage()
+	require.NoError(t, err)
+	RequireEqualJSON(t, []byte(dummyRes), res)
+	require.Len(t, httpBackend.Requests(), 1)
+	require.Equal(t, int64(0), wsBackendMessages.Load())
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, makeSendRawTransaction(txHex1)))
+	_, res, err = conn.ReadMessage()
+	require.NoError(t, err)
+	RequireEqualJSON(t, []byte(limRes), res)
+	require.Len(t, httpBackend.Requests(), 1)
+	require.Equal(t, int64(0), wsBackendMessages.Load())
+}
+
+func TestWSWhitelistedUnmappedTransactionRejected(t *testing.T) {
+	var wsBackendMessages atomic.Int64
+	wsBackend := NewMockWSBackend(nil, func(conn *websocket.Conn, msgType int, data []byte) {
+		wsBackendMessages.Add(1)
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":1,"result":"ws-backend"}`)))
+	}, nil)
+	defer wsBackend.Close()
+
+	httpBackend := NewMockBackend(SingleResponseHandler(200, dummyRes))
+	defer httpBackend.Close()
+
+	config := ReadConfig("sender_rate_limit")
+	config.Server.RPCPort = 0
+	config.Server.WSPort = 8546
+	config.WSBackendGroup = "main"
+	config.WSMethodWhitelist = []string{"eth_sendRawTransaction"}
+	config.Backends["good"].RPCURL = httpBackend.URL()
+	config.Backends["good"].WSURL = wsBackend.URL()
+	delete(config.RPCMethodMappings, "eth_sendRawTransaction")
+
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://127.0.0.1:8546", nil) // nolint:bodyclose
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, makeSendRawTransaction(txHex1)))
+	_, res, err := conn.ReadMessage()
+	require.NoError(t, err)
+	RequireEqualJSON(t, []byte(`{"jsonrpc":"2.0","error":{"code":-32601,"message":"rpc method is not whitelisted"},"id":1}`), res)
+	require.Empty(t, httpBackend.Requests())
+	require.Equal(t, int64(0), wsBackendMessages.Load())
+}
+
+func TestWSWhitelistedUnmappedSubscriptionUsesWSBackend(t *testing.T) {
+	var wsBackendMessages atomic.Int64
+	wsBackend := NewMockWSBackend(nil, func(conn *websocket.Conn, msgType int, data []byte) {
+		wsBackendMessages.Add(1)
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":1,"result":"subscription-ok"}`)))
+	}, nil)
+	defer wsBackend.Close()
+
+	config := ReadConfig("ws")
+	config.Server.RPCPort = 0
+	config.Backends["good"].RPCURL = wsBackend.URL()
+	config.Backends["good"].WSURL = wsBackend.URL()
+	config.WSMethodWhitelist = []string{"eth_subscribe"}
+
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://127.0.0.1:8546", nil) // nolint:bodyclose
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newHeads"]}`)))
+	_, res, err := conn.ReadMessage()
+	require.NoError(t, err)
+	RequireEqualJSON(t, []byte(`{"jsonrpc":"2.0","id":1,"result":"subscription-ok"}`), res)
+	require.Equal(t, int64(1), wsBackendMessages.Load())
+}
+
 func TestWSClientClosure(t *testing.T) {
 	backendHdlr := new(backendHandler)
 	clientHdlr := new(clientHandler)
@@ -231,12 +341,11 @@ func TestWSClientExceedReadLimit(t *testing.T) {
 
 	payload := strings.Repeat("barf", 1024*1024)
 	clientReq := "{\"id\": 1, \"method\": \"eth_subscribe\", \"params\": [\"" + payload + "\"]}"
-	err = client.WriteMessage(
+	writeErr := client.WriteMessage(
 		websocket.TextMessage,
 		[]byte(clientReq),
 	)
-	require.Error(t, err)
 	require.Eventually(t, closed.Load, time.Second, 10*time.Millisecond,
-		"connection should be closed after exceeding the read limit")
+		"connection should be closed after exceeding the read limit; write error: %v", writeErr)
 
 }

--- a/proxyd/integration_tests/ws_test.go
+++ b/proxyd/integration_tests/ws_test.go
@@ -1,8 +1,10 @@
 package integration_tests
 
 import (
+	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -256,6 +258,69 @@ func TestWSWhitelistedUnmappedSubscriptionUsesWSBackend(t *testing.T) {
 	require.NoError(t, err)
 	RequireEqualJSON(t, []byte(`{"jsonrpc":"2.0","id":1,"result":"subscription-ok"}`), res)
 	require.Equal(t, int64(1), wsBackendMessages.Load())
+}
+
+func TestWSMappedRequestDoesNotBlockSubscriptionTraffic(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() {
+		close(release)
+	})
+	httpBackend := NewMockBackend(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startedOnce.Do(func() {
+			close(started)
+		})
+		<-release
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x123"}`))
+	}))
+	defer httpBackend.Close()
+
+	var wsBackendMessages atomic.Int64
+	wsBackend := NewMockWSBackend(nil, func(conn *websocket.Conn, msgType int, data []byte) {
+		wsBackendMessages.Add(1)
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":2,"result":"subscription-ok"}`)))
+	}, nil)
+	defer wsBackend.Close()
+
+	config := ReadConfig("ws")
+	config.Server.RPCPort = 0
+	config.Backends["good"].RPCURL = httpBackend.URL()
+	config.Backends["good"].WSURL = wsBackend.URL()
+	config.WSMethodWhitelist = []string{"eth_chainId", "eth_subscribe"}
+
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://127.0.0.1:8546", nil) // nolint:bodyclose
+	require.NoError(t, err)
+	defer conn.Close()
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}`)))
+	require.Eventually(t, func() bool {
+		select {
+		case <-started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":2,"method":"eth_subscribe","params":["newHeads"]}`)))
+	_, res, err := conn.ReadMessage()
+	require.NoError(t, err)
+	RequireEqualJSON(t, []byte(`{"jsonrpc":"2.0","id":2,"result":"subscription-ok"}`), res)
+	require.Equal(t, int64(1), wsBackendMessages.Load())
+
+	releaseOnce.Do(func() {
+		close(release)
+	})
+	_, res, err = conn.ReadMessage()
+	require.NoError(t, err)
+	RequireEqualJSON(t, []byte(`{"jsonrpc":"2.0","id":1,"result":"0x123"}`), res)
 }
 
 func TestWSClientClosure(t *testing.T) {

--- a/proxyd/multicall_unserviceable_test.go
+++ b/proxyd/multicall_unserviceable_test.go
@@ -41,7 +41,7 @@ func TestExecuteMulticallUnserviceableMetric(t *testing.T) {
 		}
 
 		before := getUnserviceableRequestCount(RPCRequestSourceHTTP)
-		resp := bg.ExecuteMulticall(context.Background(), req)
+		resp := bg.ExecuteMulticall(context.Background(), req, RPCRequestSourceHTTP)
 		require.Error(t, resp.error)
 		require.True(t, errors.Is(resp.error, ErrNoBackends))
 		after := getUnserviceableRequestCount(RPCRequestSourceHTTP)
@@ -65,7 +65,7 @@ func TestExecuteMulticallUnserviceableMetric(t *testing.T) {
 		}
 
 		before := getUnserviceableRequestCount(RPCRequestSourceHTTP)
-		resp := bg.ExecuteMulticall(context.Background(), req)
+		resp := bg.ExecuteMulticall(context.Background(), req, RPCRequestSourceHTTP)
 		require.NoError(t, resp.error)
 		after := getUnserviceableRequestCount(RPCRequestSourceHTTP)
 

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -538,6 +538,7 @@ func Start(config *Config) (*Server, func(), error) {
 		apiKeys,
 		config.TxValidationMiddlewareConfig,
 		time.Duration(config.Server.GracefulShutdownSeconds)*time.Second,
+		config.Server.MaxConcurrentWSRPCs,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -91,6 +91,7 @@ type Server struct {
 	interopStrategy         InteropStrategy
 	publicAccess            bool
 	enableTxHashLogging     bool
+	maxConcurrentWSRPCs     int64
 
 	enableTxValidation       bool
 	txValidationFn           TxValidationFunc
@@ -132,6 +133,7 @@ func NewServer(
 	limExemptKeys []string,
 	txValidationConfig TxValidationMiddlewareConfig,
 	gracefulShutdownDuration time.Duration,
+	maxConcurrentWSRPCs int64,
 ) (*Server, error) {
 	if cache == nil {
 		cache = &NoopRPCCache{}
@@ -155,6 +157,9 @@ func NewServer(
 
 	if maxBatchSize > MaxBatchRPCCallsHardLimit {
 		maxBatchSize = MaxBatchRPCCallsHardLimit
+	}
+	if maxConcurrentWSRPCs == 0 {
+		maxConcurrentWSRPCs = defaultMaxConcurrentWSRPCs
 	}
 
 	var mainLim FrontendRateLimiter
@@ -253,6 +258,7 @@ func NewServer(
 		interopValidatingConfig:  interopValidatingConfig,
 		interopStrategy:          interopStrategy,
 		enableTxHashLogging:      enableTxHashLogging,
+		maxConcurrentWSRPCs:      maxConcurrentWSRPCs,
 		enableTxValidation:       txValidationConfig.Enabled,
 		txValidationFn:           txValidationClient.Validate,
 		txValidationEndpoint:     txValidationConfig.Endpoint,
@@ -378,7 +384,7 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 	apiKey := r.Header.Get("X-Api-Key")
 	bypassLimit := s.isValidAPIKey(apiKey)
 
-	isLimited, origin, userAgent, xff, err := s.limiterForRequest(ctx, r, bypassLimit)
+	isLimited, err := s.limiterForRequest(ctx, r, bypassLimit)
 	if err != nil {
 		writeRPCError(ctx, w, nil, err)
 		return
@@ -388,9 +394,9 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 		"received RPC request",
 		"req_id", GetReqID(ctx),
 		"auth", GetAuthCtx(ctx),
-		"user_agent", userAgent,
-		"origin", origin,
-		"remote_ip", xff,
+		"user_agent", r.Header.Get("User-Agent"),
+		"origin", r.Header.Get("Origin"),
+		"remote_ip", stripXFF(GetXForwardedFor(ctx)),
 	)
 
 	body, err := io.ReadAll(LimitReader(r.Body, s.maxBodySize))
@@ -816,7 +822,7 @@ func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
 	// User can provide an API key via the "X-Api-Key" header
 	apiKey := r.Header.Get("X-Api-Key")
 	bypassLimit := s.isValidAPIKey(apiKey)
-	isLimited, _, _, _, err := s.limiterForRequest(ctx, r, bypassLimit)
+	isLimited, err := s.limiterForRequest(ctx, r, bypassLimit)
 	if err != nil {
 		http.Error(w, "request does not include a remote IP", http.StatusBadRequest)
 		return
@@ -844,6 +850,7 @@ func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
 	proxier.requestProcessor = func(ctx context.Context, req *RPCReq) *RPCRes {
 		return s.handleWSRPC(ctx, req, isLimited, bypassLimit)
 	}
+	proxier.maxConcurrentRequests = s.maxConcurrentWSRPCs
 	go func() {
 		// Below call blocks so run it in a goroutine.
 		if err := proxier.Proxy(ctx); err != nil {
@@ -1002,7 +1009,7 @@ func (s *Server) isValidAPIKey(key string) bool {
 	return false
 }
 
-func (s *Server) limiterForRequest(ctx context.Context, r *http.Request, bypassLimit bool) (limiterFunc, string, string, string, error) {
+func (s *Server) limiterForRequest(ctx context.Context, r *http.Request, bypassLimit bool) (limiterFunc, error) {
 	origin := r.Header.Get("Origin")
 	userAgent := r.Header.Get("User-Agent")
 	// Use XFF in context since it will automatically be replaced by the remote IP
@@ -1011,7 +1018,7 @@ func (s *Server) limiterForRequest(ctx context.Context, r *http.Request, bypassL
 	isUnlimitedUserAgent := s.isUnlimitedUserAgent(userAgent)
 
 	if xff == "" {
-		return nil, origin, userAgent, xff, ErrInvalidRequest("request does not include a remote IP")
+		return nil, ErrInvalidRequest("request does not include a remote IP")
 	}
 
 	isLimited := func(method string) bool {
@@ -1043,7 +1050,7 @@ func (s *Server) limiterForRequest(ctx context.Context, r *http.Request, bypassL
 		return !ok
 	}
 
-	return isLimited, origin, userAgent, xff, nil
+	return isLimited, nil
 }
 
 func (s *Server) isGlobalLimit(method string) bool {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -46,6 +46,7 @@ const (
 	defaultWSHandshakeTimeout                       = 10 * time.Second
 	defaultWSReadTimeout                            = 2 * time.Minute
 	defaultWSWriteTimeout                           = 10 * time.Second
+	defaultMaxConcurrentWSRPCs                      = 100
 	defaultCacheTtl                                 = 1 * time.Hour
 	maxRequestBodyLogLen                            = 2000
 	defaultMaxUpstreamBatchSize                     = 10
@@ -839,7 +840,8 @@ func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	activeClientWsConnsGauge.WithLabelValues(GetAuthCtx(ctx)).Inc()
-	proxier.requestProcessor = func(ctx context.Context, req *RPCReq) (*RPCRes, bool) {
+	proxier.requestHandler = s.shouldHandleWSRPC
+	proxier.requestProcessor = func(ctx context.Context, req *RPCReq) *RPCRes {
 		return s.handleWSRPC(ctx, req, isLimited, bypassLimit)
 	}
 	go func() {
@@ -853,18 +855,25 @@ func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
 	log.Info("accepted WS connection", "auth", GetAuthCtx(ctx), "req_id", GetReqID(ctx))
 }
 
-func (s *Server) handleWSRPC(ctx context.Context, req *RPCReq, isLimited limiterFunc, bypassLimit bool) (*RPCRes, bool) {
+func (s *Server) shouldHandleWSRPC(req *RPCReq) bool {
+	if s.rpcMethodMappings[req.Method] != "" {
+		return true
+	}
+	if s.txFilter != nil && s.txFilter.IsSubmissionMethod(req.Method) {
+		return true
+	}
+	return s.enableTxValidation && s.txValidationMethods.Contains(req.Method)
+}
+
+func (s *Server) handleWSRPC(ctx context.Context, req *RPCReq, isLimited limiterFunc, bypassLimit bool) *RPCRes {
 	if s.rpcMethodMappings[req.Method] == "" {
-		if isTransactionForwardingMethod(req.Method) || (s.enableTxValidation && s.txValidationMethods.Contains(req.Method)) {
-			RecordRPCError(ctx, BackendProxyd, MethodNotAllowed, ErrMethodNotWhitelisted)
-			return NewRPCErrorRes(req.ID, ErrMethodNotWhitelisted), true
-		}
-		return nil, false
+		RecordRPCError(ctx, BackendProxyd, MethodNotAllowed, ErrMethodNotWhitelisted)
+		return NewRPCErrorRes(req.ID, ErrMethodNotWhitelisted)
 	}
 
 	localRes, group, txHash := s.prepareRPCForForward(ctx, req, isLimited, bypassLimit, RPCRequestSourceWS)
 	if localRes != nil {
-		return localRes, true
+		return localRes
 	}
 
 	forwardStart := time.Now()
@@ -877,7 +886,7 @@ func (s *Server) handleWSRPC(ctx context.Context, req *RPCReq, isLimited limiter
 			"req_id", GetReqID(ctx),
 			"err", err,
 		)
-		return NewRPCErrorRes(req.ID, err), true
+		return NewRPCErrorRes(req.ID, err)
 	}
 	if len(res) == 0 {
 		log.Error(
@@ -885,7 +894,7 @@ func (s *Server) handleWSRPC(ctx context.Context, req *RPCReq, isLimited limiter
 			"backend_group", group,
 			"req_id", GetReqID(ctx),
 		)
-		return NewRPCErrorRes(req.ID, ErrInternal), true
+		return NewRPCErrorRes(req.ID, ErrInternal)
 	}
 
 	if txHash != nil && s.enableTxHashLogging {
@@ -899,16 +908,7 @@ func (s *Server) handleWSRPC(ctx context.Context, req *RPCReq, isLimited limiter
 		)
 	}
 
-	return res[0], true
-}
-
-func isTransactionForwardingMethod(method string) bool {
-	switch method {
-	case "eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle":
-		return true
-	default:
-		return false
-	}
+	return res[0]
 }
 
 func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context.Context {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -377,45 +377,10 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 	apiKey := r.Header.Get("X-Api-Key")
 	bypassLimit := s.isValidAPIKey(apiKey)
 
-	origin := r.Header.Get("Origin")
-	userAgent := r.Header.Get("User-Agent")
-	// Use XFF in context since it will automatically be replaced by the remote IP
-	xff := stripXFF(GetXForwardedFor(ctx))
-	isUnlimitedOrigin := s.isUnlimitedOrigin(origin)
-	isUnlimitedUserAgent := s.isUnlimitedUserAgent(userAgent)
-
-	if xff == "" {
-		writeRPCError(ctx, w, nil, ErrInvalidRequest("request does not include a remote IP"))
+	isLimited, origin, userAgent, xff, err := s.limiterForRequest(ctx, r, bypassLimit)
+	if err != nil {
+		writeRPCError(ctx, w, nil, err)
 		return
-	}
-
-	isLimited := func(method string) bool {
-		if bypassLimit {
-			return false
-		}
-
-		isGloballyLimitedMethod := s.isGlobalLimit(method)
-		if !isGloballyLimitedMethod && (isUnlimitedOrigin || isUnlimitedUserAgent) {
-			return false
-		}
-
-		var lim FrontendRateLimiter
-		if method == "" {
-			lim = s.mainLim
-		} else {
-			lim = s.overrideLims[method]
-		}
-
-		if lim == nil {
-			return false
-		}
-
-		ok, err := lim.Take(ctx, xff)
-		if err != nil {
-			log.Warn("error taking rate limit", "err", err)
-			return true
-		}
-		return !ok
 	}
 
 	log.Debug(
@@ -602,6 +567,87 @@ func interopValidationReason(err error) string {
 	return "internal"
 }
 
+func (s *Server) prepareRPCForForward(
+	ctx context.Context,
+	parsedReq *RPCReq,
+	isLimited limiterFunc,
+	bypassLimit bool,
+	source string,
+) (*RPCRes, string, *common.Hash) {
+	if err := ValidateRPCReq(parsedReq); err != nil {
+		RecordRPCError(ctx, BackendProxyd, MethodUnknown, err)
+		return NewRPCErrorRes(nil, err), "", nil
+	}
+
+	if parsedReq.Method == "eth_accounts" {
+		RecordRPCForward(ctx, BackendProxyd, "eth_accounts", source)
+		return NewRPCRes(parsedReq.ID, emptyArrayResponse), "", nil
+	}
+
+	group := s.rpcMethodMappings[parsedReq.Method]
+	if group == "" {
+		// Use constant method_not_allowed to prevent DOS vector that fills up memory
+		// with arbitrary method names.
+		log.Info(
+			"blocked request for non-whitelisted method",
+			"source", source,
+			"req_id", GetReqID(ctx),
+			"method", parsedReq.Method,
+			"remote_ip", stripXFF(GetXForwardedFor(ctx)),
+		)
+		RecordRPCError(ctx, BackendProxyd, MethodNotAllowed, ErrMethodNotWhitelisted)
+		return NewRPCErrorRes(parsedReq.ID, ErrMethodNotWhitelisted), "", nil
+	}
+
+	// Take base rate limit first.
+	if isLimited("") {
+		log.Debug(
+			"rate limited individual RPC in a batch request",
+			"source", source,
+			"req_id", GetReqID(ctx),
+			"method", parsedReq.Method,
+			"remote_ip", stripXFF(GetXForwardedFor(ctx)),
+		)
+		RecordRPCError(ctx, BackendProxyd, parsedReq.Method, ErrOverRateLimit)
+		return NewRPCErrorRes(parsedReq.ID, ErrOverRateLimit), "", nil
+	}
+
+	// Take rate limit for specific methods.
+	if _, ok := s.overrideLims[parsedReq.Method]; ok && isLimited(parsedReq.Method) {
+		log.Debug(
+			"rate limited specific RPC",
+			"source", source,
+			"req_id", GetReqID(ctx),
+			"method", parsedReq.Method,
+			"remote_ip", stripXFF(GetXForwardedFor(ctx)),
+		)
+		RecordRPCError(ctx, BackendProxyd, parsedReq.Method, ErrOverRateLimit)
+		return NewRPCErrorRes(parsedReq.ID, ErrOverRateLimit), "", nil
+	}
+
+	var txHash *common.Hash
+	if s.txFilter.IsSubmissionMethod(parsedReq.Method) {
+		sub, err := s.txFilter.Build(ctx, parsedReq, bypassLimit)
+		if err != nil {
+			RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)
+			return NewRPCErrorRes(parsedReq.ID, err), "", nil
+		}
+
+		// Preserve the single-tx forwarding log; bundles are not sendRawTransaction.
+		if sub.Method == "eth_sendRawTransaction" || sub.Method == "eth_sendRawTransactionConditional" {
+			hash := sub.Txs[0].Hash()
+			txHash = &hash
+		}
+
+		if err := s.txFilter.Apply(ctx, sub); err != nil {
+			RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)
+			return NewRPCErrorRes(parsedReq.ID, err), "", nil
+		}
+	}
+
+	return nil, group, txHash
+}
+
 func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isLimited limiterFunc, isBatch bool, bypassLimit bool) ([]*RPCRes, bool, string, error) {
 	// A request set is transformed into groups of batches.
 	// Each batch group maps to a forwarded JSON-RPC batch request (subject to maxUpstreamBatchSize constraints)
@@ -637,80 +683,13 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			return []*RPCRes{res}, false, "", nil
 		}
 
-		if err := ValidateRPCReq(parsedReq); err != nil {
-			RecordRPCError(ctx, BackendProxyd, MethodUnknown, err)
-			responses[i] = NewRPCErrorRes(nil, err)
+		localRes, group, txHash := s.prepareRPCForForward(ctx, parsedReq, isLimited, bypassLimit, RPCRequestSourceHTTP)
+		if localRes != nil {
+			responses[i] = localRes
 			continue
 		}
-
-		if parsedReq.Method == "eth_accounts" {
-			RecordRPCForward(ctx, BackendProxyd, "eth_accounts", RPCRequestSourceHTTP)
-			responses[i] = NewRPCRes(parsedReq.ID, emptyArrayResponse)
-			continue
-		}
-
-		group := s.rpcMethodMappings[parsedReq.Method]
-		if group == "" {
-			// Use constant method_not_allowed to prevent DOS vector that fills up memory
-			// with arbitrary method names.
-			log.Info(
-				"blocked request for non-whitelisted method",
-				"source", "rpc",
-				"req_id", GetReqID(ctx),
-				"method", parsedReq.Method,
-				"remote_ip", stripXFF(GetXForwardedFor(ctx)),
-			)
-			RecordRPCError(ctx, BackendProxyd, MethodNotAllowed, ErrMethodNotWhitelisted)
-			responses[i] = NewRPCErrorRes(parsedReq.ID, ErrMethodNotWhitelisted)
-			continue
-		}
-
-		// Take base rate limit first
-		if isLimited("") {
-			log.Debug(
-				"rate limited individual RPC in a batch request",
-				"source", "rpc",
-				"req_id", GetReqID(ctx),
-				"method", parsedReq.Method,
-				"remote_ip", stripXFF(GetXForwardedFor(ctx)),
-			)
-			RecordRPCError(ctx, BackendProxyd, parsedReq.Method, ErrOverRateLimit)
-			responses[i] = NewRPCErrorRes(parsedReq.ID, ErrOverRateLimit)
-			continue
-		}
-
-		// Take rate limit for specific methods.
-		if _, ok := s.overrideLims[parsedReq.Method]; ok && isLimited(parsedReq.Method) {
-			log.Debug(
-				"rate limited specific RPC",
-				"source", "rpc",
-				"req_id", GetReqID(ctx),
-				"method", parsedReq.Method,
-				"remote_ip", stripXFF(GetXForwardedFor(ctx)),
-			)
-			RecordRPCError(ctx, BackendProxyd, parsedReq.Method, ErrOverRateLimit)
-			responses[i] = NewRPCErrorRes(parsedReq.ID, ErrOverRateLimit)
-			continue
-		}
-
-		// Run the unified transaction-submission filter. Sender-based rate
-		// limits apply regardless of origin or user-agent, so they don't use
-		// the isLimited method.
-		if s.txFilter.IsSubmissionMethod(parsedReq.Method) {
-			sub, err := s.txFilter.Build(ctx, parsedReq, bypassLimit)
-			if err != nil {
-				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)
-				responses[i] = NewRPCErrorRes(parsedReq.ID, err)
-				continue
-			}
-			if sub.Method == "eth_sendRawTransaction" || sub.Method == "eth_sendRawTransactionConditional" {
-				txHashes[i] = sub.Txs[0].Hash() // preserve single-tx forwarding log; bundles aren't sendRawTransaction
-			}
-			if err := s.txFilter.Apply(ctx, sub); err != nil {
-				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)
-				responses[i] = NewRPCErrorRes(parsedReq.ID, err)
-				continue
-			}
+		if txHash != nil {
+			txHashes[i] = *txHash
 		}
 
 		id := string(parsedReq.ID)
@@ -829,8 +808,18 @@ func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Server is draining", http.StatusServiceUnavailable)
 		return
 	}
+	ctx = context.WithoutCancel(ctx)
 
 	log.Info("received WS connection", "req_id", GetReqID(ctx))
+
+	// User can provide an API key via the "X-Api-Key" header
+	apiKey := r.Header.Get("X-Api-Key")
+	bypassLimit := s.isValidAPIKey(apiKey)
+	isLimited, _, _, _, err := s.limiterForRequest(ctx, r, bypassLimit)
+	if err != nil {
+		http.Error(w, "request does not include a remote IP", http.StatusBadRequest)
+		return
+	}
 
 	clientConn, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -850,6 +839,9 @@ func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	activeClientWsConnsGauge.WithLabelValues(GetAuthCtx(ctx)).Inc()
+	proxier.requestProcessor = func(ctx context.Context, req *RPCReq) (*RPCRes, bool) {
+		return s.handleWSRPC(ctx, req, isLimited, bypassLimit)
+	}
 	go func() {
 		// Below call blocks so run it in a goroutine.
 		if err := proxier.Proxy(ctx); err != nil {
@@ -859,6 +851,64 @@ func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	log.Info("accepted WS connection", "auth", GetAuthCtx(ctx), "req_id", GetReqID(ctx))
+}
+
+func (s *Server) handleWSRPC(ctx context.Context, req *RPCReq, isLimited limiterFunc, bypassLimit bool) (*RPCRes, bool) {
+	if s.rpcMethodMappings[req.Method] == "" {
+		if isTransactionForwardingMethod(req.Method) || (s.enableTxValidation && s.txValidationMethods.Contains(req.Method)) {
+			RecordRPCError(ctx, BackendProxyd, MethodNotAllowed, ErrMethodNotWhitelisted)
+			return NewRPCErrorRes(req.ID, ErrMethodNotWhitelisted), true
+		}
+		return nil, false
+	}
+
+	localRes, group, txHash := s.prepareRPCForForward(ctx, req, isLimited, bypassLimit, RPCRequestSourceWS)
+	if localRes != nil {
+		return localRes, true
+	}
+
+	forwardStart := time.Now()
+	res, servedBy, err := s.BackendGroups[group].ForwardWithSource(ctx, []*RPCReq{req}, false, RPCRequestSourceWS)
+	forwardDuration := time.Since(forwardStart)
+	if err != nil {
+		log.Error(
+			"error forwarding WS RPC",
+			"backend_group", group,
+			"req_id", GetReqID(ctx),
+			"err", err,
+		)
+		return NewRPCErrorRes(req.ID, err), true
+	}
+	if len(res) == 0 {
+		log.Error(
+			"empty response forwarding WS RPC",
+			"backend_group", group,
+			"req_id", GetReqID(ctx),
+		)
+		return NewRPCErrorRes(req.ID, ErrInternal), true
+	}
+
+	if txHash != nil && s.enableTxHashLogging {
+		log.Info("sendRawTransaction forwarded",
+			"tx_hash", *txHash,
+			"req_id", GetReqID(ctx),
+			"backend", servedBy,
+			"backend_group", group,
+			"duration_ms", forwardDuration.Milliseconds(),
+			"source", RPCRequestSourceWS,
+		)
+	}
+
+	return res[0], true
+}
+
+func isTransactionForwardingMethod(method string) bool {
+	switch method {
+	case "eth_sendRawTransaction", "eth_sendRawTransactionConditional", "eth_sendBundle":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context.Context {
@@ -950,6 +1000,50 @@ func (s *Server) isValidAPIKey(key string) bool {
 		}
 	}
 	return false
+}
+
+func (s *Server) limiterForRequest(ctx context.Context, r *http.Request, bypassLimit bool) (limiterFunc, string, string, string, error) {
+	origin := r.Header.Get("Origin")
+	userAgent := r.Header.Get("User-Agent")
+	// Use XFF in context since it will automatically be replaced by the remote IP
+	xff := stripXFF(GetXForwardedFor(ctx))
+	isUnlimitedOrigin := s.isUnlimitedOrigin(origin)
+	isUnlimitedUserAgent := s.isUnlimitedUserAgent(userAgent)
+
+	if xff == "" {
+		return nil, origin, userAgent, xff, ErrInvalidRequest("request does not include a remote IP")
+	}
+
+	isLimited := func(method string) bool {
+		if bypassLimit {
+			return false
+		}
+
+		isGloballyLimitedMethod := s.isGlobalLimit(method)
+		if !isGloballyLimitedMethod && (isUnlimitedOrigin || isUnlimitedUserAgent) {
+			return false
+		}
+
+		var lim FrontendRateLimiter
+		if method == "" {
+			lim = s.mainLim
+		} else {
+			lim = s.overrideLims[method]
+		}
+
+		if lim == nil {
+			return false
+		}
+
+		ok, err := lim.Take(ctx, xff)
+		if err != nil {
+			log.Warn("error taking rate limit", "err", err)
+			return true
+		}
+		return !ok
+	}
+
+	return isLimited, origin, userAgent, xff, nil
 }
 
 func (s *Server) isGlobalLimit(method string) bool {


### PR DESCRIPTION
Routes websocket transaction RPCs through the same pre-forward validation and backend-group forwarding path used by HTTP. This keeps subscription-style websocket traffic on the pinned upstream connection, while mapped RPC methods now get sender limits, interop validation, tx validation middleware, and HTTP-style backend selection.

Also enforces `max_ws_conns` with a per-backend websocket semaphore and records WS-routed backend forwards with the WS source label.

Additional coverage locks in that whitelisted-but-unmapped transaction forwarding methods fail closed locally, while whitelisted subscription methods that are not RPC-mapped still fall through to the WS upstream.

Test plan:
- `go test ./integration_tests -run 'TestWS(MappedTransactionUsesHTTPPipeline|WhitelistedUnmappedTransactionRejected|WhitelistedUnmappedSubscriptionUsesWSBackend)$' -count=1 -v`
- `go test .`
- `go test ./integration_tests -count=1`