### PR TITLE
fix(op-ufm): dont mark missing txs as seen

### DIFF
--- a/op-ufm/pkg/provider/heartbeat.go
+++ b/op-ufm/pkg/provider/heartbeat.go
@@ -71,9 +71,7 @@ func (p *Provider) Heartbeat(ctx context.Context) {
 				"hash", hash,
 				"url", p.config.URL,
 				"err", err)
-			if !errors.Is(err, ethereum.NotFound) {
-				continue
-			}
+			continue
 		}
 
 		log.Debug("got transaction",


### PR DESCRIPTION
Previously, if a provider responded with `ethereum.NotFound` for an `eth_getTransactionByHash` request, op-ufm still marked the tx as seen by that provider. This caused `ufm_first_seen_latency` and `ufm_provider_to_provider_latency` to be recorded for txs that had not actually propagated to the provider.

This PR treats `ethereum.NotFound` as “not seen yet” and skips the seen/latency accounting for that heartbeat attempt.