### PR TITLE
proxyd: parallelize EL consensus-poller RPCs in UpdateBackend

### DIFF
--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -3,7 +3,6 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -16,12 +15,6 @@ import (
 
 const (
 	DefaultPollerInterval = 1 * time.Second
-)
-
-var (
-	errZeroLatestBlock    = errors.New("backend responded with blockheight 0 for latest block")
-	errZeroSafeBlock      = errors.New("backend responded with blockheight 0 for safe block")
-	errZeroFinalizedBlock = errors.New("backend responded with blockheight 0 for finalized block")
 )
 
 type OnConsensusBroken func()
@@ -395,20 +388,68 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 			return
 		}
 	} else {
-		var err error
-		inSync, err = cp.isELInSync(ctx, be)
-		RecordConsensusBackendInSync(be, err == nil && inSync)
-		if err != nil {
-			log.Warn("error updating backend sync state", "name", be.Name, "err", err)
+		// eth_syncing and the three eth_getBlockByNumber calls are independent RPCs against
+		// the same backend — fire them concurrently instead of one after another so a single
+		// poll cycle costs one round trip, not four. Errors/results are collected and then
+		// checked in the same precedence order the old sequential code used, so behavior on
+		// failure (which error wins, what gets banned/logged) is unchanged.
+		var inSyncErr, latestErr, safeErr, finalizedErr error
+
+		var wg sync.WaitGroup
+		wg.Add(4)
+		go func() {
+			defer wg.Done()
+			inSync, inSyncErr = cp.isELInSync(ctx, be)
+		}()
+		go func() {
+			defer wg.Done()
+			latestBlockNumber, latestBlockHash, latestErr = cp.fetchELBlock(ctx, be, "latest")
+		}()
+		go func() {
+			defer wg.Done()
+			safeBlockNumber, _, safeErr = cp.fetchELBlock(ctx, be, "safe")
+		}()
+		go func() {
+			defer wg.Done()
+			finalizedBlockNumber, _, finalizedErr = cp.fetchELBlock(ctx, be, "finalized")
+		}()
+		wg.Wait()
+
+		RecordConsensusBackendInSync(be, inSyncErr == nil && inSync)
+		if inSyncErr != nil {
+			log.Warn("error updating backend sync state", "name", be.Name, "err", inSyncErr)
 			return
 		}
-		els, err := cp.fetchELState(ctx, be)
-		if err != nil {
+
+		if latestErr != nil {
+			log.Warn("error updating backend - latest block will not be updated", "name", be.Name, "err", latestErr)
 			return
 		}
-		latestBlockNumber, latestBlockHash = els.LatestBlockNumber, els.LatestBlockHash
-		safeBlockNumber = els.SafeBlockNumber
-		finalizedBlockNumber = els.FinalizedBlockNumber
+		if latestBlockNumber == 0 {
+			log.Warn("error backend responded a 200 with blockheight 0 for latest block", "name", be.Name)
+			be.intermittentErrorsSlidingWindow.Incr()
+			return
+		}
+
+		if safeErr != nil {
+			log.Warn("error updating backend - safe block will not be updated", "name", be.Name, "err", safeErr)
+			return
+		}
+		if safeBlockNumber == 0 {
+			log.Warn("error backend responded a 200 with blockheight 0 for safe block", "name", be.Name)
+			be.intermittentErrorsSlidingWindow.Incr()
+			return
+		}
+
+		if finalizedErr != nil {
+			log.Warn("error updating backend - finalized block will not be updated", "name", be.Name, "err", finalizedErr)
+			return
+		}
+		if finalizedBlockNumber == 0 {
+			log.Warn("error backend responded a 200 with blockheight 0 for finalized block", "name", be.Name)
+			be.intermittentErrorsSlidingWindow.Incr()
+			return
+		}
 	}
 
 	RecordConsensusBackendUpdateDelay(be, bs.lastUpdate)
@@ -766,48 +807,6 @@ func (cp *ConsensusPoller) findConsensusBlock(
 	}
 }
 
-// fetchELState fetches the block numbers and hashes for the latest, safe, and finalized
-// tags from a single EL backend, performing zero-value validation inline.
-func (cp *ConsensusPoller) fetchELState(ctx context.Context, be *Backend) (ELBlockState, error) {
-	var s ELBlockState
-	var err error
-
-	s.LatestBlockNumber, s.LatestBlockHash, err = cp.fetchELBlock(ctx, be, "latest")
-	if err != nil {
-		log.Warn("error updating backend - latest block will not be updated", "name", be.Name, "err", err)
-		return ELBlockState{}, err
-	}
-	if s.LatestBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for latest block", "name", be.Name)
-		be.intermittentErrorsSlidingWindow.Incr()
-		return ELBlockState{}, errZeroLatestBlock
-	}
-
-	s.SafeBlockNumber, _, err = cp.fetchELBlock(ctx, be, "safe")
-	if err != nil {
-		log.Warn("error updating backend - safe block will not be updated", "name", be.Name, "err", err)
-		return ELBlockState{}, err
-	}
-	if s.SafeBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for safe block", "name", be.Name)
-		be.intermittentErrorsSlidingWindow.Incr()
-		return ELBlockState{}, errZeroSafeBlock
-	}
-
-	s.FinalizedBlockNumber, _, err = cp.fetchELBlock(ctx, be, "finalized")
-	if err != nil {
-		log.Warn("error updating backend - finalized block will not be updated", "name", be.Name, "err", err)
-		return ELBlockState{}, err
-	}
-	if s.FinalizedBlockNumber == 0 {
-		log.Warn("error backend responded a 200 with blockheight 0 for finalized block", "name", be.Name)
-		be.intermittentErrorsSlidingWindow.Incr()
-		return ELBlockState{}, errZeroFinalizedBlock
-	}
-
-	return s, nil
-}
-
 // fetchELBlock calls eth_getBlockByNumber and returns the block number and hash.
 func (cp *ConsensusPoller) fetchELBlock(ctx context.Context, be *Backend, block string) (blockNumber hexutil.Uint64, blockHash string, err error) {
 	var rpcRes RPCRes
@@ -915,14 +914,6 @@ func (cp *ConsensusPoller) GetLastUpdate(be *Backend) time.Time {
 	defer bs.backendStateMux.Unlock()
 	bs.backendStateMux.Lock()
 	return bs.lastUpdate
-}
-
-// ELBlockState holds the block numbers and hashes fetched from an EL backend in a single polling cycle.
-type ELBlockState struct {
-	LatestBlockNumber    hexutil.Uint64
-	LatestBlockHash      string
-	SafeBlockNumber      hexutil.Uint64
-	FinalizedBlockNumber hexutil.Uint64
 }
 
 // backendStateUpdate is a value object passed to setBackendState to avoid

--- a/proxyd/integration_tests/consensus_test.go
+++ b/proxyd/integration_tests/consensus_test.go
@@ -236,6 +236,23 @@ func TestConsensus(t *testing.T) {
 		require.Equal(t, 1, len(consensusGroup))
 	})
 
+	t.Run("prevent using a backend when eth_syncing errors", func(t *testing.T) {
+		reset()
+		// A transport/RPC-level failure (unlike overrideNotInSync, which returns a
+		// successful-but-not-synced response) exercises the concurrent isELInSync
+		// error path in UpdateBackend.
+		nodes["node1"].handler.AddOverride(&ms.MethodTemplate{
+			Method:       "eth_syncing",
+			ResponseCode: 500,
+		})
+		update()
+
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+		require.NotContains(t, consensusGroup, nodes["node1"].backend)
+		require.False(t, bg.Consensus.IsBanned(nodes["node1"].backend))
+		require.Equal(t, 1, len(consensusGroup))
+	})
+
 	t.Run("advance consensus", func(t *testing.T) {
 		reset()
 

--- a/proxyd/integration_tests/mock_backend_test.go
+++ b/proxyd/integration_tests/mock_backend_test.go
@@ -241,20 +241,26 @@ func (m *MockBackend) Requests() []*RecordedRequest {
 }
 
 func (m *MockBackend) wrappedHandler(w http.ResponseWriter, r *http.Request) {
-	m.mtx.Lock()
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		panic(err)
 	}
 	clone := r.Clone(context.Background())
 	clone.Body = io.NopCloser(bytes.NewReader(body))
+
+	// Only the shared request log and handler reference need the lock. Holding it across
+	// ServeHTTP would force concurrent requests to this backend to execute one at a time,
+	// unlike a real backend, which breaks tests that rely on genuinely concurrent RPCs.
+	m.mtx.Lock()
 	m.requests = append(m.requests, &RecordedRequest{
 		Method:  r.Method,
 		Headers: r.Header.Clone(),
 		Body:    body,
 	})
-	m.handler.ServeHTTP(w, clone)
+	handler := m.handler
 	m.mtx.Unlock()
+
+	handler.ServeHTTP(w, clone)
 }
 
 type MockWSBackend struct {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

UpdateBackend previously issued eth_syncing, eth_getBlockByNumber("latest"), ("safe"), and ("finalized") sequentially against the same backend, so one poll cycle cost the sum of four round trips. In our production deployment this measured at ~690ms/poll even with consensus_poller_interval set to 250ms, since the call chain itself exceeded the configured interval and became the real bottleneck.

Fire the four RPCs concurrently instead; a cycle now costs roughly one round trip. Error/zero-value precedence on failure is unchanged from the sequential version (sync error > latest > safe > finalized), just evaluated after all four results are in rather than short-circuiting between calls.

Also fixes MockBackend.wrappedHandler in the integration test harness, which held its mutex across the full handler invocation and serialized concurrent requests to the same mock backend — harmless for the old sequential poller, but it caused the new concurrent calls to queue behind each other and time out in tests that simulate a slow backend. The lock now only guards the shared request log and handler reference, not handler execution, matching how a real backend actually behaves under concurrent load.

**Tests**

- `go test ./...` (full `proxyd` module) — pass
- `go test ./... -race` — pass, no data races introduced by the new concurrent goroutines
- `go test ./integration_tests/... -run TestConsensus -count=3` — repeated to rule out flakiness from the new concurrency, pass
- Added a new case ("prevent using a backend when eth_syncing errors") covering an actual RPC/transport-level failure on the concurrent isELInSync path, distinct from the existing not-in-sync case which only covers a successful-but-not-synced response
- Manual end-to-end smoke test: built the Docker image from this branch and ran it with a config pointed at real production backends. Confirmed it forms a healthy 3-backend consensus group, serves `eth_blockNumber` correctly, shows no bans/errors, and reports a lower `proxyd_consensus_backend_update_delay` than the previous sequential implementation under the same `consensus_poller_interval`.

The existing `TestConsensus` suite in `integration_tests/` already exercised `UpdateBackend`'s success/error/zero-block paths end-to-end through the mock backends and passes unchanged (the mock harness fix above was needed for it to keep doing so under real concurrency instead of only proving it works when serialized).

**Additional context**

Root-caused via production instrumentation rather than guesswork: `proxyd_consensus_backend_update_delay` is `time.Since(lastUpdate)` recorded on every poll (see `RecordConsensusBackendUpdateDelay` in `metrics.go`), so it directly reports the achieved loop period, not a random-phase staleness sample. In our deployment, it measured ~690-694ms with `consensus_poller_interval = "250ms"` configured — meaning the four sequential RPCs inside `UpdateBackend`, not the poller's idle wait, were the actual bottleneck. This change removes that bottleneck; it does not change proxyd's consensus semantics (the served head is still `min(latest_block)` across in-consensus backends).

**Metadata**

Fixes #[Link to Issue]
