### PR TITLE
fix(proxyd): log unexpected block tags as decimal not hex

### DIFF
--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -463,11 +463,11 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 	if !expectedBlockTags && !be.forcedCandidate {
 		log.Warn("backend banned - unexpected block tags",
 			"backend", be.Name,
-			"oldFinalized", bs.finalizedBlockNumber,
-			"finalizedBlockNumber", finalizedBlockNumber,
-			"oldSafe", bs.safeBlockNumber,
-			"safeBlockNumber", safeBlockNumber,
-			"latestBlockNumber", latestBlockNumber,
+			"oldFinalized", uint64(bs.finalizedBlockNumber),
+			"finalizedBlockNumber", uint64(finalizedBlockNumber),
+			"oldSafe", uint64(bs.safeBlockNumber),
+			"safeBlockNumber", uint64(safeBlockNumber),
+			"latestBlockNumber", uint64(latestBlockNumber),
 		)
 		if cp.consensusLayer {
 			RecordCLBanUnexpectedBlockTags(be)


### PR DESCRIPTION
## Summary
The `backend banned - unexpected block tags` warning logged block numbers as `hexutil.Uint64`, which renders as hex (e.g. `0x1a2b3c`). Cast to `uint64` so they log as decimal ints for easier reading.

## Changes
- `consensus_poller.go`: cast the five block-number log fields to `uint64`.