### PR TITLE
ci: add beta parallel apko image builds

### DIFF
--- a/.github/images.apko.json
+++ b/.github/images.apko.json
@@ -1,0 +1,168 @@
+{
+  "shared_paths": [
+    ".github/images.apko.json",
+    ".github/workflows/build-images.apko.yaml",
+    "melange/pipelines/**",
+    "go.mod"
+  ],
+  "melange_archs": [
+    "x86_64",
+    "aarch64"
+  ],
+  "apko_archs": "amd64,arm64",
+  "release": {
+    "tag_regex": "^([^/]+)/(v.+)$",
+    "service_match": 1,
+    "version_match": 2,
+    "publish_tag": "${version}",
+    "source_ref": "${ref_name}"
+  },
+  "default_runners": {
+    "x86_64": "ubuntu-24.04",
+    "aarch64": "ubuntu-24.04-arm"
+  },
+  "melange": {
+    "cci-stats": {},
+    "op-conductor-mon": {},
+    "op-signer": {},
+    "op-txproxy": {},
+    "op-ufm": {},
+    "peer-mgmt-service": {},
+    "proxyd": {},
+    "op-conductor-ops": {},
+    "replica-healthcheck": {},
+    "circleci-runner": {}
+  },
+  "images": {
+    "cci-stats": {
+      "needs_melange": [
+        "cci-stats"
+      ],
+      "paths": [
+        "cci-stats/**"
+      ],
+      "nexus_paths": [
+        "melange/cci-stats.yaml",
+        "apko/cci-stats.yaml"
+      ],
+      "smoke_test": "cci-stats --help"
+    },
+    "op-conductor-mon": {
+      "needs_melange": [
+        "op-conductor-mon"
+      ],
+      "paths": [
+        "op-conductor-mon/**"
+      ],
+      "nexus_paths": [
+        "melange/op-conductor-mon.yaml",
+        "apko/op-conductor-mon.yaml"
+      ],
+      "smoke_test": "op-conductor-mon --help"
+    },
+    "op-signer": {
+      "needs_melange": [
+        "op-signer"
+      ],
+      "paths": [
+        "op-signer/**"
+      ],
+      "nexus_paths": [
+        "melange/op-signer.yaml",
+        "apko/op-signer.yaml"
+      ],
+      "smoke_test": "op-signer --help"
+    },
+    "op-txproxy": {
+      "needs_melange": [
+        "op-txproxy"
+      ],
+      "paths": [
+        "op-txproxy/**"
+      ],
+      "nexus_paths": [
+        "melange/op-txproxy.yaml",
+        "apko/op-txproxy.yaml"
+      ],
+      "smoke_test": "op-txproxy --help"
+    },
+    "op-ufm": {
+      "needs_melange": [
+        "op-ufm"
+      ],
+      "paths": [
+        "op-ufm/**"
+      ],
+      "nexus_paths": [
+        "melange/op-ufm.yaml",
+        "apko/op-ufm.yaml"
+      ],
+      "smoke_test": "ufm --help"
+    },
+    "peer-mgmt-service": {
+      "needs_melange": [
+        "peer-mgmt-service"
+      ],
+      "paths": [
+        "peer-mgmt-service/**"
+      ],
+      "nexus_paths": [
+        "melange/peer-mgmt-service.yaml",
+        "apko/peer-mgmt-service.yaml"
+      ],
+      "smoke_test": "pms --help"
+    },
+    "proxyd": {
+      "needs_melange": [
+        "proxyd"
+      ],
+      "paths": [
+        "proxyd/**"
+      ],
+      "nexus_paths": [
+        "melange/proxyd.yaml",
+        "apko/proxyd.yaml"
+      ],
+      "smoke_test": "proxyd --help"
+    },
+    "op-conductor-ops": {
+      "needs_melange": [
+        "op-conductor-ops"
+      ],
+      "paths": [
+        "op-conductor-ops/**"
+      ],
+      "nexus_paths": [
+        "melange/op-conductor-ops.yaml",
+        "apko/op-conductor-ops.yaml"
+      ],
+      "smoke_test": "op-conductor-ops --help"
+    },
+    "replica-healthcheck": {
+      "needs_melange": [
+        "replica-healthcheck"
+      ],
+      "paths": [
+        "replica-healthcheck/**"
+      ],
+      "nexus_paths": [
+        "melange/replica-healthcheck.yaml",
+        "apko/replica-healthcheck.yaml"
+      ],
+      "smoke_test": "node --version"
+    },
+    "circleci-runner-wolfi": {
+      "type": "base",
+      "needs_melange": [
+        "circleci-runner"
+      ],
+      "paths": [],
+      "nexus_paths": [
+        "melange/circleci-runner.yaml",
+        "melange/pipelines/circleci-runner/**",
+        "apko/circleci-runner-wolfi.yaml"
+      ],
+      "smoke_test": "mise --version,go version,rustc --version,cargo --version,sccache --version,clang --version,mold --version,protoc --version,cc --version,pkg-config --version,git --version,bash --version"
+    }
+  }
+}

--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -1,0 +1,150 @@
+name: build-images.apko
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*/v*"
+    paths:
+      - ".github/images.apko.json"
+      - ".github/workflows/build-images.apko.yaml"
+      - "melange/**"
+      - "apko/**"
+      - "go.mod"
+      - "cci-stats/**"
+      - "op-conductor-mon/**"
+      - "op-conductor-ops/**"
+      - "op-signer/**"
+      - "op-txproxy/**"
+      - "op-ufm/**"
+      - "peer-mgmt-service/**"
+      - "proxyd/**"
+      - "replica-healthcheck/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/images.apko.json"
+      - ".github/workflows/build-images.apko.yaml"
+      - "melange/**"
+      - "apko/**"
+      - "go.mod"
+      - "cci-stats/**"
+      - "op-conductor-mon/**"
+      - "op-conductor-ops/**"
+      - "op-signer/**"
+      - "op-txproxy/**"
+      - "op-ufm/**"
+      - "peer-mgmt-service/**"
+      - "proxyd/**"
+      - "replica-healthcheck/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  SOURCE_DATE_EPOCH: 0
+
+jobs:
+  plan:
+    name: plan
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    outputs:
+      melange_matrix_json: ${{ steps.plan.outputs.melange_matrix_json }}
+      apko_matrix_json: ${{ steps.plan.outputs.apko_matrix_json }}
+      smoke_matrix_json: ${{ steps.plan.outputs.smoke_matrix_json }}
+      has_builds: ${{ steps.plan.outputs.has_builds }}
+      is_release: ${{ steps.plan.outputs.is_release }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Plan melange, apko, and smoke matrices
+        id: plan
+        uses: ethereum-optimism/factory/actions/apko-plan@32cc2090b11d510e3babad942b62b99defccfca1
+        with:
+          config: .github/images.apko.json
+
+  melange:
+    name: melange (${{ matrix.stack }}, ${{ matrix.arch }})
+    needs: plan
+    if: needs.plan.outputs.has_builds == 'true' && needs.plan.outputs.melange_matrix_json != '[]'
+    strategy:
+      fail-fast: true
+      matrix:
+        include: ${{ fromJson(needs.plan.outputs.melange_matrix_json) }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@32cc2090b11d510e3babad942b62b99defccfca1
+    with:
+      stack: ${{ matrix.stack }}
+      arch: ${{ matrix.arch }}
+      runner: ${{ matrix.runner }}
+      melange-config: ${{ matrix.melange_config }}
+      source-repository: ${{ matrix.source_repository }}
+      source-ref: ${{ matrix.source_ref }}
+      source-path: ${{ matrix.source_path }}
+      checkout-source: ${{ matrix.checkout_source }}
+      source-submodules: ${{ matrix.source_submodules }}
+      use-github-app-token: ${{ matrix.use_github_app_token }}
+      use-gha-cache: ${{ matrix.use_gha_cache }}
+      cache-key-files: ${{ matrix.cache_key_files }}
+
+  apko:
+    name: apko (${{ matrix.service }})
+    needs: [plan, melange]
+    if: |
+      always() &&
+      needs.plan.outputs.has_builds == 'true' &&
+      (needs.melange.result == 'success' || needs.melange.result == 'skipped')
+    strategy:
+      fail-fast: true
+      matrix:
+        include: ${{ fromJson(needs.plan.outputs.apko_matrix_json) }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+      actions: read
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@32cc2090b11d510e3babad942b62b99defccfca1
+    with:
+      service: ${{ matrix.service }}
+      needs-melange-apks: ${{ matrix.needs_melange_apks }}
+      registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus
+      publish-tag: ${{ matrix.publish_tag }}
+      archs: ${{ matrix.archs }}
+
+  smoke-test:
+    name: smoke test (${{ matrix.service }}, ${{ matrix.arch }})
+    needs: [plan, apko]
+    if: |
+      always() &&
+      needs.plan.outputs.has_builds == 'true' &&
+      needs.plan.outputs.smoke_matrix_json != '[]' &&
+      needs.apko.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.plan.outputs.smoke_matrix_json) }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@32cc2090b11d510e3babad942b62b99defccfca1
+    with:
+      service: ${{ matrix.service }}
+      registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus
+      arch: ${{ matrix.arch }}
+      runner: ${{ matrix.runner }}
+      smoke-test: ${{ matrix.smoke_test }}

--- a/apko/cci-stats.yaml
+++ b/apko/cci-stats.yaml
@@ -1,0 +1,30 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - cci-stats@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/cci-stats
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/infra
+  org.opencontainers.image.title: cci-stats

--- a/apko/circleci-runner-wolfi.yaml
+++ b/apko/circleci-runner-wolfi.yaml
@@ -52,7 +52,31 @@ accounts:
     - username: circleci
       uid: 1001
       gid: 1001
+      homedir: /home/circleci
+      shell: /bin/bash
   run-as: 1001
+
+paths:
+  - path: /home/circleci
+    type: permissions
+    uid: 1001
+    gid: 1001
+    permissions: 0o755
+  - path: /home/circleci/.local
+    type: permissions
+    uid: 1001
+    gid: 1001
+    permissions: 0o755
+  - path: /home/circleci/.local/bin
+    type: permissions
+    uid: 1001
+    gid: 1001
+    permissions: 0o755
+  - path: /home/circleci/.local/bin/mise
+    type: permissions
+    uid: 1001
+    gid: 1001
+    permissions: 0o755
 
 entrypoint:
   command: /bin/bash

--- a/apko/circleci-runner-wolfi.yaml
+++ b/apko/circleci-runner-wolfi.yaml
@@ -1,0 +1,63 @@
+# Wolfi/apko CircleCI base image. Ships the clang/libclang toolchain,
+# protobuf toolchain, sccache, and Go/Rust tools used by CI jobs.
+# Unlike a service image this is a base: no single entrypoint, and it provides
+# a non-root `circleci` user (uid 1001) and the shell/coreutils/git exec
+# environment CircleCI jobs assume in place of cimg/base.
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    # CircleCI runtime / exec environment (parity with cimg/base)
+    - wolfi-baselayout
+    - ca-certificates-bundle
+    - glibc
+    - libgcc
+    - libstdc++
+    - busybox
+    - bash
+    - coreutils
+    - git
+    - openssh-client
+    - curl
+    # Toolchain (mirrors the Dockerfile apt package set)
+    - build-base            # build-essential / gcc toolchain
+    - clang-19              # clang + /usr/lib/libclang.so for bindgen (reth-mdbx-sys)
+    - libclang-cpp-19       # libclang-cpp runtime
+    - mold                  # faster linker used by Rust jobs
+    - protoc                # protobuf-compiler
+    - protobuf-dev          # libprotobuf-dev, including google/protobuf/*.proto
+    - sqlite-dev            # libsqlite3-dev
+    - tpm2-tss-dev          # libtss2-dev
+    - pkgconf               # pkg-config
+    - sccache               # Wolfi-maintained sccache (replaces pinned 0.9.1)
+    # CircleCI / mise-managed toolchain baseline
+    - circleci-runner
+    - go-1.26
+    - rust-1.94
+
+environment:
+  PATH: /home/circleci/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  HOME: /home/circleci
+
+# CircleCI jobs expect a non-root `circleci` user (uid 1001, as in cimg/base)
+# with a writable home for rustup/cargo.
+accounts:
+  groups:
+    - groupname: circleci
+      gid: 1001
+  users:
+    - username: circleci
+      uid: 1001
+      gid: 1001
+  run-as: 1001
+
+entrypoint:
+  command: /bin/bash
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/infra
+  org.opencontainers.image.title: circleci-runner-wolfi
+  org.opencontainers.image.description: CircleCI base image with clang, protobuf, sccache, mise, Go, and Rust for Optimism CI jobs

--- a/apko/op-conductor-mon.yaml
+++ b/apko/op-conductor-mon.yaml
@@ -1,0 +1,30 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-conductor-mon@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/op-conductor-mon
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/infra
+  org.opencontainers.image.title: op-conductor-mon

--- a/apko/op-conductor-ops.yaml
+++ b/apko/op-conductor-ops.yaml
@@ -1,0 +1,37 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - python-3.12
+    # Runtime deps (poetry deps aren't installed by the wheel build); apk pulls
+    # transitive deps (click, rich, typing-extensions) automatically.
+    - py3.12-requests
+    - py3.12-typer
+    - py3.12-toml
+    - op-conductor-ops@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  PYTHONUNBUFFERED: "1"
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/op-conductor-ops
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/infra
+  org.opencontainers.image.title: op-conductor-ops

--- a/apko/op-signer.yaml
+++ b/apko/op-signer.yaml
@@ -1,0 +1,34 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - glibc
+    - libgcc
+    - op-signer@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+work-dir: /app
+
+entrypoint:
+  command: /usr/bin/op-signer
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/infra
+  org.opencontainers.image.title: op-signer

--- a/apko/op-txproxy.yaml
+++ b/apko/op-txproxy.yaml
@@ -1,0 +1,30 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-txproxy@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/op-txproxy
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/infra
+  org.opencontainers.image.title: op-txproxy

--- a/apko/op-ufm.yaml
+++ b/apko/op-ufm.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - glibc
+    - libgcc
+    - op-ufm@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/ufm
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/infra
+  org.opencontainers.image.title: op-ufm

--- a/apko/peer-mgmt-service.yaml
+++ b/apko/peer-mgmt-service.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - glibc
+    - libgcc
+    - peer-mgmt-service@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/pms
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/infra
+  org.opencontainers.image.title: peer-mgmt-service

--- a/apko/proxyd.yaml
+++ b/apko/proxyd.yaml
@@ -1,0 +1,32 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - glibc
+    - libgcc
+    - proxyd@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/proxyd
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/infra
+  org.opencontainers.image.title: proxyd

--- a/apko/replica-healthcheck.yaml
+++ b/apko/replica-healthcheck.yaml
@@ -1,0 +1,33 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - nodejs-22
+    - replica-healthcheck@local
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  NODE_ENV: production
+  NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/extra-ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: node /usr/share/replica-healthcheck/dist/src/service.js
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/infra
+  org.opencontainers.image.title: replica-healthcheck

--- a/melange/cci-stats.yaml
+++ b/melange/cci-stats.yaml
@@ -1,0 +1,31 @@
+package:
+  name: cci-stats
+  version: "0.0.0"
+  epoch: 0
+  description: cci-stats — CI statistics runner
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: go/build
+    with:
+      modroot: cci-stats
+      packages: ./cmd/runner
+      output: cci-stats
+      go-package: go-1.26
+      ldflags: -s -w
+
+  - uses: strip

--- a/melange/circleci-runner.yaml
+++ b/melange/circleci-runner.yaml
@@ -1,0 +1,23 @@
+package:
+  name: circleci-runner
+  version: "2026.2.2"
+  epoch: 0
+  description: CircleCI runner tooling for Optimism CI jobs
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+
+pipeline:
+  - uses: circleci-runner/install
+
+  - uses: strip

--- a/melange/op-conductor-mon.yaml
+++ b/melange/op-conductor-mon.yaml
@@ -1,0 +1,38 @@
+package:
+  name: op-conductor-mon
+  version: "0.0.0"
+  epoch: 0
+  description: op-conductor-mon — OP Stack conductor monitor
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: go/build
+    with:
+      modroot: op-conductor-mon
+      packages: ./cmd/monitor
+      output: op-conductor-mon
+      go-package: go-1.26
+      ldflags: -s -w -checklinkname=0
+
+  # The k8s chart invokes command: ["/app/op-conductor-mon", ...] (legacy WORKDIR
+  # convention). go/build installs to /usr/bin; add a /app compat symlink so the
+  # image is drop-in for the existing chart.
+  - runs: |
+      install -d "${{targets.destdir}}/app"
+      ln -sf /usr/bin/op-conductor-mon "${{targets.destdir}}/app/op-conductor-mon"
+
+  - uses: strip

--- a/melange/op-conductor-ops.yaml
+++ b/melange/op-conductor-ops.yaml
@@ -1,0 +1,29 @@
+package:
+  name: op-conductor-ops
+  version: "0.0.0"
+  epoch: 0
+  description: op-conductor-ops — CLI for managing OP Conductor sequencer clusters
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - python-3.12
+      - py3.12-build
+      - py3.12-installer
+      - py3.12-pip
+      - py3.12-setuptools
+      - py3.12-poetry-core
+
+pipeline:
+  - uses: python/build-wheel
+    working-directory: op-conductor-ops
+
+  - uses: strip

--- a/melange/op-signer.yaml
+++ b/melange/op-signer.yaml
@@ -1,0 +1,35 @@
+package:
+  name: op-signer
+  version: "0.0.0"
+  epoch: 0
+  description: op-signer — OP Stack transaction signer
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+  environment:
+    CGO_ENABLED: "1"
+
+pipeline:
+  - uses: go/build
+    with:
+      modroot: op-signer
+      packages: ./cmd
+      output: op-signer
+      go-package: go-1.26
+      ldflags: -s -w
+
+  - uses: app-compat/install-to-app
+    with:
+      binary-name: op-signer
+
+  - uses: strip

--- a/melange/op-txproxy.yaml
+++ b/melange/op-txproxy.yaml
@@ -1,0 +1,31 @@
+package:
+  name: op-txproxy
+  version: "0.0.0"
+  epoch: 0
+  description: op-txproxy — OP Stack transaction proxy
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: go/build
+    with:
+      modroot: op-txproxy
+      packages: ./cmd
+      output: op-txproxy
+      go-package: go-1.26
+      ldflags: -s -w
+
+  - uses: strip

--- a/melange/op-ufm.yaml
+++ b/melange/op-ufm.yaml
@@ -1,0 +1,31 @@
+package:
+  name: op-ufm
+  version: "0.0.0"
+  epoch: 0
+  description: op-ufm — OP Stack uptime fault monitor
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+  environment:
+    CGO_ENABLED: "1"
+
+pipeline:
+  - uses: go/build
+    with:
+      modroot: op-ufm
+      packages: ./cmd/ufm
+      output: ufm
+      go-package: go-1.26
+      ldflags: -s -w
+
+  - uses: strip

--- a/melange/peer-mgmt-service.yaml
+++ b/melange/peer-mgmt-service.yaml
@@ -1,0 +1,35 @@
+package:
+  name: peer-mgmt-service
+  version: "0.0.0"
+  epoch: 0
+  description: peer-mgmt-service — OP Stack peer management service
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+  environment:
+    CGO_ENABLED: "1"
+
+pipeline:
+  - uses: go/build
+    with:
+      modroot: peer-mgmt-service
+      packages: ./cmd/pms
+      output: pms
+      go-package: go-1.26
+      ldflags: -s -w
+
+  - uses: app-compat/install-to-app
+    with:
+      binary-name: pms
+
+  - uses: strip

--- a/melange/pipelines/app-compat/install-to-app.yaml
+++ b/melange/pipelines/app-compat/install-to-app.yaml
@@ -1,0 +1,15 @@
+name: Install binary symlink under /app for Helm chart compatibility.
+
+# Helm charts for OP Stack infra services expect binaries at /app/<name>.
+# Melange's go/build installs to /usr/bin/<name>. This pipeline creates a
+# /app/<name> → /usr/bin/<name> symlink so both paths work.
+
+inputs:
+  binary-name:
+    description: Binary filename (e.g. "pms"), installed at /usr/bin/<binary-name>
+    required: true
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.destdir}}/app"
+      ln -sf "/usr/bin/${{inputs.binary-name}}" "${{targets.destdir}}/app/${{inputs.binary-name}}"

--- a/melange/pipelines/circleci-runner/install.yaml
+++ b/melange/pipelines/circleci-runner/install.yaml
@@ -1,0 +1,53 @@
+name: Install pinned mise for CircleCI jobs
+
+# The Optimism CircleCI orb expects mise at $HOME/.local/bin/mise. Installing
+# there lets checkout-with-mise short-circuit its network install without
+# breaking the later cache-copy step.
+
+needs:
+  packages:
+    - busybox
+    - ca-certificates-bundle
+    - curl
+
+inputs:
+  version:
+    description: mise version without leading v
+    default: "2026.2.2"
+
+pipeline:
+  - runs: |
+      set -euo pipefail
+
+      case "${{build.arch}}" in
+        x86_64)
+          platform=linux-x64
+          checksum=7d1ffcceb32f861d9d0e00b7ccabe9ee962d6ca51daa7f66715c46b9856169d8
+          ;;
+        aarch64)
+          platform=linux-arm64
+          checksum=86576902e7cb0fe860d192961c6fecc756e585c16420b0c00c9485bc64f8f86d
+          ;;
+        *)
+          echo "unsupported melange arch for mise: ${{build.arch}}" >&2
+          exit 1
+          ;;
+      esac
+
+      archive="mise-v${{inputs.version}}-${platform}.tar.gz"
+      url="https://github.com/jdx/mise/releases/download/v${{inputs.version}}/${archive}"
+      work="$(mktemp -d)"
+      trap 'rm -rf "$work"' EXIT
+
+      curl -fsSL --retry 3 -o "$work/$archive" "$url"
+      printf '%s  %s\n' "$checksum" "$work/$archive" | sha256sum -c -
+      tar -xzf "$work/$archive" -C "$work"
+
+      install -Dm755 \
+        "$work/mise/bin/mise" \
+        "${{targets.contextdir}}/home/circleci/.local/bin/mise"
+
+      mkdir -p "${{targets.contextdir}}/usr/local/bin"
+      ln -sf /home/circleci/.local/bin/mise "${{targets.contextdir}}/usr/local/bin/mise"
+
+      chown -R 1001:1001 "${{targets.contextdir}}/home/circleci"

--- a/melange/pipelines/yarn/build.yaml
+++ b/melange/pipelines/yarn/build.yaml
@@ -1,0 +1,31 @@
+name: Build a standalone yarn application from source.
+
+needs:
+  packages:
+    - busybox
+    - nodejs
+    - yarn
+
+inputs:
+  output:
+    description: "Package name used for the install directory under /usr/share/"
+    required: true
+  subdir:
+    description: "Subdirectory containing the app within the source checkout"
+    default: "."
+  build-cmd:
+    description: "Build command to run"
+    default: "yarn build"
+
+pipeline:
+  - runs: |
+      set -euo pipefail
+      cd ${{inputs.subdir}}
+      yarn install --frozen-lockfile --ignore-scripts
+      ${{inputs.build-cmd}}
+      mkdir -p ${{targets.contextdir}}/usr/share/${{inputs.output}}
+      cp -r dist ${{targets.contextdir}}/usr/share/${{inputs.output}}/
+      cp -r node_modules ${{targets.contextdir}}/usr/share/${{inputs.output}}/
+      cp package.json ${{targets.contextdir}}/usr/share/${{inputs.output}}/
+      find ${{targets.contextdir}}/usr/share/${{inputs.output}}/node_modules -type d -name '*musl*' -exec rm -rf {} + 2>/dev/null || true
+      find ${{targets.contextdir}}/usr/share/${{inputs.output}}/node_modules -type f -name '*musl*.node' -delete 2>/dev/null || true

--- a/melange/proxyd.yaml
+++ b/melange/proxyd.yaml
@@ -1,0 +1,31 @@
+package:
+  name: proxyd
+  version: "0.0.0"
+  epoch: 0
+  description: proxyd — OP Stack RPC request router and proxy
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+  environment:
+    CGO_ENABLED: "1"
+
+pipeline:
+  - uses: go/build
+    with:
+      modroot: proxyd
+      packages: ./cmd/proxyd
+      output: proxyd
+      go-package: go-1.26
+      ldflags: -s -w
+
+  - uses: strip

--- a/melange/replica-healthcheck.yaml
+++ b/melange/replica-healthcheck.yaml
@@ -1,0 +1,26 @@
+package:
+  name: replica-healthcheck
+  version: "0.0.0"
+  epoch: 0
+  description: replica-healthcheck — OP Stack replica health checker
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - nodejs-22
+      - yarn
+      - build-base
+
+pipeline:
+  - uses: yarn/build
+    with:
+      output: replica-healthcheck
+      subdir: replica-healthcheck

--- a/pipelines
+++ b/pipelines
@@ -1,0 +1,1 @@
+melange/pipelines


### PR DESCRIPTION
## Summary

- add a parallel apko image build workflow while keeping the existing Docker-based image workflow unchanged
- add melange and apko configuration for the covered images
- publish apko images to a separate image namespace to avoid collisions with the existing image outputs
- keep tag behavior aligned with the existing image build flow

## Vulnerability comparison

Measured with `grype 0.107.0` against the Docker images from `main` (`a82c8a58b988872a4e6dd34d06a1c4c9b1c0f75b`) and the apko images from this PR's workflow (`8f273af1bd93b8e8e6915c8359553e2e3a28b453`). Both amd64 and arm64 were measured where a Docker baseline exists; counts were identical across platforms, so the table is collapsed per image.

Totals include all severities reported by Grype. `C/H/M/L` is Critical/High/Medium/Low.

| Image | Docker total | apko total | Change | Reduction | Docker C/H/M/L | apko C/H/M/L |
|---|---:|---:|---:|---:|---:|---:|
| `cci-stats` | 6 | 6 | 0 | 0.0% | 2/1/2/1 | 2/1/2/1 |
| `circleci-runner-wolfi` | n/a | 1 | n/a | n/a | n/a | 0/0/1/0 |
| `op-conductor-mon` | 50 | 3 | -47 | 94.0% | 1/24/23/2 | 0/1/2/0 |
| `op-conductor-ops` | 41 | 14 | -27 | 65.9% | 0/10/17/3 | 0/5/7/1 |
| `op-signer` | 6 | 6 | 0 | 0.0% | 1/2/3/0 | 1/2/3/0 |
| `op-txproxy` | 6 | 6 | 0 | 0.0% | 1/3/2/0 | 1/3/2/0 |
| `op-ufm` | 7 | 7 | 0 | 0.0% | 1/2/4/0 | 1/2/4/0 |
| `peer-mgmt-service` | 14 | 14 | 0 | 0.0% | 0/4/10/0 | 0/4/10/0 |
| `proxyd` | 44 | 2 | -42 | 95.5% | 1/24/19/0 | 0/1/1/0 |
| `replica-healthcheck` | 71 | 61 | -10 | 14.1% | 0/28/29/14 | 0/25/25/11 |
