### PR TITLE
proxyd: add origin label to rpc_backend_http_response_codes_total

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -635,11 +635,11 @@ func (b *Backend) Override(opts ...BackendOpt) {
 	}
 }
 
-func (b *Backend) Forward(ctx context.Context, reqs []*RPCReq, isBatch bool) ([]*RPCRes, error) {
-	return b.ForwardWithSource(ctx, reqs, isBatch, RPCRequestSourceHTTP)
+func (b *Backend) Forward(ctx context.Context, reqs []*RPCReq, isBatch bool, origin string) ([]*RPCRes, error) {
+	return b.ForwardWithSource(ctx, reqs, isBatch, RPCRequestSourceHTTP, origin)
 }
 
-func (b *Backend) ForwardWithSource(ctx context.Context, reqs []*RPCReq, isBatch bool, source string) ([]*RPCRes, error) {
+func (b *Backend) ForwardWithSource(ctx context.Context, reqs []*RPCReq, isBatch bool, source string, origin string) ([]*RPCRes, error) {
 	var lastError error
 	// <= to account for the first attempt not technically being
 	// a retry
@@ -665,7 +665,7 @@ func (b *Backend) ForwardWithSource(ctx context.Context, reqs []*RPCReq, isBatch
 			"max_attempts", b.maxRetries+1,
 			"method", metricLabelMethod,
 		)
-		res, err := b.doForward(ctx, reqs, isBatch)
+		res, err := b.doForward(ctx, reqs, isBatch, origin)
 		switch err {
 		case nil: // do nothing
 		case ErrBackendResponseTooLarge:
@@ -767,7 +767,7 @@ func (b *Backend) ProxyWS(clientConn *websocket.Conn, methodWhitelist *StringSet
 }
 
 // ForwardRPC makes a call directly to a backend and populate the response into `res`
-func (b *Backend) ForwardRPC(ctx context.Context, res *RPCRes, id string, method string, params ...any) error {
+func (b *Backend) ForwardRPC(ctx context.Context, res *RPCRes, origin string, id string, method string, params ...any) error {
 	jsonParams, err := json.Marshal(params)
 	if err != nil {
 		return err
@@ -780,7 +780,7 @@ func (b *Backend) ForwardRPC(ctx context.Context, res *RPCRes, id string, method
 		ID:      []byte(id),
 	}
 
-	slicedRes, err := b.doForward(ctx, []*RPCReq{&rpcReq}, false)
+	slicedRes, err := b.doForward(ctx, []*RPCReq{&rpcReq}, false, origin)
 	if err != nil {
 		return err
 	}
@@ -796,7 +796,7 @@ func (b *Backend) ForwardRPC(ctx context.Context, res *RPCRes, id string, method
 	return nil
 }
 
-func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool) ([]*RPCRes, error) {
+func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool, origin string) ([]*RPCRes, error) {
 	// we are concerned about network error rates, so we record 1 request independently of how many are in the batch
 	b.networkRequestsSlidingWindow.Incr()
 
@@ -920,6 +920,7 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 		metricLabelMethod,
 		strconv.Itoa(httpRes.StatusCode),
 		strconv.FormatBool(isBatch),
+		origin,
 	).Inc()
 
 	// if the response in unsuccessful and its status code is unexpected, consider that as an unhealthy backend
@@ -1102,11 +1103,11 @@ func (bg *BackendGroup) Primaries() []*Backend {
 }
 
 // NOTE: BackendGroup Forward contains the log for balancing with consensus aware
-func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool) ([]*RPCRes, string, error) {
-	return bg.ForwardWithSource(ctx, rpcReqs, isBatch, RPCRequestSourceHTTP)
+func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool, origin string) ([]*RPCRes, string, error) {
+	return bg.ForwardWithSource(ctx, rpcReqs, isBatch, RPCRequestSourceHTTP, origin)
 }
 
-func (bg *BackendGroup) ForwardWithSource(ctx context.Context, rpcReqs []*RPCReq, isBatch bool, source string) ([]*RPCRes, string, error) {
+func (bg *BackendGroup) ForwardWithSource(ctx context.Context, rpcReqs []*RPCReq, isBatch bool, source string, origin string) ([]*RPCRes, string, error) {
 	if len(rpcReqs) == 0 {
 		return nil, "", nil
 	}
@@ -1135,14 +1136,14 @@ func (bg *BackendGroup) ForwardWithSource(ctx context.Context, rpcReqs []*RPCReq
 	// When routing_strategy is set to 'multicall' the request will be forward to all backends
 	// and return the first successful response
 	if bg.GetRoutingStrategy() == MulticallRoutingStrategy && isValidMulticallTx(rpcReqs) && !isBatch {
-		backendResp := bg.ExecuteMulticall(ctx, rpcReqs, source)
+		backendResp := bg.ExecuteMulticall(ctx, rpcReqs, source, origin)
 		return backendResp.RPCRes, backendResp.ServedBy, backendResp.error
 	}
 
 	ch := make(chan BackendGroupRPCResponse)
 	go func() {
 		defer close(ch)
-		backendResp := bg.ForwardRequestToBackendGroup(rpcReqs, backends, ctx, isBatch, source)
+		backendResp := bg.ForwardRequestToBackendGroup(rpcReqs, backends, ctx, isBatch, source, origin)
 		if backendResp.error != nil && errors.Is(backendResp.error, ErrNoBackends) {
 			RecordUnserviceableRequest(ctx, source)
 		}
@@ -1184,7 +1185,7 @@ type multicallTuple struct {
 }
 
 // Note: rpcReqs should only contain 1 request of 'sendRawTransactions'
-func (bg *BackendGroup) ExecuteMulticall(ctx context.Context, rpcReqs []*RPCReq, source string) *BackendGroupRPCResponse {
+func (bg *BackendGroup) ExecuteMulticall(ctx context.Context, rpcReqs []*RPCReq, source string, origin string) *BackendGroupRPCResponse {
 	// Create ctx without cancel so background tasks process
 	// after original request returns
 	bgCtx := context.WithoutCancel(ctx)
@@ -1197,7 +1198,7 @@ func (bg *BackendGroup) ExecuteMulticall(ctx context.Context, rpcReqs []*RPCReq,
 	ch := make(chan *multicallTuple, len(bg.Backends))
 	for _, backend := range bg.Backends {
 		wg.Add(1)
-		go bg.MulticallRequest(backend, rpcReqs, &wg, bgCtx, ch, source)
+		go bg.MulticallRequest(backend, rpcReqs, &wg, bgCtx, ch, source, origin)
 	}
 
 	go func() {
@@ -1217,7 +1218,7 @@ func (bg *BackendGroup) ExecuteMulticall(ctx context.Context, rpcReqs []*RPCReq,
 	return resp
 }
 
-func (bg *BackendGroup) MulticallRequest(backend *Backend, rpcReqs []*RPCReq, wg *sync.WaitGroup, ctx context.Context, ch chan *multicallTuple, source string) {
+func (bg *BackendGroup) MulticallRequest(backend *Backend, rpcReqs []*RPCReq, wg *sync.WaitGroup, ctx context.Context, ch chan *multicallTuple, source string, origin string) {
 	defer wg.Done()
 	log.Debug("forwarding multicall request to backend",
 		"req_id", GetReqID(ctx),
@@ -1226,7 +1227,7 @@ func (bg *BackendGroup) MulticallRequest(backend *Backend, rpcReqs []*RPCReq, wg
 	)
 
 	RecordBackendGroupMulticallRequest(bg, backend.Name)
-	backendResp := bg.ForwardRequestToBackendGroup(rpcReqs, []*Backend{backend}, ctx, false, source)
+	backendResp := bg.ForwardRequestToBackendGroup(rpcReqs, []*Backend{backend}, ctx, false, source, origin)
 
 	multicallResp := &multicallTuple{
 		response:    backendResp,
@@ -1849,6 +1850,7 @@ func (bg *BackendGroup) ForwardRequestToBackendGroup(
 	ctx context.Context,
 	isBatch bool,
 	source string,
+	origin string,
 ) *BackendGroupRPCResponse {
 	for _, back := range backends {
 		res := make([]*RPCRes, 0)
@@ -1858,7 +1860,7 @@ func (bg *BackendGroup) ForwardRequestToBackendGroup(
 
 		if len(rpcReqs) > 0 {
 
-			res, err = back.ForwardWithSource(ctx, rpcReqs, isBatch, source)
+			res, err = back.ForwardWithSource(ctx, rpcReqs, isBatch, source, origin)
 
 			// below are errors that we explicitly handle so that we don't
 			// mark this request as unserviceable (unserviceable requests

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -226,18 +226,18 @@ func TestAllowedStatusCodes(t *testing.T) {
 	require.Equal(t, []int{400, 413}, healthyBackend.allowedStatusCodes) // default allowed status codes
 
 	healthyBackend.allowedStatusCodes = []int{} // no need to explicitly allow 200
-	res, err := healthyBackend.doForward(context.Background(), []*RPCReq{{ID: []byte("1"), Method: "eth_blockNumber"}}, false)
+	res, err := healthyBackend.doForward(context.Background(), []*RPCReq{{ID: []byte("1"), Method: "eth_blockNumber"}}, false, RPCRequestOriginClient)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Nil(t, res[0].Error) // denoting a successful RPC response
 
-	res, err = unhealthyBackend.doForward(context.Background(), []*RPCReq{{ID: []byte("1"), Method: "eth_blockNumber"}}, false)
+	res, err = unhealthyBackend.doForward(context.Background(), []*RPCReq{{ID: []byte("1"), Method: "eth_blockNumber"}}, false, RPCRequestOriginClient)
 	require.Error(t, err)
 	require.Nil(t, res)
 	require.ErrorContains(t, err, "response code 503")
 
 	unhealthyBackend.allowedStatusCodes = []int{503}
-	res, err = unhealthyBackend.doForward(context.Background(), []*RPCReq{{ID: []byte("1"), Method: "eth_blockNumber"}}, false)
+	res, err = unhealthyBackend.doForward(context.Background(), []*RPCReq{{ID: []byte("1"), Method: "eth_blockNumber"}}, false, RPCRequestOriginClient)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	// denotes the RPC response holding the error

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -815,7 +815,7 @@ func (cp *ConsensusPoller) fetchELBlock(ctx context.Context, be *Backend, block 
 		"backend", be.Name,
 		"block", block,
 	)
-	err = be.ForwardRPC(ctx, &rpcRes, "67", "eth_getBlockByNumber", block, false)
+	err = be.ForwardRPC(ctx, &rpcRes, RPCRequestOriginConsensus, "67", "eth_getBlockByNumber", block, false)
 	if err != nil {
 		return 0, "", err
 	}
@@ -849,7 +849,7 @@ func (cp *ConsensusPoller) getPeerCount(ctx context.Context, be *Backend) (count
 // fetchELPeerCount calls net_peerCount and returns the peer count.
 func (cp *ConsensusPoller) fetchELPeerCount(ctx context.Context, be *Backend) (count uint64, err error) {
 	var rpcRes RPCRes
-	err = be.ForwardRPC(ctx, &rpcRes, "67", "net_peerCount")
+	err = be.ForwardRPC(ctx, &rpcRes, RPCRequestOriginConsensus, "67", "net_peerCount")
 	if err != nil {
 		return 0, err
 	}
@@ -867,7 +867,7 @@ func (cp *ConsensusPoller) fetchELPeerCount(ctx context.Context, be *Backend) (c
 // isELInSync checks if an EL backend is in sync by calling eth_syncing.
 func (cp *ConsensusPoller) isELInSync(ctx context.Context, be *Backend) (result bool, err error) {
 	var rpcRes RPCRes
-	err = be.ForwardRPC(ctx, &rpcRes, "67", "eth_syncing")
+	err = be.ForwardRPC(ctx, &rpcRes, RPCRequestOriginConsensus, "67", "eth_syncing")
 	if err != nil {
 		return false, err
 	}

--- a/proxyd/consensus_poller_cl.go
+++ b/proxyd/consensus_poller_cl.go
@@ -253,7 +253,7 @@ func (cp *ConsensusPoller) fetchCLSyncStatus(ctx context.Context, be *Backend) (
 	log.Trace("executing fetchCLSyncStatus for backend",
 		"backend", be.Name,
 	)
-	if err := be.ForwardRPC(ctx, &rpcRes, "67", "optimism_syncStatus"); err != nil {
+	if err := be.ForwardRPC(ctx, &rpcRes, RPCRequestOriginConsensus, "67", "optimism_syncStatus"); err != nil {
 		return nil, nil, err
 	}
 
@@ -529,7 +529,7 @@ func (cp *ConsensusPoller) verifyCLOutputRoots(
 // fetchCLOutputRoot calls optimism_outputAtBlock and returns the outputRoot hash.
 func (cp *ConsensusPoller) fetchCLOutputRoot(ctx context.Context, be *Backend, block hexutil.Uint64) (string, error) {
 	var rpcRes RPCRes
-	if err := be.ForwardRPC(ctx, &rpcRes, "67", "optimism_outputAtBlock", block.String()); err != nil {
+	if err := be.ForwardRPC(ctx, &rpcRes, RPCRequestOriginConsensus, "67", "optimism_outputAtBlock", block.String()); err != nil {
 		return "", err
 	}
 	jsonMap, ok := rpcRes.Result.(map[string]interface{})
@@ -550,7 +550,7 @@ func (cp *ConsensusPoller) fetchCLPeerCount(ctx context.Context, be *Backend) (c
 	log.Trace("executing fetchCLPeerCount",
 		"backend", be.Name,
 	)
-	err = be.ForwardRPC(ctx, &rpcRes, "67", "opp2p_peerStats")
+	err = be.ForwardRPC(ctx, &rpcRes, RPCRequestOriginConsensus, "67", "opp2p_peerStats")
 	if err != nil {
 		return 0, err
 	}

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -21,6 +21,9 @@ const (
 	RPCRequestSourceHTTP = "http"
 	RPCRequestSourceWS   = "ws"
 
+	RPCRequestOriginClient    = "client"
+	RPCRequestOriginConsensus = "consensus"
+
 	BackendProxyd    = "proxyd"
 	SourceClient     = "client"
 	SourceBackend    = "backend"
@@ -65,6 +68,7 @@ var (
 		"method_name",
 		"status_code",
 		"batched",
+		"origin",
 	})
 
 	rpcInteropFilterChecksTotal = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/proxyd/multicall_unserviceable_test.go
+++ b/proxyd/multicall_unserviceable_test.go
@@ -41,7 +41,7 @@ func TestExecuteMulticallUnserviceableMetric(t *testing.T) {
 		}
 
 		before := getUnserviceableRequestCount(RPCRequestSourceHTTP)
-		resp := bg.ExecuteMulticall(context.Background(), req, RPCRequestSourceHTTP)
+		resp := bg.ExecuteMulticall(context.Background(), req, RPCRequestSourceHTTP, RPCRequestOriginClient)
 		require.Error(t, resp.error)
 		require.True(t, errors.Is(resp.error, ErrNoBackends))
 		after := getUnserviceableRequestCount(RPCRequestSourceHTTP)
@@ -65,7 +65,7 @@ func TestExecuteMulticallUnserviceableMetric(t *testing.T) {
 		}
 
 		before := getUnserviceableRequestCount(RPCRequestSourceHTTP)
-		resp := bg.ExecuteMulticall(context.Background(), req, RPCRequestSourceHTTP)
+		resp := bg.ExecuteMulticall(context.Background(), req, RPCRequestSourceHTTP, RPCRequestOriginClient)
 		require.NoError(t, resp.error)
 		after := getUnserviceableRequestCount(RPCRequestSourceHTTP)
 
@@ -104,7 +104,7 @@ func TestForwardUnserviceableMetric(t *testing.T) {
 		require.NotEqual(t, MulticallRoutingStrategy, bg.GetRoutingStrategy())
 
 		before := getUnserviceableRequestCount(RPCRequestSourceHTTP)
-		_, _, err := bg.Forward(context.Background(), req, false)
+		_, _, err := bg.Forward(context.Background(), req, false, RPCRequestOriginClient)
 		require.Error(t, err)
 		require.True(t, errors.Is(err, ErrNoBackends))
 		after := getUnserviceableRequestCount(RPCRequestSourceHTTP)
@@ -128,7 +128,7 @@ func TestForwardUnserviceableMetric(t *testing.T) {
 		}
 
 		before := getUnserviceableRequestCount(RPCRequestSourceHTTP)
-		_, _, err := bg.Forward(context.Background(), req, false)
+		_, _, err := bg.Forward(context.Background(), req, false, RPCRequestOriginClient)
 		require.NoError(t, err)
 		after := getUnserviceableRequestCount(RPCRequestSourceHTTP)
 

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -739,7 +739,7 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			end := int(math.Min(float64(start+s.maxUpstreamBatchSize), float64(len(cacheMisses))))
 			elems := cacheMisses[start:end]
 			forwardStart := time.Now()
-			res, sb, err := s.BackendGroups[group.backendGroup].Forward(ctx, createBatchRequest(elems), isBatch)
+			res, sb, err := s.BackendGroups[group.backendGroup].Forward(ctx, createBatchRequest(elems), isBatch, RPCRequestOriginClient)
 			forwardDuration := time.Since(forwardStart)
 			servedBy[sb] = true
 
@@ -884,7 +884,7 @@ func (s *Server) handleWSRPC(ctx context.Context, req *RPCReq, isLimited limiter
 	}
 
 	forwardStart := time.Now()
-	res, servedBy, err := s.BackendGroups[group].ForwardWithSource(ctx, []*RPCReq{req}, false, RPCRequestSourceWS)
+	res, servedBy, err := s.BackendGroups[group].ForwardWithSource(ctx, []*RPCReq{req}, false, RPCRequestSourceWS, RPCRequestOriginClient)
 	forwardDuration := time.Since(forwardStart)
 	if err != nil {
 		log.Error(


### PR DESCRIPTION
**Description**

Adds an `origin` label to `proxyd_rpc_backend_http_response_codes_total` so client-driven backend responses can be told apart from proxyd's own internal (consensus-poller) requests.

Motivation: The OPE dashboard needs client-facing status-code counts broken down by backend. The only metric carrying both `backend_name` and `status_code` is this one, and it was inflated by poller traffic with no way to filter it out.
