### PR TITLE
replica-healthcheck: fix memory leak by switching to StaticJsonRpcProvider

### DIFF
--- a/replica-healthcheck/src/service.ts
+++ b/replica-healthcheck/src/service.ts
@@ -43,11 +43,11 @@ export class HealthcheckService extends BaseServiceV2<
       },
       optionsSpec: {
         referenceRpcProvider: {
-          validator: validators.provider,
+          validator: validators.staticJsonRpcProvider,
           desc: 'Provider for interacting with L1',
         },
         targetRpcProvider: {
-          validator: validators.provider,
+          validator: validators.staticJsonRpcProvider,
           desc: 'Provider for interacting with L2',
         },
         onDivergenceWaitMs: {
@@ -141,7 +141,7 @@ export class HealthcheckService extends BaseServiceV2<
     if (!reference) {
       // This is ok, but we should log it and restart the loop.
       this.logger.info(`reference block was not found`, {
-        blockNumber: reference.number,
+        blockNumber: minBlock,
       })
       return
     }
@@ -150,7 +150,7 @@ export class HealthcheckService extends BaseServiceV2<
     if (!target) {
       // This is ok, but we should log it and restart the loop.
       this.logger.info(`target block was not found`, {
-        blockNumber: target.number,
+        blockNumber: minBlock,
       })
       return
     }


### PR DESCRIPTION
## Summary
- Swap `validators.provider` → `validators.staticJsonRpcProvider` for both `referenceRpcProvider` and `targetRpcProvider` in `HealthcheckService`.
- Fix a latent null-deref in the `getBlock(minBlock)` null-check branches (was reading `.number` off the null value).

## Root cause
`validators.provider` (in `@eth-optimism/common-ts@0.8.9`) returns a plain `ethers.providers.JsonRpcProvider`. That class calls `detectNetwork()` on every `send()`, doubling outbound RPCs and — more importantly — chaining a Promise per call whose downstream native-side state (HTTP agent pool, TLS session buffers, V8 arenas) is not reclaimed to the OS at the same rate it accretes. Result: perfectly linear RSS growth (~5 MB/day per pod in prod over the 90d window), independent of GC activity. `StaticJsonRpcProvider` performs `detectNetwork()` once and caches; it removes the per-call promise chain entirely.

## Data collection

Local A/B on a single machine against a shared reth RPC endpoint. Both arms ran the same source with the same aggressive loop rate (~5 iters/sec vs prod's 0.2 iters/sec = 25× the fire rate) so 22 minutes of local runtime approximates ~9 hours of prod loop-count.

The only difference between arms was the provider validator:

- **Arm A** — `validators.staticJsonRpcProvider` (this PR)
- **Arm B** — `validators.provider` (current prod)

Sampling: `process_resident_memory_bytes` and `nodejs_heap_size_used_bytes` scraped from the service's `/metrics` endpoint every 2 min after a 5 min warmup, for 22 min. Pprof heap profiles captured at warm-baseline and end for constructor-level diffing.

## Results

| | Arm A (this PR) | Arm B (current prod) |
|---|---|---|
| RSS start | 354.0 MB | 360.1 MB |
| RSS end | 354.7 MB | 396.8 MB |
| RSS Δ over 22 min | **+0.7 MB** | **+36.7 MB** |
| Rate | ~31 KB/min | ~1.6 MB/min |

Arm B leaks ~53× faster than Arm A in RSS, on the same code, same RPC, same loop cadence. V8 heap oscillates on the normal GC sawtooth in both arms and net-decreases over the window, confirming the retention lives in native memory outside V8's heap — consistent with the detectNetwork-per-call hypothesis.

A residual ~31 KB/min in Arm A is below the pprof.heap sampling floor (512 KB) and could not be attributed from these profiles. It projects to ~1.2 MB/day per pod in prod, which is ≥4× below the current observed growth rate. If it persists as a linear climb after this rollout, we will follow up with native heap profiling.

## Side effects

Two shifts worth calling out before rollout:

- **`targetConnectionFailures` / `referenceConnectionFailures` counters may stop incrementing on transient RPC outages.** The service classifies connection errors by `err.message.includes('could not detect network')`, which is emitted by ethers' `detectNetwork()` codepath. Non-Static exercises that path on every call; Static only calls it once at startup. Post-startup HTTP failures now surface as different error messages (fetch errors, timeouts), fall through to the `else throw err` branch, and are caught by `BaseServiceV2`'s outer handler as `unhandledErrors` — the two specific counters lose fidelity as a health signal. If anything alerts on those counters directly, the alert will effectively stop firing.
- **~50% drop in outbound RPC volume from replica-healthcheck.** The `eth_chainId` probe that non-Static fired before every real call is gone. Any dashboards/alerts thresholded on the previous rate for this service will need re-baselining.

Also, the bundled null-deref fix means transient null-block returns no longer crash the main loop — expect fewer service-driven pod restarts and lower `unhandledErrors_total` slope.

## Test plan
- [ ] CI green
- [ ] Deploy to one canary replica; confirm `/metrics` and `/healthz` still respond and divergence detection still fires on a known-diverged pair
- [ ] Watch `container_memory_working_set_bytes{pod=~"replica-healthcheck-.*"}` for the canary vs fleet over 24–48h — expect the canary's line to flatten
- [ ] Roll out fleet-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)