### PR TITLE
fix(proxyd): tighten interop access-list descriptor timestamp

### DIFF
--- a/proxyd/interop.go
+++ b/proxyd/interop.go
@@ -48,7 +48,14 @@ func validateAndDeduplicateInteropAccessList(entriesToParse []common.Hash) ([]co
 	return deduplicatedAccessListEntries, nil
 }
 
+const (
+	// Clock-skew tolerance only; the executing message's later block is the real lower bound.
+	interopExecutingDescriptorClockToleranceSeconds uint64 = 30
+
+	// Expiry-window margin; matches op-reth's CHECK_ACCESS_LIST_TIMEOUT_SECS.
+	interopExecutingDescriptorTimeoutSeconds uint64 = 7200
+)
+
 func getInteropExecutingDescriptorTimestamp() uint64 {
-	// intentionally kept to be slightly in the future (but within the expiryAt of the associated message) to proceed through the access-list time-checks
-	return uint64(time.Now().Unix() + 1000)
+	return uint64(time.Now().Unix()) + interopExecutingDescriptorClockToleranceSeconds
 }

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -549,6 +549,7 @@ func performCheckAccessListOp(ctx context.Context, accessList []common.Hash, url
 	err = validatingBackend.CheckAccessList(ctx, accessList, safety.CrossUnsafe, messages.ExecutingDescriptor{
 		ChainID:   chainID,
 		Timestamp: getInteropExecutingDescriptorTimestamp(),
+		Timeout:   interopExecutingDescriptorTimeoutSeconds,
 	})
 
 	var httpCode int

--- a/proxyd/interop_strategy_test.go
+++ b/proxyd/interop_strategy_test.go
@@ -2,6 +2,7 @@ package proxyd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	interopErrors "github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -367,4 +370,34 @@ func TestDefinitiveInteropRejection_Classification(t *testing.T) {
 		"a soft out-of-sync FutureData failure is not a verdict")
 	require.False(t, isDefinitiveInteropRejection(&RPCErr{Code: uninitializedRPCCode, HTTPErrorCode: 400}),
 		"a soft out-of-sync Uninitialized failure is not a verdict")
+}
+
+// Descriptor must carry a near-future timestamp (clock skew only) and op-reth's expiry timeout.
+func TestExecutingDescriptor_NearFutureTimestampAndExpiryTimeout(t *testing.T) {
+	var got messages.ExecutingDescriptor
+	captured := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Params []json.RawMessage `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		require.Len(t, req.Params, 3)
+		require.NoError(t, json.Unmarshal(req.Params[2], &got))
+		captured <- struct{}{}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(validInteropFilterResponse))
+	}))
+	t.Cleanup(srv.Close)
+
+	before := uint64(time.Now().Unix())
+	_, _, err := performCheckAccessListOp(context.Background(), testAccessList, srv.URL, eth.ChainIDFromUInt64(420120003))
+	require.NoError(t, err)
+	<-captured
+	after := uint64(time.Now().Unix())
+
+	require.Equal(t, interopExecutingDescriptorTimeoutSeconds, got.Timeout, "timeout should match op-reth's expiry margin")
+	require.GreaterOrEqual(t, got.Timestamp, before+interopExecutingDescriptorClockToleranceSeconds)
+	require.LessOrEqual(t, got.Timestamp, after+interopExecutingDescriptorClockToleranceSeconds,
+		"timestamp must be near-future (clock skew only), not a large forward window")
 }


### PR DESCRIPTION
proxyd validated interop executing-message txs against op-interop-filter with an `ExecutingDescriptor` of `{Timestamp: now+1000, Timeout: 0}`.

The filter enforces the timestamp invariant `init_ts < inclusion_ts` against `descriptor.Timestamp` (Rule 1), and uses `Timeout` only for the expiry-window margin (Rule 4). Setting `Timestamp = now+1000` made Rule 1 a near-no-op — accepting initiating messages up to 1000s in the future — and left the expiry margin as a side effect of that same inflated value.

This change:
- `Timestamp = now + 30s` — clock-skew tolerance only, so it stays a tight near-future lower bound. It must be slightly ahead of `now` (not `now`) because the executing message lands in a *later* block, and proxyd is a one-shot accept/reject gateway, so it must still admit references to messages in the chain's current head (timestamp ~now).
- `Timeout = 7200` — matches op-reth's `CHECK_ACCESS_LIST_TIMEOUT_SECS`, moving the expiry-window margin to where it belongs and aligning proxyd's admission with the EL's.

The filter's lockstep cross-validation remains the authoritative backstop; this tightens proxyd's own check so it isn't relying on a 1000s future window.