### PR TITLE
ci(apko): fix parity gaps before production promotion

### DIFF
--- a/apko/op-ufm.yaml
+++ b/apko/op-ufm.yaml
@@ -26,6 +26,7 @@ accounts:
 
 entrypoint:
   command: /usr/bin/ufm
+cmd: /etc/ufm/config.toml
 
 annotations:
   org.opencontainers.image.source: https://github.com/ethereum-optimism/infra

--- a/apko/proxyd.yaml
+++ b/apko/proxyd.yaml
@@ -26,6 +26,7 @@ accounts:
 
 entrypoint:
   command: /usr/bin/proxyd
+cmd: /etc/proxyd/proxyd.toml
 
 annotations:
   org.opencontainers.image.source: https://github.com/ethereum-optimism/infra

--- a/melange/op-ufm.yaml
+++ b/melange/op-ufm.yaml
@@ -18,6 +18,8 @@ environment:
       - go-1.26
   environment:
     CGO_ENABLED: "1"
+    GITCOMMIT: "melange"
+    GITDATE: "0"
 
 pipeline:
   - uses: go/build
@@ -26,6 +28,6 @@ pipeline:
       packages: ./cmd/ufm
       output: ufm
       go-package: go-1.26
-      ldflags: -s -w
+      ldflags: -s -w -X main.GitVersion=${{package.version}} -X main.GitCommit=$GITCOMMIT -X main.GitDate=$GITDATE
 
   - uses: strip

--- a/melange/proxyd.yaml
+++ b/melange/proxyd.yaml
@@ -18,6 +18,8 @@ environment:
       - go-1.26
   environment:
     CGO_ENABLED: "1"
+    GITCOMMIT: "melange"
+    GITDATE: "0"
 
 pipeline:
   - uses: go/build
@@ -26,6 +28,6 @@ pipeline:
       packages: ./cmd/proxyd
       output: proxyd
       go-package: go-1.26
-      ldflags: -s -w
+      ldflags: -s -w -X main.GitVersion=${{package.version}} -X main.GitCommit=$GITCOMMIT -X main.GitDate=$GITDATE
 
   - uses: strip


### PR DESCRIPTION
## Summary

Follow-up to #664. Fixes identified parity gaps before treating APKO images as production replacements for Docker images.

- **proxyd, op-ufm**: carry over default config argument from Docker `CMD` — without this, running the image bare crashes immediately
- **proxyd, op-ufm**: inject `GitVersion`/`GitCommit`/`GitDate` via melange ldflags to match goreleaser/Makefile; `GITCOMMIT`/`GITDATE` default to `"melange"`/`"0"` for dev builds

Closes part of ethereum-optimism/cloud-security#221.

## Test plan

- [ ] CI passes melange builds for proxyd and op-ufm
- [ ] Smoke tests pass
- [ ] `docker run <image> --help` still works (cmd is a default, not enforced)
- [ ] `docker run <image>` fails with config-not-found (not arg-missing), matching Docker image behavior