### PR TITLE
ci: bump factory pins to latest main

### DIFF
--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@71a5f61d2b308d705de4a8959d89156755f68db3
+        uses: ethereum-optimism/factory/actions/apko-plan@80fb1914d8f68ea4ac277beff4541cc4a669569f
         with:
           config: .github/images.apko.json
 
@@ -86,7 +86,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@80fb1914d8f68ea4ac277beff4541cc4a669569f
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -118,7 +118,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@80fb1914d8f68ea4ac277beff4541cc4a669569f
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -141,7 +141,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@71a5f61d2b308d705de4a8959d89156755f68db3
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@80fb1914d8f68ea4ac277beff4541cc4a669569f
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
       - name: Plan
         id: plan
-        uses: ethereum-optimism/factory/actions/plan@d1304a6e3ef93a8fcb0f672707f5f2ae9737a59d
+        uses: ethereum-optimism/factory/actions/plan@80fb1914d8f68ea4ac277beff4541cc4a669569f
 
   build:
     needs: [plan]
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.plan.outputs.matrix_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@d1304a6e3ef93a8fcb0f672707f5f2ae9737a59d
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@80fb1914d8f68ea4ac277beff4541cc4a669569f
     with:
       image_name: ${{ matrix.image_name }}
       tag: ${{ matrix.tag }}


### PR DESCRIPTION
## Summary

Bumps all `ethereum-optimism/factory` action and reusable-workflow pins in `build-images.yaml` and `build-images.apko.yaml` to the latest `main` commit `80fb1914d8f68ea4ac277beff4541cc4a669569f`.

The motivating change is https://github.com/ethereum-optimism/factory/pull/46, which fixes the `actions/plan` step failing with `echo: write error: Broken pipe` under `pipefail` on PRs that change more than 50 files. That failure skipped the downstream image build and smoke-test jobs.

Other factory changes picked up by the bump:
- https://github.com/ethereum-optimism/factory/pull/38 optional `runner_amd64`/`runner_arm64` inputs on `docker.yaml`
- https://github.com/ethereum-optimism/factory/pull/39 Nexus apko reusable workflows (unused here)
- https://github.com/ethereum-optimism/factory/pull/40 apko-plan `BASH_REMATCH` fix
- https://github.com/ethereum-optimism/factory/pull/42 pass Cargo profile to melange builds
- https://github.com/ethereum-optimism/factory/pull/43 restore isolated melange artifacts