### PR TITLE
fix(proxyd): instrumentation of unserviceable requests metric

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1120,6 +1120,9 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 	go func() {
 		defer close(ch)
 		backendResp := bg.ForwardRequestToBackendGroup(rpcReqs, backends, ctx, isBatch)
+		if backendResp.error != nil && errors.Is(backendResp.error, ErrNoBackends) {
+			RecordUnserviceableRequest(ctx, RPCRequestSourceHTTP)
+		}
 		ch <- *backendResp
 	}()
 	backendResp := <-ch
@@ -1183,7 +1186,12 @@ func (bg *BackendGroup) ExecuteMulticall(ctx context.Context, rpcReqs []*RPCReq)
 		close(ch)
 	}()
 
-	return bg.ProcessMulticallResponses(ch, bgCtx)
+	resp, unserviceable := bg.ProcessMulticallResponses(ch, bgCtx)
+	// resp.error != nil is kinda redundant (but still kept it as a fail safe) as unserviceable can only be true for a negative response
+	if resp.error != nil && unserviceable {
+		RecordUnserviceableRequest(bgCtx, RPCRequestSourceHTTP)
+	}
+	return resp
 }
 
 func (bg *BackendGroup) MulticallRequest(backend *Backend, rpcReqs []*RPCReq, wg *sync.WaitGroup, ctx context.Context, ch chan *multicallTuple) {
@@ -1229,25 +1237,27 @@ func (bg *BackendGroup) MulticallRequest(backend *Backend, rpcReqs []*RPCReq, wg
 	}
 }
 
-func (bg *BackendGroup) ProcessMulticallResponses(ch chan *multicallTuple, ctx context.Context) *BackendGroupRPCResponse {
+func (bg *BackendGroup) ProcessMulticallResponses(ch chan *multicallTuple, ctx context.Context) (resp *BackendGroupRPCResponse, unserviceable bool) {
+	allBackendsUnserviceable := true
 	var finalResp *BackendGroupRPCResponse
 	i := 0
 	for {
 		multicallResp, ok := <-ch
 		if !ok {
+			// we didn't reach a successful response until the end of channel, so return the final (negative) response
 			log.Trace("multicall response channel closed",
 				"req_id", GetReqID(ctx),
 				"auth", GetAuthCtx(ctx),
 				"response_count", i,
 			)
 			if i > 0 {
-				return finalResp
+				return finalResp, allBackendsUnserviceable
 			}
 			return &BackendGroupRPCResponse{
 				RPCRes:   nil,
 				ServedBy: "",
 				error:    errors.New("no multicall response received"),
-			}
+			}, allBackendsUnserviceable // in case of no response/backends, it's fair to assume the request was unserviceable
 		}
 
 		i++
@@ -1262,12 +1272,16 @@ func (bg *BackendGroup) ProcessMulticallResponses(ch chan *multicallTuple, ctx c
 				"backend", backendName,
 			)
 			finalResp = resp
+			if !errors.Is(resp.error, ErrNoBackends) {
+				allBackendsUnserviceable = false
+			}
 			continue
 		}
 
 		// Assuming multicall doesn't support batch
 		if bg.multicallRPCErrorCheck && resp.RPCRes[0].IsError() {
 			finalResp = resp
+			allBackendsUnserviceable = false // coz the backend served a response (just an RPC-level error)
 			continue
 		}
 
@@ -1277,7 +1291,7 @@ func (bg *BackendGroup) ProcessMulticallResponses(ch chan *multicallTuple, ctx c
 			"served_by", resp.ServedBy,
 			"backend", backendName,
 		)
-		return resp
+		return resp, false // unserviceable is false because we received a successful response
 	}
 }
 
@@ -1814,7 +1828,6 @@ func (bg *BackendGroup) ForwardRequestToBackendGroup(
 		}
 	}
 
-	RecordUnserviceableRequest(ctx, RPCRequestSourceHTTP)
 	return &BackendGroupRPCResponse{
 		RPCRes:   nil,
 		ServedBy: "",

--- a/proxyd/multicall_unserviceable_test.go
+++ b/proxyd/multicall_unserviceable_test.go
@@ -88,7 +88,7 @@ func TestForwardUnserviceableMetric(t *testing.T) {
 
 	req := []*RPCReq{{ID: []byte("1"), Method: "eth_blockNumber", JSONRPC: "2.0"}}
 
-	t.Run("all backends fail increments exactly once", func(t *testing.T) {
+	t.Run("all backends fail increments unserviceable counter exactly once", func(t *testing.T) {
 		s1 := newServer(http.StatusServiceUnavailable, `{"error":"down"}`)
 		s2 := newServer(http.StatusServiceUnavailable, `{"error":"down"}`)
 		defer s1.Close()
@@ -113,7 +113,7 @@ func TestForwardUnserviceableMetric(t *testing.T) {
 			"a fully-unserviceable forward must increment the counter exactly once regardless of backend count")
 	})
 
-	t.Run("a successful backend does not increment", func(t *testing.T) {
+	t.Run("at least one successful backend does not increment unserviceable counter", func(t *testing.T) {
 		s1 := newServer(http.StatusServiceUnavailable, `{"error":"down"}`)
 		s2 := newServer(http.StatusOK, `{"jsonrpc":"2.0","result":"0x123","id":1}`)
 		defer s1.Close()

--- a/proxyd/multicall_unserviceable_test.go
+++ b/proxyd/multicall_unserviceable_test.go
@@ -1,0 +1,160 @@
+package proxyd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+)
+
+// TestExecuteMulticallUnserviceableMetric is an end-to-end check that the
+// proxyd_unserviceable_requests_total counter is incremented exactly once when
+// all backends fail, and not at all when at least one backend serves the
+// request.
+func TestExecuteMulticallUnserviceableMetric(t *testing.T) {
+	newServer := func(status int, body string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(body))
+		}))
+	}
+
+	req := []*RPCReq{{ID: []byte("1"), Method: "eth_sendRawTransaction", JSONRPC: "2.0"}}
+
+	t.Run("all backends fail increments exactly once", func(t *testing.T) {
+		s1 := newServer(http.StatusServiceUnavailable, `{"error":"down"}`)
+		s2 := newServer(http.StatusServiceUnavailable, `{"error":"down"}`)
+		defer s1.Close()
+		defer s2.Close()
+
+		bg := &BackendGroup{
+			Name: "group",
+			Backends: []*Backend{
+				NewBackend("b1", s1.URL, "", semaphore.NewWeighted(100)),
+				NewBackend("b2", s2.URL, "", semaphore.NewWeighted(100)),
+			},
+		}
+
+		before := getUnserviceableRequestCount(RPCRequestSourceHTTP)
+		resp := bg.ExecuteMulticall(context.Background(), req)
+		require.Error(t, resp.error)
+		require.True(t, errors.Is(resp.error, ErrNoBackends))
+		after := getUnserviceableRequestCount(RPCRequestSourceHTTP)
+
+		require.Equal(t, float64(1), after-before,
+			"a fully-unserviceable multicall must increment the counter exactly once")
+	})
+
+	t.Run("a successful backend does not increment", func(t *testing.T) {
+		s1 := newServer(http.StatusServiceUnavailable, `{"error":"down"}`)
+		s2 := newServer(http.StatusOK, `{"jsonrpc":"2.0","result":"0x123","id":1}`)
+		defer s1.Close()
+		defer s2.Close()
+
+		bg := &BackendGroup{
+			Name: "group",
+			Backends: []*Backend{
+				NewBackend("b1", s1.URL, "", semaphore.NewWeighted(100)),
+				NewBackend("b2", s2.URL, "", semaphore.NewWeighted(100)),
+			},
+		}
+
+		before := getUnserviceableRequestCount(RPCRequestSourceHTTP)
+		resp := bg.ExecuteMulticall(context.Background(), req)
+		require.NoError(t, resp.error)
+		after := getUnserviceableRequestCount(RPCRequestSourceHTTP)
+
+		require.Equal(t, float64(0), after-before,
+			"a served multicall must not increment the unserviceable counter")
+	})
+}
+
+// TestForwardUnserviceableMetric covers the normal (non-multicall) routing
+// path: ForwardRequestToBackendGroup is invoked once with the full backend
+// list, so the unserviceable counter must increment exactly once when every
+// backend fails, and never when any backend serves the request.
+func TestForwardUnserviceableMetric(t *testing.T) {
+	newServer := func(status int, body string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(body))
+		}))
+	}
+
+	req := []*RPCReq{{ID: []byte("1"), Method: "eth_blockNumber", JSONRPC: "2.0"}}
+
+	t.Run("all backends fail increments exactly once", func(t *testing.T) {
+		s1 := newServer(http.StatusServiceUnavailable, `{"error":"down"}`)
+		s2 := newServer(http.StatusServiceUnavailable, `{"error":"down"}`)
+		defer s1.Close()
+		defer s2.Close()
+
+		bg := &BackendGroup{
+			Name: "group",
+			Backends: []*Backend{
+				NewBackend("b1", s1.URL, "", semaphore.NewWeighted(100)),
+				NewBackend("b2", s2.URL, "", semaphore.NewWeighted(100)),
+			},
+		}
+		require.NotEqual(t, MulticallRoutingStrategy, bg.GetRoutingStrategy())
+
+		before := getUnserviceableRequestCount(RPCRequestSourceHTTP)
+		_, _, err := bg.Forward(context.Background(), req, false)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrNoBackends))
+		after := getUnserviceableRequestCount(RPCRequestSourceHTTP)
+
+		require.Equal(t, float64(1), after-before,
+			"a fully-unserviceable forward must increment the counter exactly once regardless of backend count")
+	})
+
+	t.Run("a successful backend does not increment", func(t *testing.T) {
+		s1 := newServer(http.StatusServiceUnavailable, `{"error":"down"}`)
+		s2 := newServer(http.StatusOK, `{"jsonrpc":"2.0","result":"0x123","id":1}`)
+		defer s1.Close()
+		defer s2.Close()
+
+		bg := &BackendGroup{
+			Name: "group",
+			Backends: []*Backend{
+				NewBackend("b1", s1.URL, "", semaphore.NewWeighted(100)),
+				NewBackend("b2", s2.URL, "", semaphore.NewWeighted(100)),
+			},
+		}
+
+		before := getUnserviceableRequestCount(RPCRequestSourceHTTP)
+		_, _, err := bg.Forward(context.Background(), req, false)
+		require.NoError(t, err)
+		after := getUnserviceableRequestCount(RPCRequestSourceHTTP)
+
+		require.Equal(t, float64(0), after-before,
+			"a served forward must not increment the unserviceable counter")
+	})
+}
+
+func getUnserviceableRequestCount(requestSource string) float64 {
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		return 0
+	}
+
+	var total float64
+	for _, mf := range metricFamilies {
+		if mf.GetName() != "proxyd_unserviceable_requests_total" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "request_source" && label.GetValue() == requestSource {
+					total += metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return total
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A clear and concise description of the features you're adding in this pull request.

**Tests**

Before this PR

```
❯ git checkout main                                         
Switched to branch 'main'
Your branch is up to date with 'origin/main'.

❯ go test ./ -run 'TestExecuteMulticallUnserviceableMetric|TestForwardUnserviceableMetric' -v
=== RUN   TestExecuteMulticallUnserviceableMetric
=== RUN   TestExecuteMulticallUnserviceableMetric/all_backends_fail_increments_exactly_once
    multicall_unserviceable_test.go:49: 
                Error Trace:    /Users/ykukreja/OPLabs/Projects/infra/proxyd/multicall_unserviceable_test.go:49
                Error:          Not equal: 
                                expected: 1
                                actual  : 2
                Test:           TestExecuteMulticallUnserviceableMetric/all_backends_fail_increments_exactly_once
                Messages:       a fully-unserviceable multicall must increment the counter exactly once
=== RUN   TestExecuteMulticallUnserviceableMetric/a_successful_backend_does_not_increment
    multicall_unserviceable_test.go:72: 
                Error Trace:    /Users/ykukreja/OPLabs/Projects/infra/proxyd/multicall_unserviceable_test.go:72
                Error:          Not equal: 
                                expected: 0
                                actual  : 1
                Test:           TestExecuteMulticallUnserviceableMetric/a_successful_backend_does_not_increment
                Messages:       a served multicall must not increment the unserviceable counter
--- FAIL: TestExecuteMulticallUnserviceableMetric (0.00s)
    --- FAIL: TestExecuteMulticallUnserviceableMetric/all_backends_fail_increments_exactly_once (0.00s)
    --- FAIL: TestExecuteMulticallUnserviceableMetric/a_successful_backend_does_not_increment (0.00s)
=== RUN   TestForwardUnserviceableMetric
=== RUN   TestForwardUnserviceableMetric/all_backends_fail_increments_unserviceable_counter_exactly_once
=== RUN   TestForwardUnserviceableMetric/at_least_one_successful_backend_does_not_increment_unserviceable_counter
--- PASS: TestForwardUnserviceableMetric (0.00s)
    --- PASS: TestForwardUnserviceableMetric/all_backends_fail_increments_unserviceable_counter_exactly_once (0.00s)
    --- PASS: TestForwardUnserviceableMetric/at_least_one_successful_backend_does_not_increment_unserviceable_counter (0.00s)
FAIL
FAIL    github.com/ethereum-optimism/infra/proxyd       0.729s
FAIL
```

After this PR


```
❯ git checkout yash/proxyd-fix-unserviceable-requests-metric
Switched to branch 'yash/proxyd-fix-unserviceable-requests-metric'
Your branch is behind 'origin/yash/proxyd-fix-unserviceable-requests-metric' by 1 commit, and can be fast-forwarded.
  (use "git pull" to update your local branch)

❯ go test ./ -run 'TestExecuteMulticallUnserviceableMetric|TestForwardUnserviceableMetric' -v
=== RUN   TestExecuteMulticallUnserviceableMetric
=== RUN   TestExecuteMulticallUnserviceableMetric/all_backends_fail_increments_exactly_once
=== RUN   TestExecuteMulticallUnserviceableMetric/a_successful_backend_does_not_increment
--- PASS: TestExecuteMulticallUnserviceableMetric (0.00s)
    --- PASS: TestExecuteMulticallUnserviceableMetric/all_backends_fail_increments_exactly_once (0.00s)
    --- PASS: TestExecuteMulticallUnserviceableMetric/a_successful_backend_does_not_increment (0.00s)
=== RUN   TestForwardUnserviceableMetric
=== RUN   TestForwardUnserviceableMetric/all_backends_fail_increments_unserviceable_counter_exactly_once
=== RUN   TestForwardUnserviceableMetric/at_least_one_successful_backend_does_not_increment_unserviceable_counter
--- PASS: TestForwardUnserviceableMetric (0.00s)
    --- PASS: TestForwardUnserviceableMetric/all_backends_fail_increments_unserviceable_counter_exactly_once (0.00s)
    --- PASS: TestForwardUnserviceableMetric/at_least_one_successful_backend_does_not_increment_unserviceable_counter (0.00s)
PASS
ok      github.com/ethereum-optimism/infra/proxyd       0.887s
```

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
