### PR TITLE
proxyd: Fix a race between reading results and draining discarded ones in multi call strategy

### DIFF
--- a/proxyd/Makefile
+++ b/proxyd/Makefile
@@ -25,6 +25,10 @@ test:
 	go test -v ./...
 .PHONY: test
 
+test-race:
+	go test -race ./...
+.PHONY: test-race
+
 lint:
 	golangci-lint run ./...
 .PHONY: lint

--- a/proxyd/interop_strategy.go
+++ b/proxyd/interop_strategy.go
@@ -157,31 +157,17 @@ func (s *multicallStrategyImpl) ValidateAccessList(ctx context.Context, interopA
 		return nil
 	}
 
+	// Buffer one slot per backend so every sender can deliver its result without
+	// blocking, even after we return early on the first success and stop
+	// receiving. Senders complete and exit on their own.
 	resultChan := make(chan error, len(s.urls))
 	// concurrently broadcast the checkAccessList operation to all the validating backends
-	var wg sync.WaitGroup
 	for _, url := range s.urls {
-		wg.Add(1)
 		go func(ctx context.Context, url string) {
-			defer wg.Done()
 			_, _, err := performCheckAccessListOp(ctx, accessListToValidate, url, s.chainID)
 			resultChan <- err
 		}(ctx, url)
 	}
-
-	// goroutine which waits for all the sender goroutines created above to be done, and drain and close the resultChan
-	go func() {
-		wg.Wait()
-		log.Debug(
-			"all interop validating backends have responded",
-			"source", "rpc",
-			"req_id", GetReqID(ctx),
-			"method", "eth_sendRawTransaction",
-		)
-		for range resultChan {
-		} // drain the channel
-		close(resultChan)
-	}()
 
 	// Success: if at least one backend responds successfully
 	// Failure: the first error response if all the backends respond with an error

--- a/proxyd/interop_strategy_test.go
+++ b/proxyd/interop_strategy_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -400,4 +402,41 @@ func TestExecutingDescriptor_NearFutureTimestampAndExpiryTimeout(t *testing.T) {
 	require.GreaterOrEqual(t, got.Timestamp, before+interopExecutingDescriptorClockToleranceSeconds)
 	require.LessOrEqual(t, got.Timestamp, after+interopExecutingDescriptorClockToleranceSeconds,
 		"timestamp must be near-future (clock skew only), not a large forward window")
+}
+
+func newMulticallStrategy(urls []string) *multicallStrategyImpl {
+	return NewMulticallStrategy(urls,
+		WithChainID(420120003),
+		WithValidateAndDeduplicateInteropAccessList(false),
+	)
+}
+
+// multicallValidateGoroutineRunning reports whether any goroutine is still
+// parked inside multicallStrategyImpl.ValidateAccessList. After the call
+// returns, the broadcast sender goroutines exit on their own; anything left
+// behind is a leak.
+func multicallValidateGoroutineRunning() bool {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Contains(string(buf[:n]), "multicallStrategyImpl).ValidateAccessList")
+}
+
+// TestMulticall_DoesNotLeakGoroutine guards against the dual-receiver pattern:
+// a drainer goroutine that out-lives the call by blocking forever on the
+// result channel (and can steal verdicts from the main collector). The result
+// channel is buffered to the number of backends, so no sender ever blocks even
+// when we return early on the first success, and no drainer is needed.
+func TestMulticall_DoesNotLeakGoroutine(t *testing.T) {
+	urls := []string{
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
+		newInteropFilterServer(t, 200, validInteropFilterResponse, 0),
+	}
+	s := newMulticallStrategy(urls)
+	require.NoError(t, s.ValidateAccessList(context.Background(), testAccessList))
+
+	require.Eventually(t, func() bool {
+		return !multicallValidateGoroutineRunning()
+	}, 2*time.Second, 20*time.Millisecond,
+		"multicall strategy leaked a goroutine blocked on its result channel")
 }


### PR DESCRIPTION
The drain isn't required as the channel is big enough to hold all responses anyway. Previously there would be a race between the two readers. This could result in a deadlock if all responses returned an error causing the result reader to actually read all responses if the last one was actually read by the draining thread that was unblocked when the last response was _written_ (but possibly not yet read).