### PR TITLE
fix(proxyd): fix tx_validation_middleware RPC error when failing close against a failing screening-service/provider

### DIFF
--- a/proxyd/tx_validation_middleware.go
+++ b/proxyd/tx_validation_middleware.go
@@ -87,27 +87,28 @@ func (c *TxValidationClient) Validate(ctx context.Context, endpoint string, payl
 
 	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(payload))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create validation request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to execute validation request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read validation response body: %w", err)
 	}
 
 	var validationRes txValidationResponse
 	if err := json.Unmarshal(body, &validationRes); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal validation response: %w", err)
 	}
 
 	if msg := validationRes.ErrorCode + validationRes.ErrorMessage; msg != "" {
+		log.Error("tx validation service error", "req_id", GetReqID(ctx), "error", msg)
 		return nil, ErrInternal
 	}
 	return validationRes.Unauthorized, nil
@@ -199,7 +200,7 @@ func validateTransactions(
 			"error", validationErr,
 			"tx_count", len(txs),
 		)
-		return ErrInternal
+		return ErrTransactionRejected // the fail_closed behaviour is about rejecting the transaction
 	}
 
 	for txHash, isUnauthorized := range validationResults {

--- a/proxyd/tx_validation_middleware_test.go
+++ b/proxyd/tx_validation_middleware_test.go
@@ -243,7 +243,7 @@ func TestValidateTransactions_ServiceError_FailClosed(t *testing.T) {
 	// With failOpen=false, service errors should reject transaction
 	err := validateTransactions(context.Background(), []*types.Transaction{tx}, "http://test", mockValidation, false)
 	require.Error(t, err)
-	require.Equal(t, ErrInternal, err)
+	require.Equal(t, ErrTransactionRejected, err)
 }
 
 func TestTxValidationClient_HTTPServer(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A clear and concise description of the features you're adding in this pull request.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
