### PR TITLE
op-ufm: fix memory leaks in provider tx pool and RPC clients

### DIFF
--- a/op-ufm/pkg/metrics/clients/eth.go
+++ b/op-ufm/pkg/metrics/clients/eth.go
@@ -30,6 +30,10 @@ func Dial(providerName string, url string) (*InstrumentedEthClient, error) {
 	return &InstrumentedEthClient{c: c, providerName: providerName}, nil
 }
 
+func (i *InstrumentedEthClient) Close() {
+	i.c.Close()
+}
+
 func (i *InstrumentedEthClient) TransactionByHash(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error) {
 	start := time.Now()
 	tx, isPending, err := i.c.TransactionByHash(ctx, hash)

--- a/op-ufm/pkg/provider/heartbeat.go
+++ b/op-ufm/pkg/provider/heartbeat.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-ufm/pkg/metrics"
-	"github.com/ethereum-optimism/optimism/op-ufm/pkg/metrics/clients"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/log"
@@ -17,6 +16,25 @@ func (p *Provider) Heartbeat(ctx context.Context) {
 	log.Debug("heartbeat",
 		"provider", p.name,
 		"count", len(p.txPool.Transactions))
+
+	// GC stale entries. When a provider never observes a tx (e.g. it never
+	// propagates there, or the receipt lookup errored out on the source
+	// provider), the "seen by all" removal path below never fires and the
+	// entry would live forever. Anything older than 2x the receipt timeout is
+	// definitely not going to be usefully tracked anymore.
+	staleThreshold := 2 * time.Duration(p.config.ReceiptRetrievalTimeout)
+	p.txPool.M.Lock()
+	for hash, st := range p.txPool.Transactions {
+		if time.Since(st.SentAt) > staleThreshold {
+			log.Warn("evicting stale transaction from pool",
+				"provider", p.name,
+				"hash", hash,
+				"sourceProvider", st.ProviderSource,
+				"age", time.Since(st.SentAt))
+			delete(p.txPool.Transactions, hash)
+		}
+	}
+	p.txPool.M.Unlock()
 
 	metrics.RecordTransactionsInFlight(p.config.Network, len(p.txPool.Transactions))
 
@@ -42,12 +60,13 @@ func (p *Provider) Heartbeat(ctx context.Context) {
 		return
 	}
 
-	client, err := clients.Dial(p.name, p.config.URL)
+	client, err := p.ethClientOrDial()
 	if err != nil {
 		log.Error("cant dial to provider",
 			"provider", p.name,
 			"url", p.config.URL,
 			"err", err)
+		return
 	}
 
 	log.Debug("checking in-flight tx",

--- a/op-ufm/pkg/provider/provider.go
+++ b/op-ufm/pkg/provider/provider.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/tls"
 	"github.com/ethereum-optimism/optimism/op-ufm/pkg/config"
 	iclients "github.com/ethereum-optimism/optimism/op-ufm/pkg/metrics/clients"
-	"github.com/ethereum-optimism/optimism/op-service/tls"
 	"github.com/ethereum/go-ethereum/log"
 )
 

--- a/op-ufm/pkg/provider/provider.go
+++ b/op-ufm/pkg/provider/provider.go
@@ -2,9 +2,13 @@ package provider
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-ufm/pkg/config"
+	iclients "github.com/ethereum-optimism/optimism/op-ufm/pkg/metrics/clients"
+	"github.com/ethereum-optimism/optimism/op-service/tls"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type Provider struct {
@@ -15,6 +19,10 @@ type Provider struct {
 	txPool       *NetworkTransactionPool
 
 	cancelFunc context.CancelFunc
+
+	clientMu     sync.Mutex
+	ethClient    *iclients.InstrumentedEthClient
+	signerClient *iclients.InstrumentedSignerClient
 }
 
 func New(name string, cfg *config.ProviderConfig,
@@ -45,6 +53,52 @@ func (p *Provider) Shutdown() {
 	if p.cancelFunc != nil {
 		p.cancelFunc()
 	}
+	p.clientMu.Lock()
+	defer p.clientMu.Unlock()
+	if p.ethClient != nil {
+		p.ethClient.Close()
+		p.ethClient = nil
+	}
+	p.signerClient = nil
+}
+
+// ethClientOrDial returns the cached eth client, dialing lazily on first use.
+// The client is reused across Heartbeat and RoundTrip cycles so we do not open
+// a fresh HTTP connection (and its transport goroutines) every interval.
+func (p *Provider) ethClientOrDial() (*iclients.InstrumentedEthClient, error) {
+	p.clientMu.Lock()
+	defer p.clientMu.Unlock()
+	if p.ethClient != nil {
+		return p.ethClient, nil
+	}
+	c, err := iclients.Dial(p.name, p.config.URL)
+	if err != nil {
+		return nil, err
+	}
+	p.ethClient = c
+	return c, nil
+}
+
+// signerClientOrDial returns the cached signer client, initialising it lazily.
+// The upstream SignerClient does not expose Close(), so we simply reuse the
+// single instance for the lifetime of the provider.
+func (p *Provider) signerClientOrDial() (*iclients.InstrumentedSignerClient, error) {
+	p.clientMu.Lock()
+	defer p.clientMu.Unlock()
+	if p.signerClient != nil {
+		return p.signerClient, nil
+	}
+	tlsConfig := tls.CLIConfig{
+		TLSCaCert: p.signerConfig.TLSCaCert,
+		TLSCert:   p.signerConfig.TLSCert,
+		TLSKey:    p.signerConfig.TLSKey,
+	}
+	c, err := iclients.NewSignerClient(p.name, log.Root(), p.signerConfig.URL, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+	p.signerClient = c
+	return c, nil
 }
 
 func (p *Provider) Name() string {

--- a/op-ufm/pkg/provider/roundtrip.go
+++ b/op-ufm/pkg/provider/roundtrip.go
@@ -9,7 +9,6 @@ import (
 	iclients "github.com/ethereum-optimism/optimism/op-ufm/pkg/metrics/clients"
 	"github.com/ethereum/go-ethereum/core"
 
-	"github.com/ethereum-optimism/optimism/op-service/tls"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/txpool"
@@ -25,7 +24,7 @@ func (p *Provider) RoundTrip(ctx context.Context) {
 	log.Debug("RoundTrip",
 		"provider", p.name)
 
-	client, err := iclients.Dial(p.name, p.config.URL)
+	client, err := p.ethClientOrDial()
 	if err != nil {
 		log.Error("cant dial to provider",
 			"provider", p.name,
@@ -145,6 +144,20 @@ func (p *Provider) RoundTrip(ctx context.Context) {
 	p.txPool.LastSend = sentAt
 	p.txPool.M.Unlock()
 
+	// If we bail out before the tx succeeds end-to-end, drop it from the pool.
+	// The Heartbeat "seen by all providers" removal path only fires on success,
+	// so without this every timeout/error would strand the entry forever and
+	// leak memory in proportion to failure rate * uptime.
+	success := false
+	defer func() {
+		if success {
+			return
+		}
+		p.txPool.M.Lock()
+		delete(p.txPool.Transactions, txHash.Hex())
+		p.txPool.M.Unlock()
+	}()
+
 	var receipt *types.Receipt
 	attempt = 0
 	for receipt == nil {
@@ -187,6 +200,7 @@ func (p *Provider) RoundTrip(ctx context.Context) {
 	}
 
 	roundTripLatency := time.Since(roundTripStartedAt)
+	success = true
 
 	metrics.RecordRoundTripLatency(p.name, roundTripLatency)
 	metrics.RecordGasUsed(p.name, receipt.GasUsed)
@@ -295,12 +309,7 @@ func (p *Provider) sign(ctx context.Context, from *common.Address, tx *types.Tra
 		}
 		return types.SignTx(tx, types.LatestSignerForChainID(&p.walletConfig.ChainID), privateKey)
 	case "signer":
-		tlsConfig := tls.CLIConfig{
-			TLSCaCert: p.signerConfig.TLSCaCert,
-			TLSCert:   p.signerConfig.TLSCert,
-			TLSKey:    p.signerConfig.TLSKey,
-		}
-		client, err := iclients.NewSignerClient(p.name, log.Root(), p.signerConfig.URL, tlsConfig)
+		client, err := p.signerClientOrDial()
 		if err != nil || client == nil {
 			log.Error("failed to create signer client", "err", err)
 		}


### PR DESCRIPTION
## What was leaking

op-ufm sends test transactions to RPC providers and measures how fast each provider sees them. Three things kept growing forever inside the running process:

1. **A tracking list of in-flight transactions.** Every time we sent a tx, we added it to a shared map. The map only removed entries when *every* provider had confirmed seeing the tx. If any provider missed it, or if receipt retrieval timed out, the entry stayed forever.
2. **RPC connections.** Every polling cycle we opened a fresh connection to each RPC provider and never closed the old one. Over days this piles up thousands of TCP connections and their background goroutines.
3. **Signer connections.** Same story for the signing service — a new client per transaction, none closed.

## Why memory was climbing

<!-- drag/drop the memory usage screenshot here in the GitHub web UI to embed it -->
_Memory Usage (w/o cache) — `ufm-*` pod, 07-01 → 07-30. Steady ~25 MiB/day climb, restart on ~07-08, resumes climbing on the same slope._

Every polling interval added a little to each of the three piles above. Because nothing ever cleaned them up, the pod's memory grew in a straight line — ~25 MiB/day, ~50 MiB → ~810 MiB over four weeks — until it got restarted, and then climbed again on the exact same slope. After this change, all three have bounded size, so memory should flatten out.

## What the fix does

1. **Take out the trash.** If a transaction fails or times out, `RoundTrip` now removes it from the map on the way out (via `defer`). As a backup, once per heartbeat we sweep the map and evict anything older than `2 × ReceiptRetrievalTimeout` — so even "success but never fully propagated" entries can't linger.
2. **Dial once, reuse.** Each provider opens its RPC connection the first time it's needed and reuses that same client for every subsequent `Heartbeat` and `RoundTrip`. `Shutdown()` closes it cleanly. `InstrumentedEthClient.Close()` delegates to the underlying `ethclient.Client`.
3. **Same for the signer.** One signer client per provider, held for the process lifetime. (Upstream `SignerClient` has no `Close()` in the pinned optimism version, so caching is the best we can do.)

## Files touched

- `pkg/provider/roundtrip.go` — cached client lookup + `defer` cleanup of the tx pool on failure paths.
- `pkg/provider/heartbeat.go` — cached client lookup + age-based GC sweep at the top of each heartbeat.
- `pkg/provider/provider.go` — client caching, lazy dial, shutdown wiring.
- `pkg/metrics/clients/eth.go` — added `Close()` on `InstrumentedEthClient`.

## Testing in dev after 3 days
<img width="1417" height="317" alt="image" src="https://github.com/user-attachments/assets/e2764a0c-1c14-4cab-b98c-8ea297f59d75" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)