### PR TITLE
build(go): require Go 1.26.5

### DIFF
--- a/bailiff/go.mod
+++ b/bailiff/go.mod
@@ -1,6 +1,8 @@
 module bailiff
 
-go 1.23.1
+go 1.26.0
+
+toolchain go1.26.5
 
 require (
 	github.com/ethereum-optimism/optimism v1.9.3

--- a/cci-stats/go.mod
+++ b/cci-stats/go.mod
@@ -2,6 +2,8 @@ module github.com/ethereum-optimism/infra/cci-stats
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/axelKingsley/go-circleci v0.9.1
 	github.com/jackc/pgx/v5 v5.9.2

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ethereum-optimism/infra
 
 go 1.26.0
+
+toolchain go1.26.5

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 # Shared tools for Go projects
 [tools]
-go = "1.26"
+go = "1.26.5"
 
 # Fake deps
 asterisc = "1.3.0"

--- a/op-conductor-mon/go.mod
+++ b/op-conductor-mon/go.mod
@@ -1,6 +1,8 @@
 module github.com/ethereum-optimism/optimism/op-conductor-mon
 
-go 1.25.0
+go 1.26.0
+
+toolchain go1.26.5
 
 require (
 	github.com/ethereum-optimism/optimism v1.7.8-0.20240620182338-0bb839cfd664

--- a/op-signer/go.mod
+++ b/op-signer/go.mod
@@ -2,6 +2,8 @@ module github.com/ethereum-optimism/infra/op-signer
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	cloud.google.com/go/kms v1.23.0
 	github.com/aws/aws-sdk-go-v2/config v1.28.11

--- a/op-txproxy/go.mod
+++ b/op-txproxy/go.mod
@@ -2,6 +2,8 @@ module github.com/ethereum-optimism/infra/op-txproxy
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/ethereum-optimism/optimism v1.9.1-0.20240827163921-45e129c8ca4b
 	github.com/ethereum/go-ethereum v1.14.11

--- a/op-ufm/go.mod
+++ b/op-ufm/go.mod
@@ -2,6 +2,8 @@ module github.com/ethereum-optimism/optimism/op-ufm
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	cloud.google.com/go/kms v1.26.0
 	github.com/BurntSushi/toml v1.3.2

--- a/peer-mgmt-service/go.mod
+++ b/peer-mgmt-service/go.mod
@@ -2,6 +2,8 @@ module github.com/ethereum-optimism/infra/peer-mgmt-service
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/ethereum-optimism/optimism v1.5.0-rc.3.0.20240131131533-152d1e0a458d
 	github.com/ethereum/go-ethereum v1.13.8

--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -2,6 +2,8 @@ module github.com/ethereum-optimism/infra/proxyd
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/alicebob/miniredis v2.5.0+incompatible


### PR DESCRIPTION
## Summary

- raise the remaining Go 1.23 and 1.25 modules to Go 1.26
- require the Go 1.26.5 toolchain across all active Go modules
- pin the local mise Go version to 1.26.5

## Testing

- `go mod tidy` across all modules
- `go test ./...` across all modules
- `make test` in `op-conductor-mon`
- proxyd integration tests