### PR TITLE
bailiff: migrate Dockerfile to Wolfi base

### DIFF
--- a/bailiff/Dockerfile
+++ b/bailiff/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.23-alpine3.20 AS builder
+FROM chainguard/wolfi-base:latest@sha256:003627df3c1e1bba0c4116afcddb314aca9594ee2328c7e876a8081a6c988b2e AS builder
+RUN apk add --no-cache go-1.26
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
@@ -7,7 +8,7 @@ ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o bailiff ./cmd/bailiff
 
-FROM alpine:3.20.3
-RUN apk add --no-cache ca-certificates git bash openssh
+FROM chainguard/wolfi-base:latest@sha256:003627df3c1e1bba0c4116afcddb314aca9594ee2328c7e876a8081a6c988b2e
+RUN apk add --no-cache ca-certificates-bundle git bash openssh-client
 COPY --from=builder /app/bailiff /
 ENTRYPOINT ["/bailiff"]


### PR DESCRIPTION
## What
Migrate `bailiff/Dockerfile` from Alpine to `chainguard/wolfi-base:latest` for both the build and runtime stages, matching the pattern already used by the other services in this repo (e.g. `op-signer`).

## Why
The runtime stage was on `alpine:3.20.3`, which ships vulnerable `libssl3`/`libcrypto3`. bailiff execs `git`, `ssh`, and `bash` at runtime (the repush path uses `GIT_SSH_COMMAND`), so that tooling has to stay — but it now comes from Wolfi's continuously-patched apk registry (`git`, `bash`, `openssh-client`, `ca-certificates-bundle`) instead of Alpine.

## Testing
- Image build CI on this PR.
- Runtime still provides `git` / `ssh` / `bash` for the repush flow.