### PR TITLE
proxyd: add per-RPC-call metrics for usage and error-rate SLO

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1479,6 +1479,18 @@ func (w *WSProxier) Proxy(ctx context.Context) error {
 	return err
 }
 
+// metricMethodName bounds the method_name label cardinality for WS traffic. See
+// Server.metricMethodName — WS uses its own whitelist.
+func (w *WSProxier) metricMethodName(method string) string {
+	if method == "" {
+		return MethodUnknown
+	}
+	if !w.methodWhitelist.Has(method) {
+		return MethodNotAllowed
+	}
+	return method
+}
+
 func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 	for {
 		// Block until we get a message.
@@ -1526,6 +1538,7 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 			)
 			msg = mustMarshalJSON(NewRPCErrorRes(id, err))
 			RecordRPCError(ctx, BackendProxyd, method, err)
+			RecordRPCCall(BackendProxyd, w.metricMethodName(method), statusCodeForRPCRes(NewRPCErrorRes(id, err)), RPCRequestSourceWS)
 
 			// Send error response to client
 			err = w.writeClientConn(msgType, msg)
@@ -1540,6 +1553,7 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 		if req.Method == "eth_accounts" {
 			msg = mustMarshalJSON(NewRPCRes(req.ID, emptyArrayResponse))
 			RecordRPCForward(ctx, BackendProxyd, "eth_accounts", RPCRequestSourceWS)
+			RecordRPCCall(BackendProxyd, "eth_accounts", statusCodeOK, RPCRequestSourceWS)
 			err = w.writeClientConn(msgType, msg)
 			if err != nil {
 				errC <- err
@@ -1549,9 +1563,11 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 		}
 
 		if w.requestHandler != nil && w.requestHandler(req) {
+			// handleWSRPC records this call; do not record it here too.
 			if !w.acquireRequestSlot() {
 				msg = mustMarshalJSON(NewRPCErrorRes(req.ID, ErrTooManyRequests))
 				RecordRPCError(ctx, BackendProxyd, req.Method, ErrTooManyRequests)
+				RecordRPCCall(BackendProxyd, w.metricMethodName(req.Method), statusCodeForRPCRes(NewRPCErrorRes(req.ID, ErrTooManyRequests)), RPCRequestSourceWS)
 				err = w.writeClientConn(msgType, msg)
 				if err != nil {
 					errC <- err
@@ -1564,6 +1580,11 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 		}
 
 		RecordRPCForward(ctx, w.backend.Name, req.Method, RPCRequestSourceWS)
+		// Counted at send time: this call's response returns asynchronously in
+		// backendPump with no id correlation back to this request, so its outcome
+		// is unknowable here. Counting at send time guarantees usage completeness
+		// at the cost of an unknown status.
+		RecordRPCCall(w.backend.Name, w.metricMethodName(req.Method), StatusCodeRelayed, RPCRequestSourceWS)
 		log.Info(
 			"forwarded WS message to backend",
 			"method", req.Method,
@@ -1654,6 +1675,13 @@ func (w *WSProxier) backendPump(ctx context.Context, errC chan error) {
 			msg = mustMarshalJSON(NewRPCErrorRes(id, err))
 			log.Info("backend responded with error", "err", err)
 		} else {
+			// A backend message with no id is a subscription notification pushed by
+			// the backend, not a response to a client call. A message WITH an id is
+			// a response to a relayed call, already counted at send time in
+			// clientPump — counting it here would double-count.
+			if len(res.ID) == 0 {
+				RecordRPCNotification(w.backend.Name)
+			}
 			if res.IsError() {
 				log.Info(
 					"backend responded with RPC error",

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1485,6 +1485,16 @@ func (w *WSProxier) metricMethodName(method string) string {
 	if method == "" {
 		return MethodUnknown
 	}
+	// MethodUnknown and MethodNotAllowed are already-bounded sentinels — e.g.
+	// clientPump passes MethodUnknown through here when a frame fails
+	// ParseRPCReq. Pass them through unchanged rather than re-running them
+	// through the whitelist, where the literal strings "unknown" and
+	// "method_not_allowed" would themselves fail the Has check and get
+	// relabeled MethodNotAllowed, mislabeling a parse failure as a
+	// not-allowed method.
+	if method == MethodUnknown || method == MethodNotAllowed {
+		return method
+	}
 	if !w.methodWhitelist.Has(method) {
 		return MethodNotAllowed
 	}
@@ -1563,7 +1573,6 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 		}
 
 		if w.requestHandler != nil && w.requestHandler(req) {
-			// handleWSRPC records this call; do not record it here too.
 			if !w.acquireRequestSlot() {
 				msg = mustMarshalJSON(NewRPCErrorRes(req.ID, ErrTooManyRequests))
 				RecordRPCError(ctx, BackendProxyd, req.Method, ErrTooManyRequests)
@@ -1575,6 +1584,7 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 				}
 				continue
 			}
+			// handleWSRPC records this call; do not record it here too.
 			go w.processClientRPC(ctx, msgType, req, errC)
 			continue
 		}

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1485,16 +1485,6 @@ func (w *WSProxier) metricMethodName(method string) string {
 	if method == "" {
 		return MethodUnknown
 	}
-	// MethodUnknown and MethodNotAllowed are already-bounded sentinels — e.g.
-	// clientPump passes MethodUnknown through here when a frame fails
-	// ParseRPCReq. Pass them through unchanged rather than re-running them
-	// through the whitelist, where the literal strings "unknown" and
-	// "method_not_allowed" would themselves fail the Has check and get
-	// relabeled MethodNotAllowed, mislabeling a parse failure as a
-	// not-allowed method.
-	if method == MethodUnknown || method == MethodNotAllowed {
-		return method
-	}
 	if !w.methodWhitelist.Has(method) {
 		return MethodNotAllowed
 	}
@@ -1535,10 +1525,22 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 		req, err := w.prepareClientMsg(msg)
 		if err != nil {
 			var id json.RawMessage
+			// method is the raw client-supplied string, used only for
+			// RecordRPCError below, which deliberately accepts unbounded
+			// cardinality. It must NOT be passed to metricMethodName: an
+			// arbitrary client-supplied method (e.g. "unknown") must not be
+			// able to masquerade as the MethodUnknown sentinel and evade the
+			// method_not_allowed bucket. metricLabel below is derived from
+			// req instead, since prepareClientMsg has exactly two failure
+			// modes: req == nil means ParseRPCReq failed (no method to speak
+			// of); req != nil means the method parsed but failed the
+			// whitelist check.
 			method := MethodUnknown
+			metricLabel := MethodUnknown
 			if req != nil {
 				id = req.ID
 				method = req.Method
+				metricLabel = MethodNotAllowed
 			}
 			log.Info(
 				"error preparing client message",
@@ -1548,7 +1550,7 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 			)
 			msg = mustMarshalJSON(NewRPCErrorRes(id, err))
 			RecordRPCError(ctx, BackendProxyd, method, err)
-			RecordRPCCall(BackendProxyd, w.metricMethodName(method), statusCodeForRPCRes(NewRPCErrorRes(id, err)), RPCRequestSourceWS)
+			RecordRPCCall(BackendProxyd, metricLabel, statusCodeForRPCRes(NewRPCErrorRes(id, err)), RPCRequestSourceWS)
 
 			// Send error response to client
 			err = w.writeClientConn(msgType, msg)

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -79,6 +79,13 @@ var (
 	ErrTooManyBatchRequests = &RPCErr{
 		Code:    JSONRPCErrorInternal - 14,
 		Message: "too many RPC calls in batch request",
+		// 413 matches ErrRequestBodyTooLarge, the sibling "request is too big"
+		// rejection, and is a client-visible change: this was previously HTTP 200.
+		// Without an HTTPErrorCode this rejection was written as HTTP 200, so a
+		// client whose every batch exceeds max_batch_size failed 100% of the time
+		// while both proxyd_http_response_codes_total and (because the rejection
+		// returns before handleBatchRPC) proxyd_rpc_calls_total reported health.
+		HTTPErrorCode: 413,
 	}
 	ErrGatewayTimeout = &RPCErr{
 		Code:          JSONRPCErrorInternal - 15,
@@ -1479,8 +1486,26 @@ func (w *WSProxier) Proxy(ctx context.Context) error {
 	return err
 }
 
-// metricMethodName bounds the method_name label cardinality for WS traffic. See
-// Server.metricMethodName — WS uses its own whitelist.
+// metricMethodName bounds the method_name label cardinality for WS traffic by
+// collapsing anything outside ws_method_whitelist to a sentinel.
+//
+// Both current call sites in clientPump are downstream of a successful
+// prepareClientMsg, which already applies the same whitelist, so the collapsing
+// branches are unreachable today and only the tests exercise them. This is kept
+// deliberately: the bound is self-contained (it consults w.methodWhitelist
+// directly, not the caller's gate), method names are client-supplied and
+// reachable by unauthenticated clients, and unbounded Prometheus label
+// cardinality is the failure mode. Any future WS metric site can call this
+// without having to prove where it sits relative to the whitelist gate.
+//
+// Note this whitelist is not the one Server.metricMethodName uses: that one keys
+// on rpc_method_mappings. shouldHandleWSRPC admits a request via
+// txFilter.IsSubmissionMethod or txValidationMethods without consulting
+// rpc_method_mappings, so a method in ws_method_whitelist but absent from
+// rpc_method_mappings records under its real name when rejected by the semaphore
+// here and as method_not_allowed when handleWSRPCInner rejects it. Both are
+// rejections, so no call is miscounted, but sum by (method_name) is not
+// comparable across the two paths in that (unusual) configuration.
 func (w *WSProxier) metricMethodName(method string) string {
 	if method == "" {
 		return MethodUnknown
@@ -1548,9 +1573,12 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 				"req_id", GetReqID(ctx),
 				"err", err,
 			)
-			msg = mustMarshalJSON(NewRPCErrorRes(id, err))
+			// Build the response once and derive the metric from that same value, so
+			// the recorded status cannot drift from what the client receives.
+			errRes := NewRPCErrorRes(id, err)
+			msg = mustMarshalJSON(errRes)
 			RecordRPCError(ctx, BackendProxyd, method, err)
-			RecordRPCCall(BackendProxyd, metricLabel, statusCodeForRPCRes(NewRPCErrorRes(id, err)), RPCRequestSourceWS)
+			RecordRPCCall(BackendProxyd, metricLabel, statusCodeForRPCRes(errRes), RPCRequestSourceWS)
 
 			// Send error response to client
 			err = w.writeClientConn(msgType, msg)
@@ -1576,9 +1604,10 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 
 		if w.requestHandler != nil && w.requestHandler(req) {
 			if !w.acquireRequestSlot() {
-				msg = mustMarshalJSON(NewRPCErrorRes(req.ID, ErrTooManyRequests))
+				errRes := NewRPCErrorRes(req.ID, ErrTooManyRequests)
+				msg = mustMarshalJSON(errRes)
 				RecordRPCError(ctx, BackendProxyd, req.Method, ErrTooManyRequests)
-				RecordRPCCall(BackendProxyd, w.metricMethodName(req.Method), statusCodeForRPCRes(NewRPCErrorRes(req.ID, ErrTooManyRequests)), RPCRequestSourceWS)
+				RecordRPCCall(BackendProxyd, w.metricMethodName(req.Method), statusCodeForRPCRes(errRes), RPCRequestSourceWS)
 				err = w.writeClientConn(msgType, msg)
 				if err != nil {
 					errC <- err
@@ -1592,11 +1621,6 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 		}
 
 		RecordRPCForward(ctx, w.backend.Name, req.Method, RPCRequestSourceWS)
-		// Counted at send time: this call's response returns asynchronously in
-		// backendPump with no id correlation back to this request, so its outcome
-		// is unknowable here. Counting at send time guarantees usage completeness
-		// at the cost of an unknown status.
-		RecordRPCCall(w.backend.Name, w.metricMethodName(req.Method), StatusCodeRelayed, RPCRequestSourceWS)
 		log.Info(
 			"forwarded WS message to backend",
 			"method", req.Method,
@@ -1609,6 +1633,14 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 			errC <- err
 			return
 		}
+
+		// Recorded after the write succeeds, so "relayed" means actually relayed —
+		// a call lost to a failed backend write is not counted as one proxyd
+		// delivered. Counted here rather than on the response because this call's
+		// response returns asynchronously in backendPump with no id correlation back
+		// to this request, so its outcome is unknowable on this side: counting at
+		// send time guarantees usage completeness at the cost of an unknown status.
+		RecordRPCCall(w.backend.Name, w.metricMethodName(req.Method), StatusCodeRelayed, RPCRequestSourceWS)
 	}
 }
 
@@ -1679,6 +1711,7 @@ func (w *WSProxier) backendPump(ctx context.Context, errC chan error) {
 		}
 
 		res, err := w.parseBackendMsg(msg)
+		isNotification := false
 		if err != nil {
 			var id json.RawMessage
 			if res != nil {
@@ -1687,13 +1720,13 @@ func (w *WSProxier) backendPump(ctx context.Context, errC chan error) {
 			msg = mustMarshalJSON(NewRPCErrorRes(id, err))
 			log.Info("backend responded with error", "err", err)
 		} else {
-			// A backend message with no id is a subscription notification pushed by
-			// the backend, not a response to a client call. A message WITH an id is
-			// a response to a relayed call, already counted at send time in
-			// clientPump — counting it here would double-count.
-			if len(res.ID) == 0 {
-				RecordRPCNotification(w.backend.Name)
-			}
+			// A backend message with no id and no error is a subscription notification
+			// pushed by the backend, not a response to a client call. A message WITH an
+			// id is a response to a relayed call, already counted at send time in
+			// clientPump — counting it here would double-count. parseBackendMsg does no
+			// shape validation beyond JSON parsing, so an id-less *error* frame is also
+			// possible and is not a notification either.
+			isNotification = len(res.ID) == 0 && !res.IsError()
 			if res.IsError() {
 				log.Info(
 					"backend responded with RPC error",
@@ -1717,6 +1750,13 @@ func (w *WSProxier) backendPump(ctx context.Context, errC chan error) {
 		if err != nil {
 			errC <- err
 			return
+		}
+
+		// Recorded only after the client write succeeds: the metric claims delivery,
+		// so a notification dropped on a slow or disconnected client must not read as
+		// one the subscriber received.
+		if isNotification {
+			RecordRPCNotification(w.backend.Name)
 		}
 	}
 }
@@ -1983,6 +2023,10 @@ func (bg *BackendGroup) ForwardRequestToBackendGroup(
 
 func OverrideResponses(res []*RPCRes, overriddenResponses []*indexedReqRes) []*RPCRes {
 	for _, ov := range overriddenResponses {
+		// proxyd produced this response itself; no backend saw the request. Mark it
+		// so per-call metrics do not attribute it to whichever backend served the
+		// elements that were forwarded alongside it.
+		ov.res.servedLocally = true
 		if len(res) > 0 {
 			// insert ov.res at position ov.index
 			res = append(res[:ov.index], append([]*RPCRes{ov.res}, res[ov.index:]...)...)

--- a/proxyd/integration_tests/batching_test.go
+++ b/proxyd/integration_tests/batching_test.go
@@ -44,6 +44,8 @@ func TestBatching(t *testing.T) {
 		maxUpstreamBatchSize int
 		numExpectedForwards  int
 		maxResponseSizeBytes int64
+		// expectedStatusCode defaults to 200 when zero.
+		expectedStatusCode int
 	}{
 		{
 			name:  "backend returns batches out of order",
@@ -118,6 +120,11 @@ func TestBatching(t *testing.T) {
 			expectedRes:          "{\"error\":{\"code\":-32014,\"message\":\"over batch size custom message\"},\"id\":null,\"jsonrpc\":\"2.0\"}",
 			maxUpstreamBatchSize: 2,
 			numExpectedForwards:  0,
+			// A rejected batch must not report HTTP 200. This rejection returns before
+			// handleBatchRPC, so it contributes nothing to proxyd_rpc_calls_total
+			// either — as HTTP 200 it was invisible to every error-rate metric while
+			// failing 100% of the client's requests.
+			expectedStatusCode: http.StatusRequestEntityTooLarge,
 		},
 		{
 			name: "eth_accounts does not get forwarded",
@@ -169,9 +176,14 @@ func TestBatching(t *testing.T) {
 			require.NoError(t, err)
 			defer shutdown()
 
+			expectedStatusCode := tt.expectedStatusCode
+			if expectedStatusCode == 0 {
+				expectedStatusCode = http.StatusOK
+			}
+
 			res, statusCode, err := client.SendBatchRPC(tt.reqs...)
 			require.NoError(t, err)
-			require.Equal(t, http.StatusOK, statusCode)
+			require.Equal(t, expectedStatusCode, statusCode)
 			RequireEqualJSON(t, []byte(tt.expectedRes), res)
 
 			if tt.numExpectedForwards != 0 {

--- a/proxyd/integration_tests/rpc_calls_test.go
+++ b/proxyd/integration_tests/rpc_calls_test.go
@@ -1,0 +1,229 @@
+package integration_tests
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/alicebob/miniredis"
+	"github.com/ethereum-optimism/infra/proxyd"
+	ms "github.com/ethereum-optimism/infra/proxyd/tools/mockserver/handler"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// sumRPCCalls totals every proxyd_rpc_calls_total series whose labels are a
+// superset of `labels`. Counters are process-global, so tests must compare
+// before/after deltas rather than absolute values.
+func sumRPCCalls(t *testing.T, labels map[string]string) float64 {
+	t.Helper()
+	return sumCounter(t, "proxyd_rpc_calls_total", labels)
+}
+
+func sumCounter(t *testing.T, name string, labels map[string]string) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	var total float64
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := make(map[string]string, len(m.GetLabel()))
+			for _, l := range m.GetLabel() {
+				got[l.GetName()] = l.GetValue()
+			}
+			match := true
+			for k, v := range labels {
+				if got[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				total += m.GetCounter().GetValue()
+			}
+		}
+	}
+	return total
+}
+
+func TestRPCCallsCountsEveryBatchElement(t *testing.T) {
+	InitLogger()
+
+	router := NewBatchRPCResponseRouter()
+	router.SetRoute("eth_chainId", "1", "0x1")
+	router.SetRoute("eth_chainId", "2", "0x1")
+	router.SetRoute("eth_chainId", "3", "0x1")
+
+	good := NewMockBackend(router)
+	defer good.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", good.URL()))
+
+	config := ReadConfig("rpc_calls")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+
+	okLabels := map[string]string{
+		"method_name": "eth_chainId",
+		"status_code": "200",
+		"transport":   "http",
+	}
+	before := sumRPCCalls(t, okLabels)
+
+	// A three-element batch must produce three increments, not one — and before
+	// this change a successful batch produced zero.
+	_, statusCode, err := client.SendBatchRPC(
+		NewRPCReq("1", "eth_chainId", nil),
+		NewRPCReq("2", "eth_chainId", nil),
+		NewRPCReq("3", "eth_chainId", nil),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 200, statusCode)
+
+	require.Equal(t, before+3, sumRPCCalls(t, okLabels))
+}
+
+func TestRPCCallsBoundsNonWhitelistedMethodName(t *testing.T) {
+	InitLogger()
+
+	good := NewMockBackend(SingleResponseHandler(200, buildResponse("0x1")))
+	defer good.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", good.URL()))
+
+	config := ReadConfig("rpc_calls")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+
+	// An arbitrary client-supplied method must collapse to method_not_allowed
+	// rather than becoming an unbounded Prometheus label value.
+	labels := map[string]string{
+		"method_name": "method_not_allowed",
+		"transport":   "http",
+	}
+	before := sumRPCCalls(t, labels)
+
+	_, _, err = client.SendRPC("definitely_not_whitelisted", nil)
+	require.NoError(t, err)
+
+	require.Equal(t, before+1, sumRPCCalls(t, labels))
+	// The raw method name must not appear anywhere in the metric.
+	require.Zero(t, sumRPCCalls(t, map[string]string{"method_name": "definitely_not_whitelisted"}))
+}
+
+func TestRPCCallsAttributesCacheHitsToCache(t *testing.T) {
+	InitLogger()
+
+	redis, err := miniredis.Run()
+	require.NoError(t, err)
+	defer redis.Close()
+	require.NoError(t, os.Setenv("REDIS_URL", fmt.Sprintf("redis://127.0.0.1:%s", redis.Port())))
+
+	router := NewBatchRPCResponseRouter()
+	// ProxydHTTPClient.SendRPC (util_test.go) always sends id "999" — the route
+	// must match that id or the mock backend 400s and the cache is never
+	// populated.
+	router.SetRoute("eth_chainId", "999", "0x1")
+
+	good := NewMockBackend(router)
+	defer good.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", good.URL()))
+
+	config := ReadConfig("rpc_calls_cache")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+
+	cacheLabels := map[string]string{
+		"backend_name": "cache",
+		"method_name":  "eth_chainId",
+		"status_code":  "200",
+		"transport":    "http",
+	}
+	before := sumRPCCalls(t, cacheLabels)
+
+	// First call populates the cache and is attributed to the backend.
+	_, _, err = client.SendRPC("eth_chainId", nil)
+	require.NoError(t, err)
+	require.Equal(t, before, sumRPCCalls(t, cacheLabels))
+
+	// Second call is served from cache and must be attributed to "cache" — a
+	// cache hit is still a client call and must appear in usage.
+	_, _, err = client.SendRPC("eth_chainId", nil)
+	require.NoError(t, err)
+	require.Equal(t, before+1, sumRPCCalls(t, cacheLabels))
+}
+
+// TestRPCCallsExcludesConsensusPoller deviates from a "send no traffic, assert
+// zero" version of this test: with no poller traffic at all, the assertions
+// below would hold vacuously regardless of whether ForwardRPC/doForward were
+// ever instrumented, which would make the test worthless against a regression.
+// Instead this actually drives one full consensus-poller update cycle against a
+// mock backend that answers eth_getBlockByNumber/net_peerCount/eth_syncing
+// correctly (reusing testdata/consensus_responses.yml, the same fixture
+// consensus_test.go relies on), and confirms the backend really was called
+// before asserting the metric stayed at zero.
+func TestRPCCallsExcludesConsensusPoller(t *testing.T) {
+	InitLogger()
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	responses := path.Join(dir, "testdata/consensus_responses.yml")
+	h := ms.MockedHandler{
+		Overrides:    []*ms.MethodTemplate{},
+		Autoload:     true,
+		AutoloadFile: responses,
+	}
+
+	good := NewMockBackend(http.HandlerFunc(h.Handler))
+	defer good.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", good.URL()))
+
+	// rpc_calls_consensus.toml enables routing_strategy = "consensus_aware" with
+	// consensus_handler = "noop" so the poller exists but is not driven by a
+	// background ticker; the test drives it synchronously below.
+	config := ReadConfig("rpc_calls_consensus")
+	svr, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	bg := svr.BackendGroups["main"]
+	require.NotNil(t, bg)
+	require.NotNil(t, bg.Consensus, "consensus poller must be active for this test to mean anything")
+
+	methods := []string{"eth_getBlockByNumber", "net_peerCount", "eth_syncing"}
+	before := make(map[string]float64, len(methods))
+	for _, method := range methods {
+		before[method] = sumRPCCalls(t, map[string]string{"method_name": method})
+	}
+
+	// Drive one full poll cycle. This calls net_peerCount, eth_syncing, and
+	// eth_getBlockByNumber (latest/safe/finalized) against the backend via
+	// Backend.ForwardRPC -> Backend.doForward, entering none of the three
+	// instrumentation sites (handleBatchRPC, the WS request/response path, or
+	// the WS relay path).
+	ctx := context.Background()
+	for _, be := range bg.Backends {
+		bg.Consensus.UpdateBackend(ctx, be)
+	}
+
+	// The poller must have actually hit the backend, or the assertions below
+	// would hold vacuously.
+	require.NotEmpty(t, good.Requests(), "consensus poller never called the backend")
+
+	for _, method := range methods {
+		require.Equal(t, before[method], sumRPCCalls(t, map[string]string{"method_name": method}), method)
+	}
+}

--- a/proxyd/integration_tests/rpc_calls_test.go
+++ b/proxyd/integration_tests/rpc_calls_test.go
@@ -126,6 +126,16 @@ func TestRPCCallsMixedBatchAcrossMinibatches(t *testing.T) {
 		"status_code":  "200",
 		"transport":    "http",
 	}
+	// The 10 net_version elements are the entire first minibatch — the exact shape
+	// the IMP-1 undercount defect lived in — so they must be asserted explicitly.
+	// sumRPCCalls only sums series matching the supplied label subset, so neither
+	// of the other two label sets covers them.
+	netVersionLabels := map[string]string{
+		"backend_name": "good",
+		"method_name":  "net_version",
+		"status_code":  "200",
+		"transport":    "http",
+	}
 	notAllowedLabels := map[string]string{
 		"backend_name": "proxyd",
 		"method_name":  "method_not_allowed",
@@ -133,7 +143,9 @@ func TestRPCCallsMixedBatchAcrossMinibatches(t *testing.T) {
 		"transport":    "http",
 	}
 	beforeOK := sumRPCCalls(t, okLabels)
+	beforeNetVersion := sumRPCCalls(t, netVersionLabels)
 	beforeNotAllowed := sumRPCCalls(t, notAllowedLabels)
+	beforeTotal := sumRPCCalls(t, map[string]string{"transport": "http"})
 
 	reqs := make([]*proxyd.RPCReq, 0, 12)
 	for i := 1; i <= 10; i++ {
@@ -148,7 +160,10 @@ func TestRPCCallsMixedBatchAcrossMinibatches(t *testing.T) {
 	require.Equal(t, 200, statusCode)
 
 	require.Equal(t, beforeOK+1, sumRPCCalls(t, okLabels))
+	require.Equal(t, beforeNetVersion+10, sumRPCCalls(t, netVersionLabels))
 	require.Equal(t, beforeNotAllowed+1, sumRPCCalls(t, notAllowedLabels))
+	// The headline claim, pinned directly: 12 elements in, 12 increments out.
+	require.Equal(t, beforeTotal+12, sumRPCCalls(t, map[string]string{"transport": "http"}))
 }
 
 func TestRPCCallsBoundsNonWhitelistedMethodName(t *testing.T) {

--- a/proxyd/integration_tests/rpc_calls_test.go
+++ b/proxyd/integration_tests/rpc_calls_test.go
@@ -91,6 +91,66 @@ func TestRPCCallsCountsEveryBatchElement(t *testing.T) {
 	require.Equal(t, before+3, sumRPCCalls(t, okLabels))
 }
 
+// TestRPCCallsMixedBatchAcrossMinibatches covers spec §5's "an N-element batch
+// with mixed outcomes produces exactly N increments with the expected status
+// distribution" — the claim the SLO rests on. The batch has 12 elements against
+// max_upstream_batch_size = 10 (testdata/rpc_calls.toml): 10 net_version calls
+// plus 1 eth_chainId call share a backend group and are forwarded across two
+// minibatches (10 then 1) — the exact multi-minibatch shape the original
+// short-circuit undercount defect (IMP-1) lived in — while 1 non-whitelisted
+// method is rejected locally without ever reaching the forward loop at all.
+func TestRPCCallsMixedBatchAcrossMinibatches(t *testing.T) {
+	InitLogger()
+
+	router := NewBatchRPCResponseRouter()
+	for i := 1; i <= 10; i++ {
+		router.SetRoute("net_version", fmt.Sprintf("%d", i), "0x1")
+	}
+	router.SetRoute("eth_chainId", "11", "0x1")
+
+	good := NewMockBackend(router)
+	defer good.Close()
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", good.URL()))
+
+	config := ReadConfig("rpc_calls")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+
+	// Mixed status, and mixed backend attribution, within one envelope.
+	okLabels := map[string]string{
+		"backend_name": "good",
+		"method_name":  "eth_chainId",
+		"status_code":  "200",
+		"transport":    "http",
+	}
+	notAllowedLabels := map[string]string{
+		"backend_name": "proxyd",
+		"method_name":  "method_not_allowed",
+		"status_code":  "403",
+		"transport":    "http",
+	}
+	beforeOK := sumRPCCalls(t, okLabels)
+	beforeNotAllowed := sumRPCCalls(t, notAllowedLabels)
+
+	reqs := make([]*proxyd.RPCReq, 0, 12)
+	for i := 1; i <= 10; i++ {
+		reqs = append(reqs, NewRPCReq(fmt.Sprintf("%d", i), "net_version", nil))
+	}
+	reqs = append(reqs, NewRPCReq("11", "eth_chainId", nil))
+	// ErrMethodNotWhitelisted.HTTPErrorCode == 403 (backend.go) — asserted below.
+	reqs = append(reqs, NewRPCReq("12", "definitely_not_whitelisted", nil))
+
+	_, statusCode, err := client.SendBatchRPC(reqs...)
+	require.NoError(t, err)
+	require.Equal(t, 200, statusCode)
+
+	require.Equal(t, beforeOK+1, sumRPCCalls(t, okLabels))
+	require.Equal(t, beforeNotAllowed+1, sumRPCCalls(t, notAllowedLabels))
+}
+
 func TestRPCCallsBoundsNonWhitelistedMethodName(t *testing.T) {
 	InitLogger()
 

--- a/proxyd/integration_tests/rpc_calls_ws_test.go
+++ b/proxyd/integration_tests/rpc_calls_ws_test.go
@@ -1,0 +1,135 @@
+package integration_tests
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/infra/proxyd"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// wsTestConfig returns a config where eth_chainId is both ws-whitelisted and
+// mapped (so it takes the handleWSRPC path) while eth_subscribe is ws-only (so it
+// takes the relay path). Mirrors the setup in ws_test.go:153.
+func wsTestConfig(httpBackendURL, wsBackendURL string) *proxyd.Config {
+	config := ReadConfig("rpc_calls")
+	config.Server.RPCPort = 0
+	config.Server.WSPort = 8546
+	config.WSBackendGroup = "main"
+	config.WSMethodWhitelist = []string{"eth_subscribe", "eth_accounts", "eth_chainId"}
+	config.Backends["good"].RPCURL = httpBackendURL
+	config.Backends["good"].WSURL = wsBackendURL
+	return config
+}
+
+func TestRPCCallsWSRelayedSubscribeAndNotifications(t *testing.T) {
+	InitLogger()
+
+	// The WS backend answers the subscribe, then pushes two notifications.
+	wsBackend := NewMockWSBackend(nil, func(conn *websocket.Conn, msgType int, data []byte) {
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage,
+			[]byte(`{"jsonrpc":"2.0","id":1,"result":"0xcafe"}`)))
+		for i := 0; i < 2; i++ {
+			require.NoError(t, conn.WriteMessage(websocket.TextMessage,
+				[]byte(`{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0xcafe","result":{}}}`)))
+		}
+	}, nil)
+	defer wsBackend.Close()
+
+	httpBackend := NewMockBackend(SingleResponseHandler(200, buildResponse("0x1")))
+	defer httpBackend.Close()
+
+	_, shutdown, err := proxyd.Start(wsTestConfig(httpBackend.URL(), wsBackend.URL()))
+	require.NoError(t, err)
+	defer shutdown()
+
+	received := make(chan struct{}, 8)
+	client, err := NewProxydWSClient("ws://127.0.0.1:8546", func(msgType int, data []byte) {
+		received <- struct{}{}
+	}, nil)
+	require.NoError(t, err)
+	defer client.HardClose()
+
+	relayedLabels := map[string]string{
+		"method_name": "eth_subscribe",
+		"status_code": "relayed",
+		"transport":   "ws",
+	}
+	beforeCalls := sumRPCCalls(t, relayedLabels)
+	beforeNotifs := sumCounter(t, "proxyd_rpc_notifications_total", map[string]string{})
+
+	require.NoError(t, client.WriteMessage(websocket.TextMessage,
+		[]byte(`{"id":1,"method":"eth_subscribe","params":["newHeads"]}`)))
+
+	// Wait for the response plus both notifications to reach the client.
+	for i := 0; i < 3; i++ {
+		select {
+		case <-received:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for WS message %d", i)
+		}
+	}
+
+	// One frame in = exactly one call, marked relayed because its response cannot
+	// be correlated back to the request.
+	require.Equal(t, beforeCalls+1, sumRPCCalls(t, relayedLabels))
+	// Both notifications counted as notifications, not as calls.
+	require.Equal(t, beforeNotifs+2, sumCounter(t, "proxyd_rpc_notifications_total", map[string]string{}))
+	// A notification must never be counted as a call.
+	require.Zero(t, sumRPCCalls(t, map[string]string{"method_name": "eth_subscription"}))
+}
+
+func TestRPCCallsWSMappedMethodRecordsRealStatusAndBackend(t *testing.T) {
+	InitLogger()
+
+	// eth_chainId is ws-whitelisted AND mapped, so it goes through handleWSRPC and
+	// out to the HTTP backend — the WS backend must see nothing.
+	var wsBackendMessages atomic.Int64
+	wsBackend := NewMockWSBackend(nil, func(conn *websocket.Conn, msgType int, data []byte) {
+		wsBackendMessages.Add(1)
+	}, nil)
+	defer wsBackend.Close()
+
+	httpBackend := NewMockBackend(SingleResponseHandler(200, buildResponse("0x1")))
+	defer httpBackend.Close()
+
+	_, shutdown, err := proxyd.Start(wsTestConfig(httpBackend.URL(), wsBackend.URL()))
+	require.NoError(t, err)
+	defer shutdown()
+
+	received := make(chan struct{}, 4)
+	client, err := NewProxydWSClient("ws://127.0.0.1:8546", func(msgType int, data []byte) {
+		received <- struct{}{}
+	}, nil)
+	require.NoError(t, err)
+	defer client.HardClose()
+
+	// Real derived status and the serving backend's name — not "relayed".
+	labels := map[string]string{
+		"backend_name": "good",
+		"method_name":  "eth_chainId",
+		"status_code":  "200",
+		"transport":    "ws",
+	}
+	before := sumRPCCalls(t, labels)
+
+	require.NoError(t, client.WriteMessage(websocket.TextMessage,
+		[]byte(`{"jsonrpc":"2.0","method":"eth_chainId","id":1}`)))
+
+	select {
+	case <-received:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for eth_chainId response")
+	}
+
+	require.Equal(t, before+1, sumRPCCalls(t, labels))
+	require.Equal(t, int64(0), wsBackendMessages.Load())
+	// It must not also be counted as relayed — that would mean both clientPump and
+	// handleWSRPC recorded the same call.
+	require.Zero(t, sumRPCCalls(t, map[string]string{
+		"method_name": "eth_chainId",
+		"status_code": "relayed",
+	}))
+}

--- a/proxyd/integration_tests/rpc_calls_ws_test.go
+++ b/proxyd/integration_tests/rpc_calls_ws_test.go
@@ -28,12 +28,22 @@ func TestRPCCallsWSRelayedSubscribeAndNotifications(t *testing.T) {
 	InitLogger()
 
 	// The WS backend answers the subscribe, then pushes two notifications.
+	// NB: this callback runs on the mock backend's read-loop goroutine, not the
+	// test goroutine, so require.NoError (which calls t.FailNow -> Goexit) would
+	// be undefined behavior here. Use t.Errorf instead so a write failure is
+	// reported rather than hanging the test to its timeout.
 	wsBackend := NewMockWSBackend(nil, func(conn *websocket.Conn, msgType int, data []byte) {
-		require.NoError(t, conn.WriteMessage(websocket.TextMessage,
-			[]byte(`{"jsonrpc":"2.0","id":1,"result":"0xcafe"}`)))
+		if err := conn.WriteMessage(websocket.TextMessage,
+			[]byte(`{"jsonrpc":"2.0","id":1,"result":"0xcafe"}`)); err != nil {
+			t.Errorf("writing subscribe response: %v", err)
+			return
+		}
 		for i := 0; i < 2; i++ {
-			require.NoError(t, conn.WriteMessage(websocket.TextMessage,
-				[]byte(`{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0xcafe","result":{}}}`)))
+			if err := conn.WriteMessage(websocket.TextMessage,
+				[]byte(`{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0xcafe","result":{}}}`)); err != nil {
+				t.Errorf("writing notification %d: %v", i, err)
+				return
+			}
 		}
 	}, nil)
 	defer wsBackend.Close()

--- a/proxyd/integration_tests/rpc_calls_ws_test.go
+++ b/proxyd/integration_tests/rpc_calls_ws_test.go
@@ -143,3 +143,96 @@ func TestRPCCallsWSMappedMethodRecordsRealStatusAndBackend(t *testing.T) {
 		"status_code": "relayed",
 	}))
 }
+
+// TestRPCCallsWSUnwhitelistedMethodNamedUnknownIsNotAllowed pins the regression
+// where a client naming its method the literal string "unknown" could collide
+// with the MethodUnknown sentinel and evade the method_not_allowed bucket. A
+// frame with method "unknown" fails the ws whitelist (prepareClientMsg returns
+// req != nil, err == ErrMethodNotWhitelisted), so it must be recorded as
+// method_not_allowed / 403, never as "unknown".
+func TestRPCCallsWSUnwhitelistedMethodNamedUnknownIsNotAllowed(t *testing.T) {
+	InitLogger()
+
+	// The frame is rejected locally by prepareClientMsg's whitelist check and
+	// never forwarded, so the WS backend must see nothing.
+	wsBackend := NewMockWSBackend(nil, func(conn *websocket.Conn, msgType int, data []byte) {}, nil)
+	defer wsBackend.Close()
+
+	httpBackend := NewMockBackend(SingleResponseHandler(200, buildResponse("0x1")))
+	defer httpBackend.Close()
+
+	_, shutdown, err := proxyd.Start(wsTestConfig(httpBackend.URL(), wsBackend.URL()))
+	require.NoError(t, err)
+	defer shutdown()
+
+	received := make(chan struct{}, 4)
+	client, err := NewProxydWSClient("ws://127.0.0.1:8546", func(msgType int, data []byte) {
+		received <- struct{}{}
+	}, nil)
+	require.NoError(t, err)
+	defer client.HardClose()
+
+	notAllowedLabels := map[string]string{
+		"method_name": "method_not_allowed",
+		"status_code": "403",
+		"transport":   "ws",
+	}
+	unknownLabels := map[string]string{
+		"method_name": "unknown",
+		"transport":   "ws",
+	}
+	beforeNotAllowed := sumRPCCalls(t, notAllowedLabels)
+	beforeUnknown := sumRPCCalls(t, unknownLabels)
+
+	require.NoError(t, client.WriteMessage(websocket.TextMessage,
+		[]byte(`{"jsonrpc":"2.0","method":"unknown","id":1}`)))
+
+	select {
+	case <-received:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for error response")
+	}
+
+	require.Equal(t, beforeNotAllowed+1, sumRPCCalls(t, notAllowedLabels))
+	require.Equal(t, beforeUnknown, sumRPCCalls(t, unknownLabels))
+}
+
+// TestRPCCallsWSMalformedFrameRecordsUnknown covers the other side of the
+// disambiguation: a frame that genuinely fails to parse (req == nil) must
+// still record method_name="unknown", not method_not_allowed.
+func TestRPCCallsWSMalformedFrameRecordsUnknown(t *testing.T) {
+	InitLogger()
+
+	wsBackend := NewMockWSBackend(nil, func(conn *websocket.Conn, msgType int, data []byte) {}, nil)
+	defer wsBackend.Close()
+
+	httpBackend := NewMockBackend(SingleResponseHandler(200, buildResponse("0x1")))
+	defer httpBackend.Close()
+
+	_, shutdown, err := proxyd.Start(wsTestConfig(httpBackend.URL(), wsBackend.URL()))
+	require.NoError(t, err)
+	defer shutdown()
+
+	received := make(chan struct{}, 4)
+	client, err := NewProxydWSClient("ws://127.0.0.1:8546", func(msgType int, data []byte) {
+		received <- struct{}{}
+	}, nil)
+	require.NoError(t, err)
+	defer client.HardClose()
+
+	unknownLabels := map[string]string{
+		"method_name": "unknown",
+		"transport":   "ws",
+	}
+	beforeUnknown := sumRPCCalls(t, unknownLabels)
+
+	require.NoError(t, client.WriteMessage(websocket.TextMessage, []byte(`{not valid json`)))
+
+	select {
+	case <-received:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for error response")
+	}
+
+	require.Equal(t, beforeUnknown+1, sumRPCCalls(t, unknownLabels))
+}

--- a/proxyd/integration_tests/testdata/rpc_calls.toml
+++ b/proxyd/integration_tests/testdata/rpc_calls.toml
@@ -1,0 +1,21 @@
+[server]
+
+rpc_port = 8545
+max_upstream_batch_size = 10
+
+[backend]
+response_timeout_seconds = 1
+
+[backends]
+[backends.good]
+rpc_url = "$GOOD_BACKEND_RPC_URL"
+ws_url = "$GOOD_BACKEND_RPC_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["good"]
+
+[rpc_method_mappings]
+eth_chainId = "main"
+net_version = "main"
+eth_call = "main"

--- a/proxyd/integration_tests/testdata/rpc_calls_cache.toml
+++ b/proxyd/integration_tests/testdata/rpc_calls_cache.toml
@@ -1,0 +1,26 @@
+[server]
+
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 1
+
+[redis]
+url = "$REDIS_URL"
+namespace = "proxyd"
+
+[cache]
+enabled = true
+
+[backends]
+[backends.good]
+rpc_url = "$GOOD_BACKEND_RPC_URL"
+ws_url = "$GOOD_BACKEND_RPC_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["good"]
+
+[rpc_method_mappings]
+eth_chainId = "main"
+net_version = "main"

--- a/proxyd/integration_tests/testdata/rpc_calls_consensus.toml
+++ b/proxyd/integration_tests/testdata/rpc_calls_consensus.toml
@@ -1,0 +1,20 @@
+[server]
+
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 1
+
+[backends]
+[backends.good]
+rpc_url = "$GOOD_BACKEND_RPC_URL"
+ws_url = "$GOOD_BACKEND_RPC_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["good"]
+routing_strategy = "consensus_aware"
+consensus_handler = "noop" # driven manually in the test for determinism
+
+[rpc_method_mappings]
+eth_chainId = "main"

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -987,11 +987,24 @@ func boolToFloat64(b bool) float64 {
 // statusCodeForRPCRes derives the HTTP-equivalent status code for a single
 // JSON-RPC response, for per-call metrics.
 //
-// An error with HTTPErrorCode == 0 means the backend answered HTTP 200 while
-// carrying a JSON-RPC error — doForward only stamps HTTPErrorCode when the
-// upstream status was non-200. Those are request-level faults ("already known",
-// "nonce too low", "execution reverted") and MUST map to 400, not 500: reporting
-// them as 5xx would burn the error-rate SLO on routine client errors.
+// An error with HTTPErrorCode == 0 is, in the common case, a backend that
+// answered HTTP 200 while carrying a JSON-RPC error: doForward stamps
+// HTTPErrorCode only when the upstream status was non-200. Those are
+// request-level faults ("already known", "nonce too low", "execution reverted")
+// and MUST map to 400, not 500 — reporting them as 5xx would burn the error-rate
+// SLO on routine client errors.
+//
+// doForward is not the only writer. HTTPErrorCode is also set on proxyd's own
+// error table (backend.go) and, notably, on interop-filter failures:
+// ParseInteropError and interop_strategy.go copy the interop filter backend's
+// raw upstream HTTP status through verbatim. So the status_code label domain is
+// not proxyd's fixed table alone — it is that table plus whatever status the
+// filter emits (bounded by HTTP's 100-599, so label cardinality stays bounded,
+// but the values are partly sourced from a remote service). Those calls are
+// recorded with backend_name="proxyd", because the filter round-trip happens in
+// prepareRPCForForward before any backend is selected; an operator paging on
+// backend_name="proxyd" with a 5xx should treat the interop filter as a
+// candidate cause alongside proxyd itself.
 func statusCodeForRPCRes(res *RPCRes) string {
 	if res == nil {
 		// Should not happen; a nil response slot is an internal failure.
@@ -1053,6 +1066,21 @@ func recordRPCCallsAll(methods, backends []string, transport, statusCode string)
 	for i := range methods {
 		RecordRPCCall(backends[i], methods[i], statusCode, transport)
 	}
+}
+
+// deadlineShortCircuitStatus returns the status the HTTP handler goes on to write
+// to the client when handleBatchRPC short-circuits on an expired context.
+//
+// HandleRPC maps context.DeadlineExceeded to ErrGatewayTimeout (504) on the batch
+// path only. The single-request path has no DeadlineExceeded case and falls
+// through to ErrInternal (500). Recording 504 on both would report a timeout the
+// client never saw for single requests — the divergence lives here so it has one
+// definition and a test.
+func deadlineShortCircuitStatus(isBatch bool) string {
+	if isBatch {
+		return statusCodeGatewayTimeout
+	}
+	return statusCodeInternal
 }
 
 // backendNameFromServedBy extracts the backend name from a servedBy string,

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -183,6 +183,28 @@ var (
 		"status_code",
 	})
 
+	rpcCallsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "rpc_calls_total",
+		Help: "Count of client-initiated JSON-RPC calls by the outcome the client received. " +
+			"One increment per call: batch elements are counted individually, as is each WS frame. " +
+			"Recorded after retries and failover, so it reflects what the client saw. " +
+			"Excludes consensus-poller traffic.",
+	}, []string{
+		"backend_name",
+		"method_name",
+		"status_code",
+		"transport",
+	})
+
+	rpcNotificationsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "rpc_notifications_total",
+		Help:      "Count of client-bound WS subscription notifications delivered.",
+	}, []string{
+		"backend_name",
+	})
+
 	httpRequestDurationSumm = promauto.NewSummary(prometheus.SummaryOpts{
 		Namespace:  MetricsNamespace,
 		Name:       "http_request_duration_seconds",
@@ -982,6 +1004,42 @@ func statusCodeForRPCRes(res *RPCRes) string {
 		return strconv.Itoa(res.Error.HTTPErrorCode)
 	}
 	return statusCodeBadRequest
+}
+
+// RecordRPCCall records one client-initiated JSON-RPC call and the outcome the
+// client received. Callers must pass a method name already bounded by
+// Server.metricMethodName or WSProxier.metricMethodName — never a raw
+// client-supplied method string, which is unbounded label cardinality.
+func RecordRPCCall(backendName, method, statusCode, transport string) {
+	if backendName == "" {
+		backendName = BackendProxyd
+	}
+	if method == "" {
+		method = MethodUnknown
+	}
+	rpcCallsTotal.WithLabelValues(backendName, method, statusCode, transport).Inc()
+}
+
+// RecordRPCNotification records one client-bound WS subscription notification.
+func RecordRPCNotification(backendName string) {
+	if backendName == "" {
+		backendName = BackendProxyd
+	}
+	rpcNotificationsTotal.WithLabelValues(backendName).Inc()
+}
+
+// recordRPCCalls records one call per element of a handled request set. Slots
+// whose response was never filled — an early return aborted the request set —
+// are recorded with fallbackStatus, which must match the status the HTTP handler
+// goes on to write to the client.
+func recordRPCCalls(responses []*RPCRes, methods, backends []string, transport, fallbackStatus string) {
+	for i := range responses {
+		status := fallbackStatus
+		if responses[i] != nil {
+			status = statusCodeForRPCRes(responses[i])
+		}
+		RecordRPCCall(backends[i], methods[i], status, transport)
+	}
 }
 
 // backendNameFromServedBy extracts the backend name from a servedBy string,

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -22,10 +22,22 @@ const (
 	RPCRequestSourceWS   = "ws"
 
 	BackendProxyd    = "proxyd"
+	BackendCache     = "cache"
 	SourceClient     = "client"
 	SourceBackend    = "backend"
 	MethodUnknown    = "unknown"
 	MethodNotAllowed = "method_not_allowed"
+
+	statusCodeOK             = "200"
+	statusCodeBadRequest     = "400"
+	statusCodeInternal       = "500"
+	statusCodeGatewayTimeout = "504"
+
+	// StatusCodeRelayed marks a WS call relayed to the backend whose response
+	// cannot be correlated back to the request (eth_subscribe / eth_unsubscribe).
+	// Deliberately non-numeric so status_code=~"2.." and status_code=~"5.." can
+	// never match it: such a call is neither a success nor a failure.
+	StatusCodeRelayed = "relayed"
 )
 
 var PayloadSizeBuckets = []float64{10, 50, 100, 500, 1000, 5000, 10000, 100000, 1000000}
@@ -948,6 +960,41 @@ func boolToFloat64(b bool) float64 {
 		return 1
 	}
 	return 0
+}
+
+// statusCodeForRPCRes derives the HTTP-equivalent status code for a single
+// JSON-RPC response, for per-call metrics.
+//
+// An error with HTTPErrorCode == 0 means the backend answered HTTP 200 while
+// carrying a JSON-RPC error — doForward only stamps HTTPErrorCode when the
+// upstream status was non-200. Those are request-level faults ("already known",
+// "nonce too low", "execution reverted") and MUST map to 400, not 500: reporting
+// them as 5xx would burn the error-rate SLO on routine client errors.
+func statusCodeForRPCRes(res *RPCRes) string {
+	if res == nil {
+		// Should not happen; a nil response slot is an internal failure.
+		return statusCodeInternal
+	}
+	if !res.IsError() {
+		return statusCodeOK
+	}
+	if res.Error.HTTPErrorCode != 0 {
+		return strconv.Itoa(res.Error.HTTPErrorCode)
+	}
+	return statusCodeBadRequest
+}
+
+// backendNameFromServedBy extracts the backend name from a servedBy string,
+// which ForwardRequestToBackendGroup formats as "<group>/<backend>". Falls back
+// to BackendProxyd so the label is never empty.
+func backendNameFromServedBy(servedBy string) string {
+	if i := strings.LastIndex(servedBy, "/"); i >= 0 {
+		servedBy = servedBy[i+1:]
+	}
+	if servedBy == "" {
+		return BackendProxyd
+	}
+	return servedBy
 }
 
 const (

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -1042,6 +1042,19 @@ func recordRPCCalls(responses []*RPCRes, methods, backends []string, transport, 
 	}
 }
 
+// recordRPCCallsAll records every call in a request set with the same status,
+// ignoring any per-element responses computed so far. Use it on exits where the
+// whole set failed wholesale and the client received a single error envelope
+// rather than any per-element results — e.g. cache hits or forwarded minibatches
+// from earlier loop iterations that succeeded before a later iteration aborted
+// the whole request. Those per-element outcomes never reached the client and
+// must not be reported as successes just because their slot was filled.
+func recordRPCCallsAll(methods, backends []string, transport, statusCode string) {
+	for i := range methods {
+		RecordRPCCall(backends[i], methods[i], statusCode, transport)
+	}
+}
+
 // backendNameFromServedBy extracts the backend name from a servedBy string,
 // which ForwardRequestToBackendGroup formats as "<group>/<backend>". Falls back
 // to BackendProxyd so the label is never empty.

--- a/proxyd/metrics_test.go
+++ b/proxyd/metrics_test.go
@@ -1,6 +1,9 @@
 package proxyd
 
 import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -179,4 +182,19 @@ func TestWSProxierMetricMethodNameBoundsCardinality(t *testing.T) {
 	require.Equal(t, "eth_subscribe", w.metricMethodName("eth_subscribe"))
 	require.Equal(t, MethodUnknown, w.metricMethodName(""))
 	require.Equal(t, MethodNotAllowed, w.metricMethodName("not_whitelisted"))
+}
+
+func TestWriteBatchRPCResRecordsEnvelopeStatus(t *testing.T) {
+	labels := map[string]string{"status_code": "200"}
+	before := gatherCounter(t, "proxyd_http_response_codes_total", labels)
+
+	rec := httptest.NewRecorder()
+	writeBatchRPCRes(context.Background(), rec, []*RPCRes{
+		{JSONRPC: JSONRPCVersion, Result: "0x1", ID: json.RawMessage("1")},
+		{JSONRPC: JSONRPCVersion, Result: "0x2", ID: json.RawMessage("2")},
+	})
+
+	require.Equal(t, 200, rec.Code)
+	// One increment per HTTP response, not per batch element.
+	require.Equal(t, before+1, gatherCounter(t, "proxyd_http_response_codes_total", labels))
 }

--- a/proxyd/metrics_test.go
+++ b/proxyd/metrics_test.go
@@ -24,6 +24,9 @@ func TestStatusCodeForRPCRes(t *testing.T) {
 		{"method not whitelisted", &RPCRes{Error: ErrMethodNotWhitelisted}, "403"},
 		{"gateway timeout", &RPCRes{Error: ErrGatewayTimeout}, "504"},
 		{"body too large", &RPCRes{Error: ErrRequestBodyTooLarge}, "413"},
+		// ErrTooManyBatchRequests carried no HTTPErrorCode, so this rejection reported
+		// 200 on both the HTTP and per-call metrics during a 100%-failure condition.
+		{"too many batch requests", &RPCRes{Error: ErrTooManyBatchRequests}, "413"},
 		{"proxyd internal", &RPCRes{Error: ErrInternal}, "500"},
 		{
 			"upstream non-200 stamped per element",
@@ -50,11 +53,6 @@ func TestStatusCodeForRPCRes(t *testing.T) {
 		{
 			"upstream method not found",
 			&RPCRes{Error: &RPCErr{Code: -32601, Message: "the method does not exist"}},
-			"400",
-		},
-		{
-			"too many batch requests has no http code",
-			&RPCRes{Error: ErrTooManyBatchRequests},
 			"400",
 		},
 		{"nil response treated as internal error", nil, "500"},
@@ -157,6 +155,33 @@ func TestRecordRPCCallsAllIgnoresPerElementResponses(t *testing.T) {
 
 	require.Equal(t, before200, gatherCounter(t, "proxyd_rpc_calls_total", labels("200")))
 	require.Equal(t, before504+3, gatherCounter(t, "proxyd_rpc_calls_total", labels("504")))
+}
+
+// The deadline short-circuit must record the status the client actually receives,
+// which differs by path: HandleRPC maps context.DeadlineExceeded to
+// ErrGatewayTimeout only for batches, and writes ErrInternal for single requests.
+// Recording 504 for both would fire a timeout alert for what the client saw as an
+// internal error — and hide it from a 500-only alert.
+func TestDeadlineShortCircuitStatusMatchesHandlerPath(t *testing.T) {
+	require.Equal(t, statusCodeGatewayTimeout, deadlineShortCircuitStatus(true))
+	require.Equal(t, statusCodeInternal, deadlineShortCircuitStatus(false))
+}
+
+// A partially-overridden batch returns a real servedBy for the elements a backend
+// answered, so the overridden elements must be distinguishable or they inherit a
+// backend that never saw them. OverrideResponses is the single merge point, so
+// marking there covers every override site.
+func TestOverrideResponsesMarksServedLocally(t *testing.T) {
+	forwarded := &RPCRes{ID: json.RawMessage(`2`), Result: "from-backend"}
+	overridden := &RPCRes{ID: json.RawMessage(`1`), Result: "from-consensus"}
+
+	res := OverrideResponses([]*RPCRes{forwarded}, []*indexedReqRes{
+		{index: 0, res: overridden},
+	})
+
+	require.Equal(t, []*RPCRes{overridden, forwarded}, res)
+	require.True(t, overridden.servedLocally, "proxyd answered this element itself")
+	require.False(t, forwarded.servedLocally, "a backend answered this element")
 }
 
 func TestServerMetricMethodNameBoundsCardinality(t *testing.T) {

--- a/proxyd/metrics_test.go
+++ b/proxyd/metrics_test.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,4 +82,83 @@ func TestBackendNameFromServedBy(t *testing.T) {
 			require.Equal(t, tt.want, backendNameFromServedBy(tt.servedBy))
 		})
 	}
+}
+
+func TestRecordRPCCallDefaultsEmptyLabels(t *testing.T) {
+	before := gatherCounter(t, "proxyd_rpc_calls_total", map[string]string{
+		"backend_name": "proxyd",
+		"method_name":  "unknown",
+		"status_code":  "500",
+		"transport":    "http",
+	})
+
+	// Empty backend and method must not produce empty label values.
+	RecordRPCCall("", "", statusCodeInternal, RPCRequestSourceHTTP)
+
+	after := gatherCounter(t, "proxyd_rpc_calls_total", map[string]string{
+		"backend_name": "proxyd",
+		"method_name":  "unknown",
+		"status_code":  "500",
+		"transport":    "http",
+	})
+	require.Equal(t, before+1, after)
+}
+
+func TestRecordRPCCallsFillsNilSlotsWithFallback(t *testing.T) {
+	labels := func(status string) map[string]string {
+		return map[string]string{
+			"backend_name": "reth-0",
+			"method_name":  "eth_chainId",
+			"status_code":  status,
+			"transport":    "http",
+		}
+	}
+	before200 := gatherCounter(t, "proxyd_rpc_calls_total", labels("200"))
+	before504 := gatherCounter(t, "proxyd_rpc_calls_total", labels("504"))
+
+	responses := []*RPCRes{{Result: "0x1"}, nil}
+	methods := []string{"eth_chainId", "eth_chainId"}
+	backends := []string{"reth-0", "reth-0"}
+
+	recordRPCCalls(responses, methods, backends, RPCRequestSourceHTTP, statusCodeGatewayTimeout)
+
+	require.Equal(t, before200+1, gatherCounter(t, "proxyd_rpc_calls_total", labels("200")))
+	require.Equal(t, before504+1, gatherCounter(t, "proxyd_rpc_calls_total", labels("504")))
+}
+
+func TestRecordRPCNotification(t *testing.T) {
+	labels := map[string]string{"backend_name": "reth-0"}
+	before := gatherCounter(t, "proxyd_rpc_notifications_total", labels)
+	RecordRPCNotification("reth-0")
+	require.Equal(t, before+1, gatherCounter(t, "proxyd_rpc_notifications_total", labels))
+}
+
+// gatherCounter returns the current value of the counter named `name` whose
+// labels are a superset of `labels`, or 0 if no such series exists yet.
+func gatherCounter(t *testing.T, name string, labels map[string]string) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := make(map[string]string, len(m.GetLabel()))
+			for _, l := range m.GetLabel() {
+				got[l.GetName()] = l.GetValue()
+			}
+			match := true
+			for k, v := range labels {
+				if got[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
 }

--- a/proxyd/metrics_test.go
+++ b/proxyd/metrics_test.go
@@ -172,3 +172,11 @@ func gatherCounter(t *testing.T, name string, labels map[string]string) float64 
 	}
 	return 0
 }
+
+func TestWSProxierMetricMethodNameBoundsCardinality(t *testing.T) {
+	w := &WSProxier{methodWhitelist: NewStringSetFromStrings([]string{"eth_subscribe"})}
+
+	require.Equal(t, "eth_subscribe", w.metricMethodName("eth_subscribe"))
+	require.Equal(t, MethodUnknown, w.metricMethodName(""))
+	require.Equal(t, MethodNotAllowed, w.metricMethodName("not_whitelisted"))
+}

--- a/proxyd/metrics_test.go
+++ b/proxyd/metrics_test.go
@@ -1,0 +1,84 @@
+package proxyd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusCodeForRPCRes(t *testing.T) {
+	tests := []struct {
+		name string
+		res  *RPCRes
+		want string
+	}{
+		{"success with result", &RPCRes{Result: "0x1"}, "200"},
+		{"success with nil result", &RPCRes{}, "200"},
+		{"rate limited", &RPCRes{Error: ErrOverRateLimit}, "429"},
+		{"client canceled", &RPCRes{Error: ErrContextCanceled}, "499"},
+		{"backend offline", &RPCRes{Error: ErrBackendOffline}, "503"},
+		{"method not whitelisted", &RPCRes{Error: ErrMethodNotWhitelisted}, "403"},
+		{"gateway timeout", &RPCRes{Error: ErrGatewayTimeout}, "504"},
+		{"body too large", &RPCRes{Error: ErrRequestBodyTooLarge}, "413"},
+		{"proxyd internal", &RPCRes{Error: ErrInternal}, "500"},
+		{
+			"upstream non-200 stamped per element",
+			&RPCRes{Error: &RPCErr{Code: -32000, Message: "boom", HTTPErrorCode: 500}},
+			"500",
+		},
+		// The critical cases: backend answered HTTP 200 carrying a JSON-RPC error,
+		// so HTTPErrorCode was never stamped. These MUST NOT be 5xx.
+		{
+			"already known",
+			&RPCRes{Error: &RPCErr{Code: -32000, Message: "already known"}},
+			"400",
+		},
+		{
+			"nonce too low",
+			&RPCRes{Error: &RPCErr{Code: -32000, Message: "nonce too low"}},
+			"400",
+		},
+		{
+			"replacement transaction underpriced",
+			&RPCRes{Error: &RPCErr{Code: -32000, Message: "replacement transaction underpriced"}},
+			"400",
+		},
+		{
+			"upstream method not found",
+			&RPCRes{Error: &RPCErr{Code: -32601, Message: "the method does not exist"}},
+			"400",
+		},
+		{
+			"too many batch requests has no http code",
+			&RPCRes{Error: ErrTooManyBatchRequests},
+			"400",
+		},
+		{"nil response treated as internal error", nil, "500"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, statusCodeForRPCRes(tt.res))
+		})
+	}
+}
+
+func TestBackendNameFromServedBy(t *testing.T) {
+	tests := []struct {
+		name     string
+		servedBy string
+		want     string
+	}{
+		{"group and backend", "replicas/reth-0", "reth-0"},
+		{"bare backend name", "reth-0", "reth-0"},
+		{"empty falls back to proxyd", "", "proxyd"},
+		{"trailing slash falls back to proxyd", "replicas/", "proxyd"},
+		{"nested slashes take the last segment", "a/b/c", "c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, backendNameFromServedBy(tt.servedBy))
+		})
+	}
+}

--- a/proxyd/metrics_test.go
+++ b/proxyd/metrics_test.go
@@ -216,11 +216,14 @@ func TestWSProxierMetricMethodNameBoundsCardinality(t *testing.T) {
 	require.Equal(t, "eth_subscribe", w.metricMethodName("eth_subscribe"))
 	require.Equal(t, MethodUnknown, w.metricMethodName(""))
 	require.Equal(t, MethodNotAllowed, w.metricMethodName("not_whitelisted"))
-	// Already-bounded sentinels (as clientPump passes through on a parse
-	// failure) must pass through unchanged, not get re-mapped by the whitelist
-	// check — the literal strings "unknown"/"method_not_allowed" are not
-	// themselves whitelisted methods.
-	require.Equal(t, MethodUnknown, w.metricMethodName(MethodUnknown))
+	// A client naming its method with one of the sentinel literals must NOT be
+	// able to masquerade as that sentinel — it is just another non-whitelisted
+	// method and must collapse to MethodNotAllowed like any other. Callers
+	// that need to report a genuine parse failure (no method to speak of) do
+	// so by recording MethodUnknown directly, without going through
+	// metricMethodName at all — see clientPump's prepareClientMsg-error
+	// branch.
+	require.Equal(t, MethodNotAllowed, w.metricMethodName(MethodUnknown))
 	require.Equal(t, MethodNotAllowed, w.metricMethodName(MethodNotAllowed))
 }
 

--- a/proxyd/metrics_test.go
+++ b/proxyd/metrics_test.go
@@ -126,6 +126,16 @@ func TestRecordRPCCallsFillsNilSlotsWithFallback(t *testing.T) {
 	require.Equal(t, before504+1, gatherCounter(t, "proxyd_rpc_calls_total", labels("504")))
 }
 
+func TestServerMetricMethodNameBoundsCardinality(t *testing.T) {
+	s := &Server{rpcMethodMappings: map[string]string{"eth_chainId": "replicas"}}
+
+	require.Equal(t, "eth_chainId", s.metricMethodName("eth_chainId"))
+	require.Equal(t, MethodUnknown, s.metricMethodName(""))
+	// An arbitrary client-supplied method must never become a label value.
+	require.Equal(t, MethodNotAllowed, s.metricMethodName("evil_"+string(make([]byte, 128))))
+	require.Equal(t, MethodNotAllowed, s.metricMethodName("not_whitelisted"))
+}
+
 func TestRecordRPCNotification(t *testing.T) {
 	labels := map[string]string{"backend_name": "reth-0"}
 	before := gatherCounter(t, "proxyd_rpc_notifications_total", labels)

--- a/proxyd/metrics_test.go
+++ b/proxyd/metrics_test.go
@@ -129,6 +129,36 @@ func TestRecordRPCCallsFillsNilSlotsWithFallback(t *testing.T) {
 	require.Equal(t, before504+1, gatherCounter(t, "proxyd_rpc_calls_total", labels("504")))
 }
 
+// TestRecordRPCCallsAllIgnoresPerElementResponses locks in the IMP-1 fix: on a
+// wholesale-failure exit, a slot that was already filled with a real success
+// (a cache hit, a locally-answered element, or a minibatch forwarded in a
+// prior loop iteration) must NOT be reported as a 200 just because a response
+// was computed for it — the client never saw it, only the single error
+// envelope. Every element must land on the fallback status.
+func TestRecordRPCCallsAllIgnoresPerElementResponses(t *testing.T) {
+	labels := func(status string) map[string]string {
+		return map[string]string{
+			"backend_name": "reth-0",
+			"method_name":  "eth_chainId",
+			"status_code":  status,
+			"transport":    "http",
+		}
+	}
+	before200 := gatherCounter(t, "proxyd_rpc_calls_total", labels("200"))
+	before504 := gatherCounter(t, "proxyd_rpc_calls_total", labels("504"))
+
+	// Three elements: two already have a filled, successful response (as they
+	// would after earlier minibatches/cache hits succeeded), one was never
+	// reached. recordRPCCallsAll must record all three as 504, none as 200.
+	methods := []string{"eth_chainId", "eth_chainId", "eth_chainId"}
+	backends := []string{"reth-0", "reth-0", "reth-0"}
+
+	recordRPCCallsAll(methods, backends, RPCRequestSourceHTTP, statusCodeGatewayTimeout)
+
+	require.Equal(t, before200, gatherCounter(t, "proxyd_rpc_calls_total", labels("200")))
+	require.Equal(t, before504+3, gatherCounter(t, "proxyd_rpc_calls_total", labels("504")))
+}
+
 func TestServerMetricMethodNameBoundsCardinality(t *testing.T) {
 	s := &Server{rpcMethodMappings: map[string]string{"eth_chainId": "replicas"}}
 
@@ -137,6 +167,10 @@ func TestServerMetricMethodNameBoundsCardinality(t *testing.T) {
 	// An arbitrary client-supplied method must never become a label value.
 	require.Equal(t, MethodNotAllowed, s.metricMethodName("evil_"+string(make([]byte, 128))))
 	require.Equal(t, MethodNotAllowed, s.metricMethodName("not_whitelisted"))
+	// eth_accounts is answered locally before the rpcMethodMappings lookup and
+	// is deliberately never mapped; it must pass through as itself rather than
+	// collapsing to MethodNotAllowed and polluting that bucket with 200s.
+	require.Equal(t, "eth_accounts", s.metricMethodName("eth_accounts"))
 }
 
 func TestRecordRPCNotification(t *testing.T) {
@@ -182,6 +216,12 @@ func TestWSProxierMetricMethodNameBoundsCardinality(t *testing.T) {
 	require.Equal(t, "eth_subscribe", w.metricMethodName("eth_subscribe"))
 	require.Equal(t, MethodUnknown, w.metricMethodName(""))
 	require.Equal(t, MethodNotAllowed, w.metricMethodName("not_whitelisted"))
+	// Already-bounded sentinels (as clientPump passes through on a parse
+	// failure) must pass through unchanged, not get re-mapped by the whitelist
+	// check — the literal strings "unknown"/"method_not_allowed" are not
+	// themselves whitelisted methods.
+	require.Equal(t, MethodUnknown, w.metricMethodName(MethodUnknown))
+	require.Equal(t, MethodNotAllowed, w.metricMethodName(MethodNotAllowed))
 }
 
 func TestWriteBatchRPCResRecordsEnvelopeStatus(t *testing.T) {

--- a/proxyd/rpc.go
+++ b/proxyd/rpc.go
@@ -18,6 +18,15 @@ type RPCRes struct {
 	Result  interface{}
 	Error   *RPCErr
 	ID      json.RawMessage
+
+	// servedLocally marks a response proxyd produced itself instead of obtaining
+	// it from a backend — a consensus-state answer or a block-tag rewrite
+	// rejection. Set by OverrideResponses, the single point where overridden
+	// responses are merged back into a batch result, and read by handleBatchRPC
+	// so per-call metrics attribute the element to proxyd rather than to the
+	// backend that served its siblings. Unexported and absent from rpcResJSON, so
+	// it never reaches the wire.
+	servedLocally bool
 }
 
 type rpcResJSON struct {

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -769,14 +769,15 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				batchRPCShortCircuitsTotal.Inc()
 				// The whole request set failed wholesale: this function returns a bare
 				// error, so HandleRPC writes a single error envelope for the entire
-				// batch (ErrGatewayTimeout/504 on the batch path; the single-request
-				// path has no DeadlineExceeded case and writes ErrInternal/500 instead).
-				// The client receives none of the per-element results computed so far
-				// (cache hits, locally-answered elements, or minibatches already
-				// forwarded in a prior iteration) — every element must be recorded with
-				// the fallback status, not the per-element status that never reached
-				// the client.
-				recordRPCCallsAll(callMethods, callBackends, RPCRequestSourceHTTP, statusCodeGatewayTimeout)
+				// request set. The client receives none of the per-element results
+				// computed so far (cache hits, locally-answered elements, or minibatches
+				// already forwarded in a prior iteration) — every element must be
+				// recorded with the status the client actually received, not the
+				// per-element status that never reached it.
+				//
+				// That status differs between the batch and single-request paths — see
+				// deadlineShortCircuitStatus.
+				recordRPCCallsAll(callMethods, callBackends, RPCRequestSourceHTTP, deadlineShortCircuitStatus(isBatch))
 				return nil, false, "", context.DeadlineExceeded
 			}
 
@@ -826,12 +827,22 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				}
 			}
 
-			// sb is "" when the forward failed outright, which backendNameFromServedBy
-			// resolves to BackendProxyd — such a batch was never served by a backend.
+			// sb is "" when the forward failed outright, and also when consensus or
+			// block-tag rewriting overrode every element so no backend was contacted at
+			// all (BackendGroup.ForwardWithSource). backendNameFromServedBy resolves
+			// both to BackendProxyd, which is the correct attribution: neither case was
+			// served by a backend.
 			forwardedBy := backendNameFromServedBy(sb)
 			for i := range elems {
 				responses[elems[i].Index] = res[i]
-				callBackends[elems[i].Index] = forwardedBy
+				// With a *partial* override, sb names the backend that served the
+				// remaining elements, so the overridden ones must not inherit it — they
+				// were answered by proxyd from consensus state or rejected by a rewrite.
+				if res[i].servedLocally {
+					callBackends[elems[i].Index] = BackendProxyd
+				} else {
+					callBackends[elems[i].Index] = forwardedBy
+				}
 
 				// TODO(inphi): batch put these
 				if res[i].Error == nil && res[i].Result != nil {
@@ -1242,7 +1253,10 @@ func writeBatchRPCRes(ctx context.Context, w http.ResponseWriter, res []*RPCRes)
 		RecordRPCError(ctx, BackendProxyd, MethodUnknown, err)
 		return
 	}
-	httpResponseCodesTotal.WithLabelValues(strconv.Itoa(200)).Inc()
+	// A batch envelope is always HTTP 200 — per-element outcomes are invisible to
+	// this metric by construction, so a batch in which every element failed still
+	// counts here as a 200. proxyd_rpc_calls_total is the per-element view.
+	httpResponseCodesTotal.WithLabelValues(statusCodeOK).Inc()
 	RecordResponsePayloadSize(ctx, ww.Len)
 }
 

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -372,6 +372,7 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 
 	// Reject new requests during drain
 	if s.isDraining.Load() {
+		httpResponseCodesTotal.WithLabelValues(strconv.Itoa(http.StatusServiceUnavailable)).Inc()
 		http.Error(w, "Server is draining", http.StatusServiceUnavailable)
 		return
 	}
@@ -1216,6 +1217,7 @@ func writeBatchRPCRes(ctx context.Context, w http.ResponseWriter, res []*RPCRes)
 		RecordRPCError(ctx, BackendProxyd, MethodUnknown, err)
 		return
 	}
+	httpResponseCodesTotal.WithLabelValues(strconv.Itoa(200)).Inc()
 	RecordResponsePayloadSize(ctx, ww.Len)
 }
 

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -655,6 +655,20 @@ func (s *Server) prepareRPCForForward(
 	return nil, group, txHash
 }
 
+// metricMethodName bounds the method_name label cardinality. Method names are
+// client-supplied and reachable by unauthenticated clients, so anything outside
+// the configured whitelist collapses to MethodNotAllowed rather than becoming an
+// unbounded Prometheus label value.
+func (s *Server) metricMethodName(method string) string {
+	if method == "" {
+		return MethodUnknown
+	}
+	if s.rpcMethodMappings[method] == "" {
+		return MethodNotAllowed
+	}
+	return method
+}
+
 func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isLimited limiterFunc, isBatch bool, bypassLimit bool) ([]*RPCRes, bool, string, error) {
 	// A request set is transformed into groups of batches.
 	// Each batch group maps to a forwarded JSON-RPC batch request (subject to maxUpstreamBatchSize constraints)
@@ -668,6 +682,9 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 	}
 
 	responses := make([]*RPCRes, len(reqs))
+	// Per-element attribution for proxyd_rpc_calls_total, parallel to responses.
+	callMethods := make([]string, len(reqs))
+	callBackends := make([]string, len(reqs))
 	batches := make(map[batchGroup][]batchElem)
 	ids := make(map[string]int, len(reqs))
 	txHashes := make(map[int]common.Hash) // tracks tx hashes by request index for forwarding logs
@@ -677,11 +694,15 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 		if err != nil {
 			log.Info("error parsing RPC call", "source", "rpc", "err", err)
 			responses[i] = NewRPCErrorRes(nil, err)
+			callMethods[i] = MethodUnknown
+			callBackends[i] = BackendProxyd
 			continue
 		}
 
 		// Simple health check
 		if len(reqs) == 1 && parsedReq.Method == proxydHealthzMethod {
+			// Deliberately not recorded in proxyd_rpc_calls_total: this is a probe,
+			// not client RPC traffic, and would dilute the SLO denominator.
 			res := &RPCRes{
 				ID:      parsedReq.ID,
 				JSONRPC: JSONRPCVersion,
@@ -690,9 +711,12 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			return []*RPCRes{res}, false, "", nil
 		}
 
+		callMethods[i] = s.metricMethodName(parsedReq.Method)
+
 		localRes, group, txHash := s.prepareRPCForForward(ctx, parsedReq, isLimited, bypassLimit, RPCRequestSourceHTTP)
 		if localRes != nil {
 			responses[i] = localRes
+			callBackends[i] = BackendProxyd
 			continue
 		}
 		if txHash != nil {
@@ -716,6 +740,7 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			backendRes, _ := s.cache.GetRPC(ctx, req.Req)
 			if backendRes != nil {
 				responses[req.Index] = backendRes
+				callBackends[req.Index] = BackendCache
 				cached = true
 			} else {
 				cacheMisses = append(cacheMisses, req)
@@ -732,6 +757,8 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 					"batch_index", i,
 				)
 				batchRPCShortCircuitsTotal.Inc()
+				// HandleRPC writes ErrGatewayTimeout (504) for this error.
+				recordRPCCalls(responses, callMethods, callBackends, RPCRequestSourceHTTP, statusCodeGatewayTimeout)
 				return nil, false, "", context.DeadlineExceeded
 			}
 
@@ -746,6 +773,8 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			if err != nil {
 				if errors.Is(err, ErrConsensusGetReceiptsCantBeBatched) ||
 					errors.Is(err, ErrConsensusGetReceiptsInvalidTarget) {
+					// HandleRPC writes ErrInvalidRequest (400) for these errors.
+					recordRPCCalls(responses, callMethods, callBackends, RPCRequestSourceHTTP, statusCodeBadRequest)
 					return nil, false, "", err
 				}
 				log.Error(
@@ -776,8 +805,12 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				}
 			}
 
+			// sb is "" when the forward failed outright, which backendNameFromServedBy
+			// resolves to BackendProxyd — such a batch was never served by a backend.
+			forwardedBy := backendNameFromServedBy(sb)
 			for i := range elems {
 				responses[elems[i].Index] = res[i]
+				callBackends[elems[i].Index] = forwardedBy
 
 				// TODO(inphi): batch put these
 				if res[i].Error == nil && res[i].Result != nil {
@@ -800,6 +833,8 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 		}
 		servedByString += sb
 	}
+
+	recordRPCCalls(responses, callMethods, callBackends, RPCRequestSourceHTTP, statusCodeInternal)
 
 	return responses, cached, servedByString, nil
 }

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -664,6 +664,15 @@ func (s *Server) metricMethodName(method string) string {
 	if method == "" {
 		return MethodUnknown
 	}
+	if method == "eth_accounts" {
+		// eth_accounts is answered locally by prepareRPCForForward, before the
+		// rpcMethodMappings lookup (proxyd never forwards it to a backend), so it
+		// is deliberately absent from rpc_method_mappings. Without this
+		// passthrough it would collapse to MethodNotAllowed and pollute that
+		// bucket — the one operators grep to find clients calling unsupported
+		// methods — with 200s.
+		return method
+	}
 	if s.rpcMethodMappings[method] == "" {
 		return MethodNotAllowed
 	}
@@ -758,8 +767,16 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 					"batch_index", i,
 				)
 				batchRPCShortCircuitsTotal.Inc()
-				// HandleRPC writes ErrGatewayTimeout (504) for this error.
-				recordRPCCalls(responses, callMethods, callBackends, RPCRequestSourceHTTP, statusCodeGatewayTimeout)
+				// The whole request set failed wholesale: this function returns a bare
+				// error, so HandleRPC writes a single error envelope for the entire
+				// batch (ErrGatewayTimeout/504 on the batch path; the single-request
+				// path has no DeadlineExceeded case and writes ErrInternal/500 instead).
+				// The client receives none of the per-element results computed so far
+				// (cache hits, locally-answered elements, or minibatches already
+				// forwarded in a prior iteration) — every element must be recorded with
+				// the fallback status, not the per-element status that never reached
+				// the client.
+				recordRPCCallsAll(callMethods, callBackends, RPCRequestSourceHTTP, statusCodeGatewayTimeout)
 				return nil, false, "", context.DeadlineExceeded
 			}
 
@@ -774,8 +791,11 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			if err != nil {
 				if errors.Is(err, ErrConsensusGetReceiptsCantBeBatched) ||
 					errors.Is(err, ErrConsensusGetReceiptsInvalidTarget) {
-					// HandleRPC writes ErrInvalidRequest (400) for these errors.
-					recordRPCCalls(responses, callMethods, callBackends, RPCRequestSourceHTTP, statusCodeBadRequest)
+					// HandleRPC writes ErrInvalidRequest (400) for these errors, as a
+					// single envelope for the whole request set — see the short-circuit
+					// case above for why every element must use the fallback status
+					// rather than any per-element result computed so far.
+					recordRPCCallsAll(callMethods, callBackends, RPCRequestSourceHTTP, statusCodeBadRequest)
 					return nil, false, "", err
 				}
 				log.Error(
@@ -848,6 +868,11 @@ func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
 
 	// Reject new WebSocket connections during drain
 	if s.isDraining.Load() {
+		// httpResponseCodesTotal is deliberately NOT incremented here (unlike the
+		// HTTP drain rejection above): WS responses never flow through
+		// writeRPCRes/writeBatchRPCRes, so no successful WS response is in this
+		// metric's population. Counting only the WS drain rejection would add a
+		// numerator entry with no denominator baseline.
 		http.Error(w, "Server is draining", http.StatusServiceUnavailable)
 		return
 	}

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -908,14 +908,27 @@ func (s *Server) shouldHandleWSRPC(req *RPCReq) bool {
 }
 
 func (s *Server) handleWSRPC(ctx context.Context, req *RPCReq, isLimited limiterFunc, bypassLimit bool) *RPCRes {
+	res, servedBy := s.handleWSRPCInner(ctx, req, isLimited, bypassLimit)
+	RecordRPCCall(
+		backendNameFromServedBy(servedBy),
+		s.metricMethodName(req.Method),
+		statusCodeForRPCRes(res),
+		RPCRequestSourceWS,
+	)
+	return res
+}
+
+// handleWSRPCInner resolves a single WS RPC and reports which backend served it.
+// The empty string means no backend was reached — proxyd answered locally.
+func (s *Server) handleWSRPCInner(ctx context.Context, req *RPCReq, isLimited limiterFunc, bypassLimit bool) (*RPCRes, string) {
 	if s.rpcMethodMappings[req.Method] == "" {
 		RecordRPCError(ctx, BackendProxyd, MethodNotAllowed, ErrMethodNotWhitelisted)
-		return NewRPCErrorRes(req.ID, ErrMethodNotWhitelisted)
+		return NewRPCErrorRes(req.ID, ErrMethodNotWhitelisted), ""
 	}
 
 	localRes, group, txHash := s.prepareRPCForForward(ctx, req, isLimited, bypassLimit, RPCRequestSourceWS)
 	if localRes != nil {
-		return localRes
+		return localRes, ""
 	}
 
 	forwardStart := time.Now()
@@ -928,7 +941,7 @@ func (s *Server) handleWSRPC(ctx context.Context, req *RPCReq, isLimited limiter
 			"req_id", GetReqID(ctx),
 			"err", err,
 		)
-		return NewRPCErrorRes(req.ID, err)
+		return NewRPCErrorRes(req.ID, err), servedBy
 	}
 	if len(res) == 0 {
 		log.Error(
@@ -936,7 +949,7 @@ func (s *Server) handleWSRPC(ctx context.Context, req *RPCReq, isLimited limiter
 			"backend_group", group,
 			"req_id", GetReqID(ctx),
 		)
-		return NewRPCErrorRes(req.ID, ErrInternal)
+		return NewRPCErrorRes(req.ID, ErrInternal), servedBy
 	}
 
 	if txHash != nil && s.enableTxHashLogging {
@@ -950,7 +963,7 @@ func (s *Server) handleWSRPC(ctx context.Context, req *RPCReq, isLimited limiter
 		)
 	}
 
-	return res[0]
+	return res[0], servedBy
 }
 
 func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context.Context {


### PR DESCRIPTION
## What

Adds two proxyd metrics that count **individual JSON-RPC calls** with the outcome the client actually received:

- `proxyd_rpc_calls_total{backend_name, method_name, status_code, transport}` — one increment per client-initiated call, recorded after retries and failover.
- `proxyd_rpc_notifications_total{backend_name}` — client-bound WS subscription notifications.

Also fixes two pre-existing bugs found while instrumenting: `proxyd_http_response_codes_total` counted nothing for successful batches (Change, item 4), and batch-size rejections were answered HTTP 200 (Change, item 5).

Nothing consumes the new metrics yet — no dashboard or SLO is repointed in this PR. See Rollout below.

> [!IMPORTANT]
> **Client-visible status code change: batches over `max_batch_size` now return HTTP 413 instead of HTTP 200.**
>
> `ErrTooManyBatchRequests` carried no `HTTPErrorCode`, so proxyd answered a rejected batch with HTTP **200** and a JSON-RPC error body. It is now 413, matching `ErrRequestBodyTooLarge`.
>
> **Who this affects:** any client sending batches larger than the deployment's `max_batch_size`. The JSON-RPC error body is unchanged — only the HTTP status. Clients that key off the JSON-RPC error are unaffected. Clients that treat non-200 as retryable will begin retrying a rejection that can never succeed, and clients that only inspect the body on a 2xx will now surface a transport-level error instead.
>
> **Why it has to change:** as HTTP 200 this rejection was invisible to every error-rate metric. The rejection also returns before `handleBatchRPC`, so the new per-call metric cannot compensate for it either — a client whose every batch was rejected failed 100% of the time while both metrics reported health. It was the only pre-dispatch rejection landing in the 2xx bucket (siblings: parse error 400, empty batch 400, body too large 413, drain 503).
>
> **Needs a release note.** `integration_tests/batching_test.go` asserted the old 200 — which is how we know nothing internal depends on it — and now asserts 413.

## Why

The OP Enterprise dashboard measures RPC usage and RPC error rate from metrics that cannot express either quantity, because proxyd has no metric representing "an RPC call the customer made, and the outcome they received." Every existing metric is either per-HTTP-envelope or per-backend-attempt:

- **`proxyd_rpc_requests_total` undercounts batch traffic by up to 100x.** It increments once per *minibatch forwarded upstream* (`backend.go`, `BackendGroup.ForwardWithSource`), so with `max_upstream_batch_size = 100` a 100-call batch counted as 1. It also misses cache hits entirely, counts batches containing zero real RPCs, and multi-counts batches spanning backend groups. This is the metric monthly quota is measured against.
- **`proxyd_http_response_codes_total` counted zero for every successful batch.** `writeBatchRPCRes` omitted the increment that `writeRPCRes` performs. Batches that failed wholesale *were* counted, so batch traffic entered the error-rate numerator but never the denominator — biasing the measured rate upward.
- **`proxyd_rpc_backend_http_response_codes_total` counts backend round-trips, not customer outcomes.** It includes consensus-poller traffic, double-counts retries, records failed-over attempts the customer never saw, and misses transport errors entirely (`doForward` returns before the increment on `err != nil`).
- **WebSocket traffic contributed to none of the status-code, error-rate, or latency metrics**, despite WS being enabled on every customer-facing deployment.

A batch also always returns HTTP 200 at the envelope level even when every call inside it failed, so an envelope-level SLI cannot fail for batch traffic at all.

## Change

1. **Status derivation** (`metrics.go`). `statusCodeForRPCRes` maps one `*RPCRes` to an HTTP-equivalent status. The load-bearing rule: an error with `HTTPErrorCode == 0` maps to **400, never 500**. That is the case where a backend answered HTTP 200 carrying a JSON-RPC error (`already known`, `nonce too low`, `execution reverted`) — `doForward` only stamps `HTTPErrorCode` on a non-200 upstream status. Mapping those to 5xx would burn the error-rate SLO on routine client faults.

2. **HTTP instrumentation** (`server.go`, `handleBatchRPC`). Per-element attribution arrays parallel to `responses`, recorded once at each client-visible exit. This one site covers batch *and* single requests (`HandleRPC` calls it with a one-element slice), and is the only place with per-element indices, the serving backend, post-failover outcomes, cache hits, and proxyd-local errors all in scope. Sentinel `backend_name` values: `cache` for cache hits, `proxyd` for locally-answered or rejected calls.

3. **WS instrumentation** (`server.go`, `backend.go`). `handleWSRPC` split into a recording wrapper plus an inner function returning `servedBy`, so its five return paths record exactly once. `clientPump` records the relay path (`eth_subscribe`/`eth_unsubscribe`) at send time with `status_code="relayed"`, since those responses return asynchronously in `backendPump` with no id correlation. `backendPump` classifies backend messages structurally — `method` with no `id` is a notification; a message carrying an `id` is already counted and is not double-counted.

4. **Envelope-metric fix** (`server.go`). `writeBatchRPCRes` now increments `proxyd_http_response_codes_total` once per response (not per element), and the `HandleRPC` drain path is counted. Healthz stays uninstrumented so probe traffic does not dilute the denominator.

5. **`ErrTooManyBatchRequests` gains `HTTPErrorCode: 413`** (`backend.go`). One line, but it is the client-visible change called out at the top of this description. See that callout for who it affects and why it cannot stay at 200.

Two properties worth calling out:

- **Attribution is per element, including for locally-overridden calls.** When consensus or block-tag rewriting answers some elements of a batch and a backend answers the rest, the overridden elements must not inherit the serving backend's name. `OverrideResponses` — the single point where overrides merge back into a batch result — marks each one with an unexported `servedLocally` flag, and `handleBatchRPC` attributes those to `proxyd`. The flag is absent from `rpcResJSON`, so it never reaches the wire.
- **The consensus poller is excluded structurally, not by label filtering.** It reaches backends via `ForwardRPC` → `doForward`, entering none of the three instrumentation sites. This is the same reason the existing latency summary is already poller-clean, and it means no `origin` label is needed on the new metric.
- **`method_name` cardinality is bounded at every site that sets it.** Method names are client-supplied and reachable by unauthenticated clients, so anything outside the configured whitelist collapses to `method_not_allowed`. `eth_accounts` is passed through explicitly because it is answered locally before the mappings lookup and would otherwise be recorded as a *successful* `method_not_allowed`.

`status_code="relayed"` is deliberately non-numeric so `status_code=~"2.."` and `=~"5.."` can never match a call whose outcome is unknowable, and it is excluded from the SLO denominator.

No signature of `Forward`, `ForwardWithSource`, `ForwardRPC`, `doForward`, or any `BackendGroup` method changed — this deliberately avoids a breaking *Go API* change for external callers. The one client-visible behavior change is the 413 above.

## Testing

Unit tests cover status derivation against the real error table (including the 200-with-JSON-RPC-error case asserting 400, not 500), the cardinality bounds, the batch-vs-single deadline status divergence, and the `servedLocally` marking at the override merge point. Integration tests cover: a 3-element batch producing exactly 3 increments (previously 0); a 12-element mixed batch spanning two minibatches, asserting all 12 increments plus per-status and per-backend attribution; cache-hit attribution to `cache`; consensus-poller traffic producing zero increments (with a guard asserting the poller actually reached the backend, so the zero cannot hold vacuously); WS relay + notification counting; the WS mapped-method path; and that a client naming its method `unknown` still collapses to `method_not_allowed`.

Two gaps worth naming rather than hiding. The single-request deadline short-circuit is covered at the helper, not end to end — reaching it requires the deadline to expire inside `prepareRPCForForward`, since a one-element request has only one minibatch iteration. And the partial-override attribution branch in `handleBatchRPC` is covered at the merge point, not through a `consensus_aware` group with a block tag past the consensus latest.

Two behaviors are mutation-verified — the instrumentation was temporarily removed and the tests confirmed to fail (`expected: 3, actual: 0` for the batch count; the cardinality bound likewise) before reverting.

Full module suite passes uncached: unit ~22s, `integration_tests` ~99s. `gofmt` and `go vet` clean.

## Rollout

**This PR changes no dashboard or SLO**, but it does change one client-visible status code. In order:

0. **Release-note the 413 before deploy.** Batches over `max_batch_size` stop returning HTTP 200 (see the callout at the top). This is the only item that affects clients rather than dashboards, and it ships the moment this deploys — it cannot be staged behind the bake window like the rest. Worth checking whether any known integration sends oversized batches; if one does, it will start seeing a transport-level error where it previously saw a 200 with an error body.
1. **Bake alongside the existing metrics** and compare per chain: new vs `proxyd_rpc_requests_total`, and the new 5xx ratio vs the current SLO value.
2. **Wire the per-call SLI alert before the bake window opens, not after.** See item 3 — during the bake there is a window in which batch failures are *less* visible on the existing metric than they were before this PR, and the new metric has no alert on it yet. That window should be as short as possible.
3. **`proxyd_http_response_codes_total` semantics change in this PR, and not only in the benign direction.** It now counts successful batches where it previously counted nothing, so the denominator grows and any existing error-rate expression over it will see its measured value **drop** on deploy. That much is the intended correction. The sharper edge: a batch is always HTTP 200 at the envelope level, so an outage that leaves batches *structurally* intact — every element `ErrNoBackends` — now adds only to `{status_code="200"}`. Previously those batches reached the numerator via `writeRPCError` and nothing reached the denominator; now the denominator grows while element-level failures still contribute nothing, so **the measured 5xx ratio over this metric falls during exactly that outage**. `proxyd_rpc_calls_total` is the metric that catches it. Both effects warrant a Grafana annotation on deploy day, and it will read as a step change to whoever owns the alerts in the `k8s` repo.
4. **Commercial review of the usage delta before the usage tile repoints.** Correcting an up-to-100x batch undercount changes the number customers are measured against. This is a pricing decision, not an engineering one.

Two things to carry into the dashboard/SLO work:

- The provider-filter allowlist in the dashboard must gain `proxyd` and `cache`, or the worst outage class (`ErrNoBackends`, rate limits, rejections — all attributed to `proxyd`) and all cache hits will be invisible in the provider-filtered graph.
- The new per-call SLI is structurally blind to envelope-level rejections (drain, 401, 413, batch-parse error), because those fail before any individual call is parsed and dispatched. If proxyd rejects everything, the numerator *and* denominator are empty, so the SLI reads 0% error or NaN rather than 100%. **Keep** an availability alert on `proxyd_http_response_codes_total` alongside the new SLI rather than replacing it.

## Relationship to #673

[#673](https://github.com/ethereum-optimism/infra/pull/673) adds an `origin` label to `proxyd_rpc_backend_http_response_codes_total` so consensus-poller traffic can be filtered out of the existing panel. It is orthogonal and can land independently. This PR subsumes the underlying need: the new metric excludes the poller structurally, and also addresses batching, retry double-counting, failed-over requests, and WS, none of which the `origin` label reaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
