### PR TITLE
fix(proxyd): parse IPv6 remote addresses

### DIFF
--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -11,10 +11,10 @@ import (
 	"io"
 	"math"
 	"math/big"
+	"net"
 	"net/http"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -886,10 +886,7 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 	authorization := vars["authorization"]
 	xff := r.Header.Get(s.rateLimitHeader)
 	if xff == "" {
-		ipPort := strings.Split(r.RemoteAddr, ":")
-		if len(ipPort) == 2 {
-			xff = ipPort[0]
-		}
+		xff = hostFromRemoteAddr(r.RemoteAddr)
 	}
 
 	ctx := context.WithValue(r.Context(), ContextKeyXForwardedFor, xff) // nolint:staticcheck
@@ -926,6 +923,17 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 		ContextKeyReqID, // nolint:staticcheck
 		randStr(10),
 	)
+}
+
+func hostFromRemoteAddr(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err == nil {
+		return host
+	}
+	if net.ParseIP(remoteAddr) != nil {
+		return remoteAddr
+	}
+	return ""
 }
 
 func randStr(l int) string {

--- a/proxyd/server_test.go
+++ b/proxyd/server_test.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -93,6 +94,52 @@ func TestIsValidAPIKey(t *testing.T) {
 			if got != tt.expected {
 				t.Errorf("isValidAPIKey() = %v, want %v: %s", got, tt.expected, tt.description)
 			}
+		})
+	}
+}
+
+func TestPopulateContextRemoteAddrFallback(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		header     string
+		want       string
+	}{
+		{
+			name:       "ipv4 host port",
+			remoteAddr: "127.0.0.1:8545",
+			want:       "127.0.0.1",
+		},
+		{
+			name:       "ipv6 host port",
+			remoteAddr: "[::1]:8545",
+			want:       "::1",
+		},
+		{
+			name:       "ipv6 without port",
+			remoteAddr: "::1",
+			want:       "::1",
+		},
+		{
+			name:       "header takes precedence",
+			remoteAddr: "[::1]:8545",
+			header:     "203.0.113.1",
+			want:       "203.0.113.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{rateLimitHeader: defaultRateLimitHeader}
+			req := httptest.NewRequest("POST", "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.header != "" {
+				req.Header.Set(defaultRateLimitHeader, tt.header)
+			}
+
+			ctx := s.populateContext(httptest.NewRecorder(), req)
+			require.NotNil(t, ctx)
+			require.Equal(t, tt.want, GetXForwardedFor(ctx))
 		})
 	}
 }


### PR DESCRIPTION
Fixes the RemoteAddr fallback used when the configured rate-limit header is absent. The previous colon split worked for IPv4 host:port values but produced an empty XFF for bracketed IPv6 addresses like [::1]:8545.

This switches the fallback to net.SplitHostPort with a bare-IP fallback and adds coverage for IPv4, bracketed IPv6, bare IPv6, and header precedence.

Test plan:
- `go test .` from `proxyd`