### PR TITLE
cci-stats: Retry pipelines that were still running when indexed

### DIFF
--- a/cci-stats/README.md
+++ b/cci-stats/README.md
@@ -18,6 +18,16 @@ To run the program, specify the following env vars:
 
 Then run `go run cmd/runner/main.go`.
 
+## Indexing model
+
+Each run indexes pipelines created after the high water mark, `MAX(created_at)` over `pipelines`,
+along with any already recorded as `complete = FALSE` within `FETCH_LIMIT_DAYS`. A pipeline that is
+still running is recorded as incomplete rather than skipped, because pipelines do not finish in
+creation order and the mark would otherwise move past it for good. Reindexing is idempotent.
+
+`pkg/service/service.go` decides when a pipeline is complete and which workflows are worth
+recording.
+
 ## Schema
 
 The schema is the migration chain in `pkg/db/migrations`, applied at startup. Nothing is applied by

--- a/cci-stats/pkg/db/db.go
+++ b/cci-stats/pkg/db/db.go
@@ -19,6 +19,12 @@ type Pipeline struct {
 	Commit    string
 	Branch    string
 	CreatedAt time.Time
+	// Complete is false while the pipeline may still create workflows, or while
+	// a matched workflow is unfinished. The ingest high water mark is
+	// MAX(created_at) over the table, so a pipeline left unrecorded can never be
+	// revisited; recording it as incomplete lets the mark advance while the
+	// pipeline stays on the retry list.
+	Complete bool
 }
 
 type Job struct {
@@ -34,8 +40,6 @@ type Job struct {
 }
 
 type TestResult struct {
-	ID      int
-	JobID   string
 	Name    string
 	Runtime float64
 	Status  string
@@ -44,6 +48,8 @@ type TestResult struct {
 
 type Connection interface {
 	LastPipeline(ctx context.Context) (*Pipeline, error)
+	IncompletePipelines(ctx context.Context, since time.Time) ([]Pipeline, error)
+	RecordPending(ctx context.Context, pipelines []Pipeline) error
 
 	Begin() (Transactor, error)
 	Close() error
@@ -52,7 +58,7 @@ type Connection interface {
 type Transactor interface {
 	InsertPipeline(ctx context.Context, p Pipeline) error
 	InsertJob(ctx context.Context, j Job) error
-	InsertTestResult(ctx context.Context, tr TestResult) (int, error)
+	ReplaceTestResults(ctx context.Context, jobID string, results []TestResult) error
 	Commit(ctx context.Context) error
 	Rollback(ctx context.Context)
 }
@@ -72,13 +78,13 @@ func New(ctx context.Context, uri string) (*PGXDB, error) {
 
 func (p *PGXDB) LastPipeline(ctx context.Context) (*Pipeline, error) {
 	sql := `
-SELECT id, number, commit, branch, created_at
+SELECT id, number, commit, branch, created_at, complete
 FROM pipelines ORDER BY created_at DESC LIMIT 1
 `
 
 	row := p.conn.QueryRow(ctx, sql)
 	var pl Pipeline
-	if err := row.Scan(&pl.ID, &pl.Number, &pl.Commit, &pl.Branch, &pl.CreatedAt); err != nil {
+	if err := row.Scan(&pl.ID, &pl.Number, &pl.Commit, &pl.Branch, &pl.CreatedAt, &pl.Complete); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
@@ -86,6 +92,59 @@ FROM pipelines ORDER BY created_at DESC LIMIT 1
 		return nil, fmt.Errorf("failed to get last pipeline: %w", err)
 	}
 	return &pl, nil
+}
+
+// IncompletePipelines returns pipelines recorded before they finished, so they
+// can be indexed again. The since bound stops a pipeline that never finishes,
+// such as one left awaiting approval, from being retried forever.
+func (p *PGXDB) IncompletePipelines(ctx context.Context, since time.Time) ([]Pipeline, error) {
+	sql := `
+SELECT id, number, commit, branch, created_at, complete
+FROM pipelines WHERE NOT complete AND created_at >= $1 ORDER BY created_at
+`
+
+	rows, err := p.conn.Query(ctx, sql, since)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query incomplete pipelines: %w", err)
+	}
+	defer rows.Close()
+
+	var res []Pipeline
+	for rows.Next() {
+		var pl Pipeline
+		if err := rows.Scan(&pl.ID, &pl.Number, &pl.Commit, &pl.Branch, &pl.CreatedAt, &pl.Complete); err != nil {
+			return nil, fmt.Errorf("failed to scan incomplete pipeline: %w", err)
+		}
+		res = append(res, pl)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read incomplete pipelines: %w", err)
+	}
+	return res, nil
+}
+
+// RecordPending records pipelines as incomplete before they are indexed, so a
+// run that stops part way leaves them on the retry list rather than behind the
+// high water mark. Pipelines already recorded are left alone, so this never
+// reopens a completed one.
+func (p *PGXDB) RecordPending(ctx context.Context, pipelines []Pipeline) error {
+	if len(pipelines) == 0 {
+		return nil
+	}
+
+	sql := `
+INSERT INTO pipelines (id, number, commit, branch, created_at, complete)
+VALUES ($1, $2, $3, $4, $5, FALSE) ON CONFLICT (id) DO NOTHING
+`
+
+	batch := &pgx.Batch{}
+	for _, pl := range pipelines {
+		batch.Queue(sql, pl.ID, pl.Number, pl.Commit, pl.Branch, pl.CreatedAt)
+	}
+	if err := p.conn.SendBatch(ctx, batch).Close(); err != nil {
+		return fmt.Errorf("failed to record pending pipelines: %w", err)
+	}
+	return nil
 }
 
 func (p *PGXDB) Begin() (Transactor, error) {
@@ -111,9 +170,12 @@ func (p *PGXTransactor) InsertPipeline(ctx context.Context, pl Pipeline) error {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
+	// The complete flag has to be updated on conflict: a pipeline is recorded
+	// while it is still running and indexed again once it finishes.
 	sql := `
-INSERT INTO pipelines (id, number, commit, branch, created_at)
-VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING
+INSERT INTO pipelines (id, number, commit, branch, created_at, complete)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (id) DO UPDATE SET complete = EXCLUDED.complete
 `
 
 	if _, err := p.tx.Exec(ctx,
@@ -123,6 +185,7 @@ VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING
 		pl.Commit,
 		pl.Branch,
 		pl.CreatedAt,
+		pl.Complete,
 	); err != nil {
 		return fmt.Errorf("failed to insert pipeline: %w", err)
 	}
@@ -133,67 +196,56 @@ func (p *PGXTransactor) InsertJob(ctx context.Context, j Job) error {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
-	type queryPkg struct {
-		query string
-		args  []any
-	}
+	sql := `
+INSERT INTO jobs (id, pipeline_id, workflow_id, workflow_name, number, name, status, started_at, stopped_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status, started_at = EXCLUDED.started_at, stopped_at = EXCLUDED.stopped_at
+`
 
-	queries := []queryPkg{
-		{
-			"DELETE FROM test_results WHERE job_id = $1",
-			[]any{j.ID},
-		},
-		{
-			`INSERT INTO jobs (id, pipeline_id, workflow_id, workflow_name, number, name, status, started_at, stopped_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT DO NOTHING`,
-			[]any{
-				j.ID,
-				j.PipelineID,
-				j.WorkflowID,
-				j.WorkflowName,
-				j.Number,
-				j.Name,
-				j.Status,
-				j.StartedAt,
-				j.StoppedAt,
-			},
-		},
-	}
-
-	for i, q := range queries {
-		if _, err := p.tx.Exec(ctx,
-			q.query,
-			q.args...,
-		); err != nil {
-			return fmt.Errorf("failed to insert job: query %d: %w", i, err)
-		}
+	if _, err := p.tx.Exec(ctx,
+		sql,
+		j.ID,
+		j.PipelineID,
+		j.WorkflowID,
+		j.WorkflowName,
+		j.Number,
+		j.Name,
+		j.Status,
+		j.StartedAt,
+		j.StoppedAt,
+	); err != nil {
+		return fmt.Errorf("failed to insert job: %w", err)
 	}
 
 	return nil
 }
 
-func (p *PGXTransactor) InsertTestResult(ctx context.Context, tr TestResult) (int, error) {
+// ReplaceTestResults swaps a job's stored results for the ones supplied. The
+// caller must not pass an empty slice: clearing the old rows is only safe when
+// there are new ones to put in their place, since a job whose metadata fetch
+// returns not found is indistinguishable from one that genuinely has none.
+func (p *PGXTransactor) ReplaceTestResults(ctx context.Context, jobID string, results []TestResult) error {
+	if len(results) == 0 {
+		return fmt.Errorf("refusing to replace test results for job %s with none", jobID)
+	}
+
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
+	if _, err := p.tx.Exec(ctx, "DELETE FROM test_results WHERE job_id = $1", jobID); err != nil {
+		return fmt.Errorf("failed to clear test results: %w", err)
+	}
+
 	sql := `
 INSERT INTO test_results (job_id, name, runtime, status, message)
-VALUES ($1, $2, $3, $4, $5) RETURNING id
+VALUES ($1, $2, $3, $4, $5)
 `
-
-	row := p.tx.QueryRow(ctx,
-		sql,
-		tr.JobID,
-		tr.Name,
-		tr.Runtime,
-		tr.Status,
-		tr.Message,
-	)
-	var id int
-	if err := row.Scan(&id); err != nil {
-		return 0, fmt.Errorf("failed to insert test result: %w", err)
+	for _, tr := range results {
+		if _, err := p.tx.Exec(ctx, sql, jobID, tr.Name, tr.Runtime, tr.Status, tr.Message); err != nil {
+			return fmt.Errorf("failed to insert test result: %w", err)
+		}
 	}
-	return id, nil
+	return nil
 }
 
 func (p *PGXTransactor) Commit(ctx context.Context) error {
@@ -202,10 +254,12 @@ func (p *PGXTransactor) Commit(ctx context.Context) error {
 	return p.tx.Commit(ctx)
 }
 
+// Rollback is safe to defer unconditionally: rolling back an already committed
+// transaction is a no-op rather than an error worth reporting.
 func (p *PGXTransactor) Rollback(ctx context.Context) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
-	if err := p.tx.Rollback(context.Background()); err != nil {
+	if err := p.tx.Rollback(context.Background()); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
 		slog.Error("error rolling back transaction", "err", err)
 	}
 }

--- a/cci-stats/pkg/db/migrate_test.go
+++ b/cci-stats/pkg/db/migrate_test.go
@@ -2,14 +2,17 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	_ "embed"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/pressly/goose/v3"
 )
 
 // legacyV1Schema is the schema as it was applied by hand, before these
@@ -24,8 +27,15 @@ var legacyV1Schema string
 const defaultTestDatabaseURI = "postgres://opc@localhost:5432/postgres?sslmode=disable"
 
 // gooseTable is the bookkeeping table goose adds. It is the only object the
-// first migration of an existing database is allowed to create.
+// baseline migration of an existing database is allowed to create.
 const gooseTable = "goose_db_version"
+
+// currentSchemaVersion is the highest migration in pkg/db/migrations. Bump it
+// when adding one.
+const currentSchemaVersion = 2
+
+// baselineVersion is the migration that reproduces the hand-applied schema.
+const baselineVersion = 1
 
 // TestMigrateFromEmpty covers a database built from nothing.
 func TestMigrateFromEmpty(t *testing.T) {
@@ -35,7 +45,7 @@ func TestMigrateFromEmpty(t *testing.T) {
 	if err := Migrate(ctx, uri); err != nil {
 		t.Fatalf("migrating an empty database: %v", err)
 	}
-	assertVersion(ctx, t, uri, 1)
+	assertVersion(ctx, t, uri, currentSchemaVersion)
 	for _, table := range []string{"pipelines", "jobs", "test_results"} {
 		assertTableExists(ctx, t, uri, schema, table)
 	}
@@ -53,7 +63,7 @@ func TestMigrateIsIdempotent(t *testing.T) {
 	if err := Migrate(ctx, uri); err != nil {
 		t.Fatalf("second migrate against an already current database: %v", err)
 	}
-	assertVersion(ctx, t, uri, 1)
+	assertVersion(ctx, t, uri, currentSchemaVersion)
 }
 
 // TestMigrateOverLegacySchema is the one that matters for the first deploy: the
@@ -67,7 +77,7 @@ func TestMigrateOverLegacySchema(t *testing.T) {
 	if err := Migrate(ctx, uri); err != nil {
 		t.Fatalf("migrating a database that was set up by hand: %v", err)
 	}
-	assertVersion(ctx, t, uri, 1)
+	assertVersion(ctx, t, uri, currentSchemaVersion)
 
 	// The point of a migration chain: a database built from scratch and one
 	// carried over from the hand-applied schema must end up identical.
@@ -82,11 +92,11 @@ func TestMigrateOverLegacySchema(t *testing.T) {
 	}
 }
 
-// TestMigrateLeavesExistingDatabaseAlone covers the first deploy of this
-// change. Against the database already in service, the baseline must add
-// goose's bookkeeping table and nothing else — no existing object altered and
-// no row touched.
-func TestMigrateLeavesExistingDatabaseAlone(t *testing.T) {
+// TestBaselineLeavesExistingDatabaseAlone covers adopting the database already
+// in service. Stopping at the baseline, it must add goose's bookkeeping table
+// and nothing else — no existing object altered and no row touched. Later
+// migrations are expected to change the schema, so they are not run here.
+func TestBaselineLeavesExistingDatabaseAlone(t *testing.T) {
 	ctx := context.Background()
 	uri, schema := newTestSchema(ctx, t, "untouched")
 	exec(ctx, t, uri, legacyV1Schema)
@@ -95,16 +105,14 @@ INSERT INTO pipelines (id, number, commit, branch, created_at)
 VALUES ('p1', 1, 'abc123', 'develop', '2026-01-01 00:00:00')`)
 
 	before := fingerprint(ctx, t, uri, schema, gooseTable)
-	if err := Migrate(ctx, uri); err != nil {
-		t.Fatalf("migrating the existing database: %v", err)
-	}
+	migrateUpTo(ctx, t, uri, baselineVersion)
 	after := fingerprint(ctx, t, uri, schema, gooseTable)
 
 	if before != after {
 		t.Errorf("the existing schema was modified:\n--- before ---\n%s\n--- after ---\n%s", before, after)
 	}
 	assertTableExists(ctx, t, uri, schema, gooseTable)
-	assertVersion(ctx, t, uri, 1)
+	assertVersion(ctx, t, uri, baselineVersion)
 
 	var count int
 	conn, err := pgx.Connect(ctx, uri)
@@ -117,6 +125,37 @@ VALUES ('p1', 1, 'abc123', 'develop', '2026-01-01 00:00:00')`)
 	}
 	if count != 1 {
 		t.Errorf("existing row did not survive the migration")
+	}
+}
+
+// TestPipelineCompleteAdoptsExistingRows covers the meaning of the complete
+// column for rows that predate it. Those pipelines were only ever written once
+// all of their workflows had finished, so they must read as complete rather
+// than land back on the retry list.
+func TestPipelineCompleteAdoptsExistingRows(t *testing.T) {
+	ctx := context.Background()
+	uri, _ := newTestSchema(ctx, t, "adopt_rows")
+	exec(ctx, t, uri, legacyV1Schema)
+	exec(ctx, t, uri, `
+INSERT INTO pipelines (id, number, commit, branch, created_at)
+VALUES ('old', 1, 'abc123', 'develop', '2026-01-01 00:00:00')`)
+
+	if err := Migrate(ctx, uri); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	conn, err := pgx.Connect(ctx, uri)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	defer conn.Close(ctx)
+
+	var complete bool
+	if err := conn.QueryRow(ctx, "SELECT complete FROM pipelines WHERE id = 'old'").Scan(&complete); err != nil {
+		t.Fatalf("reading complete: %v", err)
+	}
+	if !complete {
+		t.Error("a pipeline recorded before the column existed was left incomplete, so it will be retried forever")
 	}
 }
 
@@ -138,6 +177,32 @@ func TestMigrateRejectsNewerSchema(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "expects") {
 		t.Errorf("error does not explain the version mismatch: %v", err)
+	}
+}
+
+// migrateUpTo applies migrations only as far as version, which Migrate has no
+// reason to expose. It uses the same embedded files, so a test can pin the
+// behaviour of one migration rather than the whole chain.
+func migrateUpTo(ctx context.Context, t *testing.T, uri string, version int64) {
+	t.Helper()
+
+	sqlDB, err := sql.Open("pgx", uri)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer sqlDB.Close()
+
+	fsys, err := fs.Sub(migrations, migrationsDir)
+	if err != nil {
+		t.Fatalf("reading embedded migrations: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectPostgres, sqlDB, fsys,
+		goose.WithDisableGlobalRegistry(true))
+	if err != nil {
+		t.Fatalf("creating provider: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, version); err != nil {
+		t.Fatalf("migrating to version %d: %v", version, err)
 	}
 }
 

--- a/cci-stats/pkg/db/migrations/00002_pipeline_complete.sql
+++ b/cci-stats/pkg/db/migrations/00002_pipeline_complete.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- DEFAULT TRUE is deliberate: every pre-existing row was only written once all
+-- of its workflows had finished, so all of them are complete.
+ALTER TABLE pipelines
+    ADD COLUMN complete BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE INDEX pipelines_incomplete_idx ON pipelines (created_at) WHERE NOT complete;
+
+-- +goose Down
+DROP INDEX pipelines_incomplete_idx;
+
+ALTER TABLE pipelines
+    DROP COLUMN complete;

--- a/cci-stats/pkg/service/report_test.go
+++ b/cci-stats/pkg/service/report_test.go
@@ -1,0 +1,552 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/axelKingsley/go-circleci"
+	"github.com/ethereum-optimism/infra/cci-stats/pkg/config"
+	"github.com/ethereum-optimism/infra/cci-stats/pkg/db"
+)
+
+// fakeProjects, fakePipelines, fakeWorkflows and fakeJobs embed the client's
+// interfaces so only the calls under test need implementing.
+
+type fakeProjects struct {
+	circleci.Projects
+	pipelines []*circleci.Pipeline
+}
+
+func (f *fakeProjects) ListPipelines(_ context.Context, _ string, _ circleci.ProjectListPipelinesOptions) (*circleci.PipelineList, error) {
+	return &circleci.PipelineList{Items: f.pipelines}, nil
+}
+
+type fakePipelines struct {
+	circleci.Pipelines
+	mtx sync.Mutex
+	// states, workflows and the error maps are keyed by pipeline ID.
+	states    map[string]string
+	workflows map[string][]*circleci.Workflow
+	getErr    map[string]error
+	listErr   map[string]error
+	getCalls  int
+	// pageSize splits ListWorkflows across pages when positive.
+	pageSize    int
+	pagesServed int
+}
+
+func (f *fakePipelines) Get(_ context.Context, id string) (*circleci.Pipeline, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.getCalls++
+	if err := f.getErr[id]; err != nil {
+		return nil, err
+	}
+	return &circleci.Pipeline{State: f.states[id]}, nil
+}
+
+func (f *fakePipelines) ListWorkflows(_ context.Context, id string, opts circleci.PipelineListWorkflowsOptions) (*circleci.WorkflowList, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	if err := f.listErr[id]; err != nil {
+		return nil, err
+	}
+	f.pagesServed++
+
+	all := f.workflows[id]
+	if f.pageSize <= 0 {
+		return &circleci.WorkflowList{Items: all}, nil
+	}
+
+	offset := 0
+	if opts.PageToken != nil {
+		var err error
+		if offset, err = strconv.Atoi(*opts.PageToken); err != nil {
+			return nil, err
+		}
+	}
+	end := min(offset+f.pageSize, len(all))
+	page := &circleci.WorkflowList{Items: all[offset:end]}
+	if end < len(all) {
+		page.NextPageToken = strconv.Itoa(end)
+	}
+	return page, nil
+}
+
+type fakeWorkflows struct {
+	circleci.Workflows
+	jobs map[string][]*circleci.WorkflowJob
+}
+
+func (f *fakeWorkflows) ListWorkflowJobs(_ context.Context, id string) (*circleci.WorkflowJobList, error) {
+	return &circleci.WorkflowJobList{Items: f.jobs[id]}, nil
+}
+
+type fakeJobs struct {
+	circleci.Jobs
+	mtx sync.Mutex
+	// metadata is keyed by job number, so a job's results can be changed
+	// between runs independently of the others.
+	metadata map[string][]*circleci.TestMetadata
+}
+
+func (f *fakeJobs) ListTestMetadata(_ context.Context, _ string, jobNumber string) (*circleci.TestMetadataList, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	return &circleci.TestMetadataList{Items: f.metadata[jobNumber]}, nil
+}
+
+// fakeDB is an in-memory stand-in for the Postgres connection.
+type fakeDB struct {
+	mtx          sync.Mutex
+	pipelines    map[string]db.Pipeline
+	order        []string
+	jobs         map[string]db.Job
+	testResults  map[string][]db.TestResult
+	replaceCalls map[string]int
+}
+
+func newFakeDB() *fakeDB {
+	return &fakeDB{
+		pipelines:    map[string]db.Pipeline{},
+		jobs:         map[string]db.Job{},
+		testResults:  map[string][]db.TestResult{},
+		replaceCalls: map[string]int{},
+	}
+}
+
+func (f *fakeDB) LastPipeline(context.Context) (*db.Pipeline, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	var last *db.Pipeline
+	for _, p := range f.pipelines {
+		if last == nil || p.CreatedAt.After(last.CreatedAt) {
+			cp := p
+			last = &cp
+		}
+	}
+	return last, nil
+}
+
+func (f *fakeDB) IncompletePipelines(_ context.Context, since time.Time) ([]db.Pipeline, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	var res []db.Pipeline
+	for _, id := range f.order {
+		p := f.pipelines[id]
+		if !p.Complete && !p.CreatedAt.Before(since) {
+			res = append(res, p)
+		}
+	}
+	return res, nil
+}
+
+func (f *fakeDB) RecordPending(_ context.Context, pipelines []db.Pipeline) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	for _, p := range pipelines {
+		if _, ok := f.pipelines[p.ID]; ok {
+			continue
+		}
+		p.Complete = false
+		f.pipelines[p.ID] = p
+		f.order = append(f.order, p.ID)
+	}
+	return nil
+}
+
+func (f *fakeDB) Begin() (db.Transactor, error) { return &fakeTx{db: f}, nil }
+func (f *fakeDB) Close() error                  { return nil }
+
+type fakeTx struct {
+	db *fakeDB
+}
+
+func (t *fakeTx) InsertPipeline(_ context.Context, p db.Pipeline) error {
+	t.db.mtx.Lock()
+	defer t.db.mtx.Unlock()
+	if _, ok := t.db.pipelines[p.ID]; !ok {
+		t.db.order = append(t.db.order, p.ID)
+	}
+	t.db.pipelines[p.ID] = p
+	return nil
+}
+
+func (t *fakeTx) InsertJob(_ context.Context, j db.Job) error {
+	t.db.mtx.Lock()
+	defer t.db.mtx.Unlock()
+	t.db.jobs[j.ID] = j
+	return nil
+}
+
+// ReplaceTestResults mirrors the real implementation, which refuses to clear a
+// job's rows when handed nothing to put back.
+func (t *fakeTx) ReplaceTestResults(_ context.Context, jobID string, results []db.TestResult) error {
+	t.db.mtx.Lock()
+	defer t.db.mtx.Unlock()
+	t.db.replaceCalls[jobID]++
+	if len(results) == 0 {
+		return errors.New("refusing to replace test results with none")
+	}
+	t.db.testResults[jobID] = results
+	return nil
+}
+
+func (t *fakeTx) Commit(context.Context) error { return nil }
+func (t *fakeTx) Rollback(context.Context)     {}
+
+func testConfig() config.Config { return testConfigMatching("^main$") }
+
+func testConfigMatching(workflowPattern string) config.Config {
+	return config.Config{
+		ProjectSlug:              "gh/acme/repo",
+		BranchPatternRegex:       regexp.MustCompile(".*"),
+		WorkflowPatternRegex:     regexp.MustCompile(workflowPattern),
+		FetchLimitDays:           5,
+		MaxConcurrentFetchJobs:   1,
+		SlowTestThresholdSeconds: 0,
+	}
+}
+
+func testPipeline(id string, number int64) *circleci.Pipeline {
+	return &circleci.Pipeline{
+		ID:        id,
+		Number:    number,
+		State:     "created",
+		CreatedAt: time.Now().UTC().Add(-time.Hour),
+		Vcs:       &circleci.VCS{Revision: "abc123", Branch: "develop"},
+	}
+}
+
+// TestGenerateReport_RetriesUnfinishedPipeline covers the cycle this package
+// exists for: a pipeline seen while a workflow was still running is recorded as
+// incomplete, picked up again on the next run, and only then marked complete.
+func TestGenerateReport_RetriesUnfinishedPipeline(t *testing.T) {
+	pipeline := testPipeline("pipeline-1", 42)
+
+	pipelinesAPI := &fakePipelines{
+		states: map[string]string{"pipeline-1": "created"},
+		workflows: map[string][]*circleci.Workflow{"pipeline-1": {
+			{ID: "wf-setup", Name: "setup", Status: "success"},
+			{ID: "wf-main", Name: "main", Status: "running"},
+		}},
+	}
+	workflowsAPI := &fakeWorkflows{jobs: map[string][]*circleci.WorkflowJob{
+		"wf-main": {{ID: "job-1", JobNumber: 7, Name: "build", Status: "success"}},
+	}}
+	client := &circleci.Client{
+		Projects:  &fakeProjects{pipelines: []*circleci.Pipeline{pipeline}},
+		Pipelines: pipelinesAPI,
+		Workflows: workflowsAPI,
+		Jobs:      &fakeJobs{metadata: map[string][]*circleci.TestMetadata{"7": {{Name: "TestFoo", Result: "failed", RunTime: 1.5}}}},
+	}
+	conn := newFakeDB()
+
+	// Run one: main is still running, so nothing of it is recorded yet.
+	if err := GenerateReport(context.Background(), testConfig(), client, conn); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	got, ok := conn.pipelines["pipeline-1"]
+	if !ok {
+		t.Fatal("first run did not record the pipeline, so it can never be retried")
+	}
+	if got.Complete {
+		t.Error("pipeline marked complete while a matched workflow was still running")
+	}
+	if len(conn.jobs) != 0 {
+		t.Errorf("recorded %d jobs for an unfinished workflow, want 0", len(conn.jobs))
+	}
+	if got.Commit != "abc123" || got.Branch != "develop" || got.Number != 42 {
+		t.Errorf("pipeline recorded with wrong details: %+v", got)
+	}
+
+	// Run two: main has finished. The pipeline is no longer newly listed, so it
+	// can only be reached through the retry path.
+	client.Projects = &fakeProjects{}
+	pipelinesAPI.workflows["pipeline-1"] = []*circleci.Workflow{
+		{ID: "wf-setup", Name: "setup", Status: "success"},
+		{ID: "wf-main", Name: "main", Status: "success"},
+	}
+
+	if err := GenerateReport(context.Background(), testConfig(), client, conn); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if pipelinesAPI.getCalls == 0 {
+		t.Error("retried pipeline did not have its state refreshed")
+	}
+	got = conn.pipelines["pipeline-1"]
+	if !got.Complete {
+		t.Error("pipeline still incomplete after every matched workflow finished")
+	}
+	if len(conn.jobs) != 1 {
+		t.Fatalf("recorded %d jobs, want 1", len(conn.jobs))
+	}
+	if results := conn.testResults["wf-main/job-1"]; len(results) != 1 || results[0].Name != "TestFoo" {
+		t.Errorf("test results = %+v, want one TestFoo row", results)
+	}
+}
+
+// TestGenerateReport_KeepsTestResultsWhenMetadataMissing covers the wipe that
+// reindexing would otherwise cause: a job's stored results must survive a later
+// run whose metadata fetch comes back empty, because a spurious not found is
+// indistinguishable from a job that genuinely has no tests.
+func TestGenerateReport_KeepsTestResultsWhenMetadataMissing(t *testing.T) {
+	pipeline := testPipeline("pipeline-1", 42)
+	pipelinesAPI := &fakePipelines{
+		states: map[string]string{"pipeline-1": "created"},
+		workflows: map[string][]*circleci.Workflow{"pipeline-1": {
+			{ID: "wf-main", Name: "main", Status: "success"},
+			{ID: "wf-extra", Name: "extra", Status: "running"},
+		}},
+	}
+	jobsAPI := &fakeJobs{metadata: map[string][]*circleci.TestMetadata{
+		"7": {{Name: "TestFoo", Result: "failed", RunTime: 1.5}},
+	}}
+	client := &circleci.Client{
+		Projects:  &fakeProjects{pipelines: []*circleci.Pipeline{pipeline}},
+		Pipelines: pipelinesAPI,
+		Workflows: &fakeWorkflows{jobs: map[string][]*circleci.WorkflowJob{
+			"wf-main": {{ID: "job-1", JobNumber: 7, Name: "build", Status: "success"}},
+		}},
+		Jobs: jobsAPI,
+	}
+	conn := newFakeDB()
+	cfg := testConfigMatching("^(main|extra)$")
+
+	// Run one records the job and its results; extra is still running, so the
+	// pipeline stays on the retry list.
+	if err := GenerateReport(context.Background(), cfg, client, conn); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if len(conn.testResults["wf-main/job-1"]) != 1 {
+		t.Fatalf("first run stored %d test results, want 1", len(conn.testResults["wf-main/job-1"]))
+	}
+
+	// Run two reindexes the same job, but its metadata now comes back empty.
+	client.Projects = &fakeProjects{}
+	jobsAPI.metadata["7"] = nil
+	pipelinesAPI.workflows["pipeline-1"] = []*circleci.Workflow{
+		{ID: "wf-main", Name: "main", Status: "success"},
+		{ID: "wf-extra", Name: "extra", Status: "success"},
+	}
+
+	before := conn.replaceCalls["wf-main/job-1"]
+	if err := GenerateReport(context.Background(), cfg, client, conn); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if got := conn.testResults["wf-main/job-1"]; len(got) != 1 || got[0].Name != "TestFoo" {
+		t.Errorf("reindexing wiped stored test results: %+v", got)
+	}
+	// The storage layer also refuses an empty replace, so assert the caller did
+	// not even attempt one. Otherwise this passes on the lower guard alone.
+	if got := conn.replaceCalls["wf-main/job-1"] - before; got != 0 {
+		t.Errorf("attempted %d replacements with no metadata, want 0", got)
+	}
+}
+
+// TestGenerateReport_SkipsFailedRetry covers a retried pipeline that cannot be
+// fetched. It must neither fail the run nor stop other pipelines being indexed,
+// or a single stuck row would block everything until it ages out.
+func TestGenerateReport_SkipsFailedRetry(t *testing.T) {
+	conn := newFakeDB()
+	conn.pipelines["stuck"] = db.Pipeline{ID: "stuck", CreatedAt: time.Now().UTC().Add(-2 * time.Hour)}
+	conn.order = []string{"stuck"}
+
+	healthy := testPipeline("healthy", 1)
+	client := &circleci.Client{
+		Projects: &fakeProjects{pipelines: []*circleci.Pipeline{healthy}},
+		Pipelines: &fakePipelines{
+			states:    map[string]string{"healthy": "created"},
+			workflows: map[string][]*circleci.Workflow{"healthy": {{ID: "wf-main", Name: "main", Status: "success"}}},
+			getErr:    map[string]error{"stuck": errors.New("404 not found")},
+		},
+		Workflows: &fakeWorkflows{jobs: map[string][]*circleci.WorkflowJob{
+			"wf-main": {{ID: "job-1", JobNumber: 7, Name: "build", Status: "success"}},
+		}},
+		Jobs: &fakeJobs{},
+	}
+
+	if err := GenerateReport(context.Background(), testConfig(), client, conn); err != nil {
+		t.Fatalf("a retried pipeline that cannot be fetched failed the whole run: %v", err)
+	}
+	if got := conn.pipelines["healthy"]; !got.Complete {
+		t.Error("a stuck retry stopped a healthy pipeline being indexed")
+	}
+	if len(conn.jobs) != 1 {
+		t.Errorf("recorded %d jobs for the healthy pipeline, want 1", len(conn.jobs))
+	}
+}
+
+// TestGenerateReport_ClaimsPipelinesBeforeIndexing covers what RecordPending is
+// for: a run that stops part way must leave the pipelines it listed on the retry
+// list, not behind the high water mark.
+func TestGenerateReport_ClaimsPipelinesBeforeIndexing(t *testing.T) {
+	// The failing pipeline is listed first, so with one worker the second is
+	// never processed.
+	bad, good := testPipeline("bad", 1), testPipeline("good", 2)
+	client := &circleci.Client{
+		Projects: &fakeProjects{pipelines: []*circleci.Pipeline{bad, good}},
+		Pipelines: &fakePipelines{
+			states:    map[string]string{"bad": "created", "good": "created"},
+			workflows: map[string][]*circleci.Workflow{"good": {{ID: "wf-main", Name: "main", Status: "success"}}},
+			listErr:   map[string]error{"bad": errors.New("boom")},
+		},
+		Workflows: &fakeWorkflows{},
+		Jobs:      &fakeJobs{},
+	}
+	conn := newFakeDB()
+
+	if err := GenerateReport(context.Background(), testConfig(), client, conn); err == nil {
+		t.Fatal("expected the run to fail on the listed pipeline that could not be indexed")
+	}
+
+	// Every listed pipeline must have a row. Without the up-front claim, one the
+	// run never got to has none at all, yet the mark has already moved past it.
+	// Whether the pool got to "good" before cancelling is not deterministic, so
+	// it may legitimately be either complete or still on the retry list.
+	for _, id := range []string{"bad", "good"} {
+		if _, ok := conn.pipelines[id]; !ok {
+			t.Errorf("pipeline %q was listed but has no row, so it is behind the mark and lost", id)
+		}
+	}
+	if conn.pipelines["bad"].Complete {
+		t.Error("a pipeline that failed to index was marked complete")
+	}
+
+	retryable, err := conn.IncompletePipelines(context.Background(), time.Now().UTC().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("IncompletePipelines: %v", err)
+	}
+	var found bool
+	for _, p := range retryable {
+		found = found || p.ID == "bad"
+	}
+	if !found {
+		t.Error("a pipeline that failed to index is not on the retry list")
+	}
+}
+
+// TestGenerateReport_SkipsFailedRetryThatIsAlsoListed covers the pipeline
+// holding the high water mark. The cutoff is inclusive, so it is listed again
+// every run while also being on the retry list, and it is the pipeline most
+// likely to still be running. Failing to index it must not fail the run.
+func TestGenerateReport_SkipsFailedRetryThatIsAlsoListed(t *testing.T) {
+	stuck := testPipeline("stuck", 1)
+	conn := newFakeDB()
+	conn.pipelines["stuck"] = db.Pipeline{ID: "stuck", Number: 1, CreatedAt: stuck.CreatedAt}
+	conn.order = []string{"stuck"}
+
+	client := &circleci.Client{
+		// Still listed, because the cutoff is its own created_at.
+		Projects: &fakeProjects{pipelines: []*circleci.Pipeline{stuck}},
+		Pipelines: &fakePipelines{
+			states:  map[string]string{"stuck": "created"},
+			listErr: map[string]error{"stuck": errors.New("boom")},
+		},
+		Workflows: &fakeWorkflows{},
+		Jobs:      &fakeJobs{},
+	}
+
+	if err := GenerateReport(context.Background(), testConfig(), client, conn); err != nil {
+		t.Fatalf("a pipeline already on the retry list failed the whole run: %v", err)
+	}
+	if conn.pipelines["stuck"].Complete {
+		t.Error("a pipeline that failed to index was marked complete")
+	}
+}
+
+// TestGenerateReport_DoesNotClaimBeyondTheHorizon covers an indexer that has
+// been down for longer than FETCH_LIMIT_DAYS. The mark is then older than the
+// retry window, and anything claimed past the window could never be reindexed.
+func TestGenerateReport_DoesNotClaimBeyondTheHorizon(t *testing.T) {
+	conn := newFakeDB()
+	// FetchLimitDays is 5, so the mark sits well behind the horizon.
+	conn.pipelines["old"] = db.Pipeline{
+		ID:        "old",
+		CreatedAt: time.Now().UTC().Add(-10 * 24 * time.Hour),
+		Complete:  true,
+	}
+	conn.order = []string{"old"}
+
+	stale := testPipeline("stale", 2)
+	stale.CreatedAt = time.Now().UTC().Add(-7 * 24 * time.Hour)
+	client := &circleci.Client{
+		Projects:  &fakeProjects{pipelines: []*circleci.Pipeline{stale}},
+		Pipelines: &fakePipelines{states: map[string]string{"stale": "created"}},
+		Workflows: &fakeWorkflows{},
+		Jobs:      &fakeJobs{},
+	}
+
+	if err := GenerateReport(context.Background(), testConfig(), client, conn); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if _, ok := conn.pipelines["stale"]; ok {
+		t.Error("claimed a pipeline older than the retry window, so it can never be reindexed")
+	}
+}
+
+// TestGenerateReport_PaginatesWorkflows covers the workflow list being split
+// across pages. The count feeds the permanence decision, so a truncated list
+// could mark a pipeline complete on a partial set.
+func TestGenerateReport_PaginatesWorkflows(t *testing.T) {
+	pipeline := testPipeline("pipeline-1", 42)
+	pipelinesAPI := &fakePipelines{
+		pageSize: 1,
+		states:   map[string]string{"pipeline-1": "created"},
+		workflows: map[string][]*circleci.Workflow{"pipeline-1": {
+			{ID: "wf-setup", Name: "setup", Status: "success"},
+			{ID: "wf-main", Name: "main", Status: "running"},
+		}},
+	}
+	client := &circleci.Client{
+		Projects:  &fakeProjects{pipelines: []*circleci.Pipeline{pipeline}},
+		Pipelines: pipelinesAPI,
+		Workflows: &fakeWorkflows{},
+		Jobs:      &fakeJobs{},
+	}
+	conn := newFakeDB()
+
+	if err := GenerateReport(context.Background(), testConfig(), client, conn); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if pipelinesAPI.pagesServed != 2 {
+		t.Errorf("served %d workflow pages, want 2", pipelinesAPI.pagesServed)
+	}
+	// main is on the second page and still running, so a truncated list would
+	// have marked this complete.
+	if conn.pipelines["pipeline-1"].Complete {
+		t.Error("pipeline marked complete from a truncated workflow list")
+	}
+}
+
+// TestGenerateReport_PipelineWithNoMatchingWorkflows records the pipeline so the
+// high water mark can pass it, and does not leave it on the retry list.
+func TestGenerateReport_PipelineWithNoMatchingWorkflows(t *testing.T) {
+	pipeline := testPipeline("tag-pipeline", 9)
+	client := &circleci.Client{
+		Projects: &fakeProjects{pipelines: []*circleci.Pipeline{pipeline}},
+		Pipelines: &fakePipelines{
+			states:    map[string]string{"tag-pipeline": "created"},
+			workflows: map[string][]*circleci.Workflow{"tag-pipeline": {{ID: "wf-rel", Name: "release", Status: "success"}}},
+		},
+		Workflows: &fakeWorkflows{},
+		Jobs:      &fakeJobs{},
+	}
+	conn := newFakeDB()
+
+	if err := GenerateReport(context.Background(), testConfig(), client, conn); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := conn.pipelines["tag-pipeline"]
+	if !got.Complete {
+		t.Error("pipeline whose workflows cannot match was left on the retry list")
+	}
+	if len(conn.jobs) != 0 {
+		t.Errorf("recorded %d jobs, want 0", len(conn.jobs))
+	}
+}

--- a/cci-stats/pkg/service/service.go
+++ b/cci-stats/pkg/service/service.go
@@ -14,19 +14,64 @@ import (
 	"github.com/sourcegraph/conc/pool"
 )
 
+// pipelineWork is a pipeline queued for indexing, from either the CircleCI
+// listing or the set of pipelines held over from an earlier run.
+type pipelineWork struct {
+	pipeline db.Pipeline
+	// state is the CircleCI pipeline state, carried over from the listing. It is
+	// unset for a pipeline known only from the database, which reloads it.
+	state string
+	// retry marks a pipeline already recorded as incomplete by an earlier run.
+	// It stays on the retry list either way, so failing to index it is not fatal
+	// to the run. A pipeline claimed for the first time by this run is not a
+	// retry: a failure there is still worth surfacing.
+	retry bool
+}
+
 func GenerateReport(ctx context.Context, config config.Config, client *circleci.Client, dbConn db.Connection) error {
 	lastPipeline, err := dbConn.LastPipeline(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to fetch last pipeline: %w", err)
 	}
-	cutoff := time.Now().Add(-time.Duration(config.FetchLimitDays) * 24 * time.Hour)
-	if lastPipeline != nil {
+	// UTC because pgx reinterprets a non-UTC wall clock as UTC when writing a
+	// timestamp without time zone, which would shift the window by the offset.
+	horizon := time.Now().UTC().Add(-time.Duration(config.FetchLimitDays) * 24 * time.Hour)
+	cutoff := horizon
+	// Never reach back past the horizon, even when the mark is older because the
+	// indexer has been down for longer than FETCH_LIMIT_DAYS. Anything claimed
+	// beyond it would fall outside the retry window and so could never be
+	// reindexed.
+	if lastPipeline != nil && lastPipeline.CreatedAt.After(horizon) {
 		cutoff = lastPipeline.CreatedAt
 	}
 
-	pipelines, err := fetchPipelines(ctx, config, cutoff, client)
+	newPipelines, err := fetchPipelines(ctx, config, cutoff, client)
 	if err != nil {
 		return fmt.Errorf("failed to fetch pipelines: %w", err)
+	}
+
+	// Pipelines are not indexed in creation order, so the mark routinely moves
+	// past one that was unfinished when last seen. See db.Pipeline.Complete.
+	incomplete, err := dbConn.IncompletePipelines(ctx, horizon)
+	if err != nil {
+		return fmt.Errorf("failed to fetch incomplete pipelines: %w", err)
+	}
+	retries := make([]pipelineWork, 0, len(incomplete))
+	for _, p := range incomplete {
+		retries = append(retries, pipelineWork{pipeline: p, retry: true})
+	}
+
+	pipelines := mergePipelines(newPipelines, retries)
+	slog.Info("indexing pipelines", "new", len(newPipelines), "retried", len(retries), "total", len(pipelines))
+
+	// Each pipeline commits its own transaction, so a run that stops part way
+	// would otherwise leave the mark past pipelines it never wrote.
+	claimed := make([]db.Pipeline, 0, len(newPipelines))
+	for _, work := range newPipelines {
+		claimed = append(claimed, work.pipeline)
+	}
+	if err := dbConn.RecordPending(ctx, claimed); err != nil {
+		return fmt.Errorf("failed to record pending pipelines: %w", err)
 	}
 
 	var completed int32
@@ -36,18 +81,29 @@ func GenerateReport(ctx context.Context, config config.Config, client *circleci.
 		WithMaxGoroutines(config.MaxConcurrentFetchJobs).
 		WithContext(ctx).
 		WithCancelOnError()
-	for _, pline := range pipelines {
-		pline := pline
+	for _, work := range pipelines {
 		plinePool.Go(func(ctx context.Context) error {
-			if err := processPipeline(ctx, config, client, dbConn, pline); err != nil {
+			if err := processPipeline(ctx, config, client, dbConn, work); err != nil {
+				if work.retry {
+					// A retried pipeline stays on the retry list, so failing the
+					// run here would repeat every run until it ages out and
+					// would stop anything at all being recorded meanwhile.
+					slog.Error(
+						"skipping retried pipeline that failed to index",
+						"pipeline", work.pipeline.ID,
+						"number", work.pipeline.Number,
+						"err", err,
+					)
+					return nil
+				}
 				return fmt.Errorf("failed to process pipeline: %w", err)
 			}
 
 			cmpl := atomic.AddInt32(&completed, 1)
 			slog.Info(
 				"completed pipeline",
-				"pipeline", pline.ID,
-				"number", pline.Number,
+				"pipeline", work.pipeline.ID,
+				"number", work.pipeline.Number,
 				"total", len(pipelines),
 				"completed", cmpl,
 			)
@@ -60,37 +116,56 @@ func GenerateReport(ctx context.Context, config config.Config, client *circleci.
 	return nil
 }
 
-func processPipeline(ctx context.Context, config config.Config, client *circleci.Client, dbConn db.Connection, pline *circleci.Pipeline) error {
-	workflows, err := fetchWorkflows(ctx, config, client, pline.ID)
+func processPipeline(ctx context.Context, config config.Config, client *circleci.Client, dbConn db.Connection, work pipelineWork) error {
+	pline := work.pipeline
+
+	state := work.state
+	if state == "" {
+		// Reloaded from the database, which does not record the state.
+		fresh, err := client.Pipelines.Get(ctx, pline.ID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch pipeline: %w", err)
+		}
+		state = fresh.State
+	}
+
+	allWorkflows, err := fetchWorkflows(ctx, client, pline.ID)
 	if err != nil {
 		return fmt.Errorf("failed to fetch workflows: %w", err)
 	}
 
-	if len(workflows) == 0 {
-		slog.Info("skipping pipeline with no workflows", "pipeline", pline.ID, "number", pline.Number)
-		return nil
+	type matchedWorkflow struct {
+		workflow *circleci.Workflow
+		status   string
 	}
+	var matched []matchedWorkflow
+	var statuses []string
+	for _, wf := range allWorkflows {
+		if config.WorkflowPatternRegex.MatchString(wf.Name) {
+			status := workflowStatus(wf)
+			matched = append(matched, matchedWorkflow{workflow: wf, status: status})
+			statuses = append(statuses, status)
+		}
+	}
+	pline.Complete = pipelineComplete(state, len(allWorkflows), statuses)
 
 	workflowsJobs := make(map[string][]*circleci.WorkflowJob)
 	workflowsByID := make(map[string]*circleci.Workflow)
 
-	slog.Info("fetching jobs", "pipeline", pline.ID, "number", pline.Number)
-	for _, wf := range workflows {
-		if wf.Status == "running" ||
-			wf.Status == "not_run" ||
-			wf.Status == "failing" ||
-			wf.Status == "on_hold" ||
-			wf.Status == "canceled" ||
-			wf.Status == "unauthorized" {
-			return nil
+	slog.Info("fetching jobs", "pipeline", pline.ID, "number", pline.Number, "state", state, "complete", pline.Complete)
+	for _, m := range matched {
+		// Nothing worth recording yet. The pipeline is still written, marked
+		// incomplete, so a later run picks the workflow up once it finishes.
+		if !isTerminalStatus(m.status) {
+			continue
 		}
 
-		jobs, err := fetchJobs(ctx, client, wf.ID)
+		jobs, err := fetchJobs(ctx, client, m.workflow.ID)
 		if err != nil {
 			return fmt.Errorf("failed to fetch jobs: %w", err)
 		}
-		workflowsJobs[wf.ID] = jobs
-		workflowsByID[wf.ID] = wf
+		workflowsJobs[m.workflow.ID] = jobs
+		workflowsByID[m.workflow.ID] = m.workflow
 	}
 
 	type testMetadata struct {
@@ -130,20 +205,10 @@ func processPipeline(ctx context.Context, config config.Config, client *circleci
 	if err != nil {
 		return fmt.Errorf("failed to start transaction: %w", err)
 	}
-	defer func() {
-		if err != nil {
-			tx.Rollback(ctx)
-		}
-	}()
+	defer tx.Rollback(ctx)
 
 	slog.Info("inserting into DB", "pipeline", pline.ID, "number", pline.Number)
-	if err := tx.InsertPipeline(ctx, db.Pipeline{
-		ID:        pline.ID,
-		Number:    pline.Number,
-		Commit:    pline.Vcs.Revision,
-		Branch:    pline.Vcs.Branch,
-		CreatedAt: pline.CreatedAt,
-	}); err != nil {
+	if err := tx.InsertPipeline(ctx, pline); err != nil {
 		return fmt.Errorf("failed to insert pipeline: %w", err)
 	}
 
@@ -151,6 +216,9 @@ func processPipeline(ctx context.Context, config config.Config, client *circleci
 	for wfID, jobs := range workflowsJobs {
 		wf := workflowsByID[wfID]
 		for _, job := range jobs {
+			// StartedAt and StoppedAt are the zero time for a blocked job, which
+			// CircleCI reports without timestamps. Stored as 0001-01-01, so a
+			// query computing wall clock has to exclude them.
 			if err := tx.InsertJob(ctx, db.Job{
 				ID:           fmt.Sprintf("%s/%s", wf.ID, job.ID),
 				PipelineID:   pline.ID,
@@ -169,16 +237,25 @@ func processPipeline(ctx context.Context, config config.Config, client *circleci
 
 	slog.Info("inserting test metadata", "pipeline", pline.ID, "number", pline.Number)
 	for _, tm := range metadata {
+		// Leave the stored results alone when the fetch produced nothing. A job
+		// that genuinely has no metadata is indistinguishable from one whose
+		// fetch returned not found, and clearing on the latter would be
+		// permanent once the pipeline is marked complete.
+		if len(tm.Metadata) == 0 {
+			continue
+		}
+
+		results := make([]db.TestResult, 0, len(tm.Metadata))
 		for _, m := range tm.Metadata {
-			if _, err := tx.InsertTestResult(ctx, db.TestResult{
-				JobID:   fmt.Sprintf("%s/%s", tm.WFID, tm.JobID),
+			results = append(results, db.TestResult{
 				Name:    m.Name,
 				Runtime: m.RunTime,
 				Status:  m.Result,
 				Message: m.Message,
-			}); err != nil {
-				return fmt.Errorf("failed to insert test result: %w", err)
-			}
+			})
+		}
+		if err := tx.ReplaceTestResults(ctx, fmt.Sprintf("%s/%s", tm.WFID, tm.JobID), results); err != nil {
+			return fmt.Errorf("failed to replace test results: %w", err)
 		}
 	}
 
@@ -189,8 +266,8 @@ func processPipeline(ctx context.Context, config config.Config, client *circleci
 	return nil
 }
 
-func fetchPipelines(ctx context.Context, config config.Config, cutoff time.Time, client *circleci.Client) ([]*circleci.Pipeline, error) {
-	var res []*circleci.Pipeline
+func fetchPipelines(ctx context.Context, config config.Config, cutoff time.Time, client *circleci.Client) ([]pipelineWork, error) {
+	var res []pipelineWork
 	var pageToken string
 	opts := circleci.ProjectListPipelinesOptions{}
 
@@ -213,11 +290,20 @@ func fetchPipelines(ctx context.Context, config config.Config, cutoff time.Time,
 				done = true
 				break
 			}
-			res = append(res, p)
+			res = append(res, pipelineWork{
+				pipeline: db.Pipeline{
+					ID:        p.ID,
+					Number:    p.Number,
+					Commit:    p.Vcs.Revision,
+					Branch:    p.Vcs.Branch,
+					CreatedAt: p.CreatedAt,
+				},
+				state: p.State,
+			})
 		}
 
 		if len(res) > 0 {
-			slog.Info("fetched pipelines", "count", len(res), "last", res[len(res)-1].CreatedAt)
+			slog.Info("fetched pipelines", "count", len(res), "last", res[len(res)-1].pipeline.CreatedAt)
 		}
 
 		if done || pipelines.NextPageToken == "" {
@@ -229,20 +315,31 @@ func fetchPipelines(ctx context.Context, config config.Config, cutoff time.Time,
 	return res, nil
 }
 
-func fetchWorkflows(ctx context.Context, config config.Config, client *circleci.Client, pipelineID string) ([]*circleci.Workflow, error) {
+// fetchWorkflows returns every workflow on the pipeline. The caller filters by
+// WORKFLOW_PATTERN, since it also needs the unfiltered count.
+//
+// The list has to be exhausted: a truncated page would understate the workflows
+// and could mark a pipeline complete on a partial set.
+func fetchWorkflows(ctx context.Context, client *circleci.Client, pipelineID string) ([]*circleci.Workflow, error) {
 	var res []*circleci.Workflow
+	var pageToken string
 	opts := circleci.PipelineListWorkflowsOptions{}
 
-	workflows, err := client.Pipelines.ListWorkflows(ctx, pipelineID, opts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list workflows: %w", err)
-	}
-
-	for _, wf := range workflows.Items {
-		if !config.WorkflowPatternRegex.MatchString(wf.Name) {
-			continue
+	for {
+		if pageToken != "" {
+			opts.PageToken = &pageToken
 		}
-		res = append(res, wf)
+
+		workflows, err := client.Pipelines.ListWorkflows(ctx, pipelineID, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list workflows: %w", err)
+		}
+		res = append(res, workflows.Items...)
+
+		if workflows.NextPageToken == "" {
+			break
+		}
+		pageToken = workflows.NextPageToken
 	}
 
 	slog.Debug("fetched workflows", "count", len(res), "pipeline", pipelineID)
@@ -250,6 +347,11 @@ func fetchWorkflows(ctx context.Context, config config.Config, client *circleci.
 	return res, nil
 }
 
+// fetchJobs cannot follow NextPageToken the way its siblings do: the client's
+// ListWorkflowJobs takes no options argument, so there is nowhere to pass a page
+// token. A workflow with more jobs than CircleCI's page size is therefore
+// truncated.
+// TODO(#710): paginate once the client can express it.
 func fetchJobs(ctx context.Context, client *circleci.Client, workflowID string) ([]*circleci.WorkflowJob, error) {
 	jobs, err := client.Workflows.ListWorkflowJobs(ctx, workflowID)
 	if err != nil {
@@ -257,6 +359,101 @@ func fetchJobs(ctx context.Context, client *circleci.Client, workflowID string) 
 	}
 	slog.Debug("fetched jobs", "count", len(jobs.Items), "workflow", workflowID)
 	return jobs.Items, nil
+}
+
+// terminalWorkflowStatuses are the CircleCI workflow statuses that will not
+// change again. Everything else, notably on_hold, is still in progress.
+var terminalWorkflowStatuses = map[string]bool{
+	"success":      true,
+	"failed":       true,
+	"error":        true,
+	"canceled":     true,
+	"unauthorized": true,
+	"not_run":      true,
+}
+
+func isTerminalStatus(status string) bool {
+	return terminalWorkflowStatuses[status]
+}
+
+// workflowStatus reads the status off a workflow, which the client models as an
+// untyped field. A non-string reads as unknown, and so as still in progress,
+// because retrying is the safe direction.
+func workflowStatus(wf *circleci.Workflow) string {
+	s, ok := wf.Status.(string)
+	if !ok {
+		slog.Warn("workflow has non-string status", "workflow", wf.ID, "status", wf.Status)
+		return ""
+	}
+	return s
+}
+
+const (
+	pipelineStateCreated = "created"
+	pipelineStateErrored = "errored"
+)
+
+// pipelineWorkflowsFinal reports whether a pipeline will create no further
+// workflows.
+//
+// The state has to be consulted, because under dynamic config generation the
+// workflows worth recording are created by the continuation request, and setup
+// reaching success is not ordered against that: measured over 20 monorepo
+// pipelines the gap ran from -1s to +2s. Judging on the workflow list alone can
+// catch a pipeline looking finished a second before its real workflows exist
+// and write it off for good. CircleCI holds it in setup or pending until the
+// continuation lands, so neither reads as final here.
+func pipelineWorkflowsFinal(state string, totalWorkflows int) bool {
+	switch state {
+	case pipelineStateErrored:
+		// Never the initial state, so it needs no workflow guard.
+		return true
+	case pipelineStateCreated:
+		// Also reported before setup starts, so require evidence of workflows.
+		return totalWorkflows > 0
+	default:
+		return false
+	}
+}
+
+// pipelineComplete reports whether a pipeline is done producing data.
+func pipelineComplete(state string, totalWorkflows int, matchedStatuses []string) bool {
+	if !pipelineWorkflowsFinal(state, totalWorkflows) {
+		return false
+	}
+	for _, s := range matchedStatuses {
+		if !isTerminalStatus(s) {
+			return false
+		}
+	}
+	return true
+}
+
+// mergePipelines combines newly discovered pipelines with those being retried.
+// A pipeline in both keeps the freshly fetched copy, which already carries a
+// current state, but stays marked as a retry so that failing to index it is not
+// fatal. The pipeline holding the high water mark is listed again every run, so
+// without this the commonest retry would be the one losing that protection.
+func mergePipelines(fetched []pipelineWork, retries []pipelineWork) []pipelineWork {
+	retrying := make(map[string]bool, len(retries))
+	for _, p := range retries {
+		retrying[p.pipeline.ID] = true
+	}
+
+	seen := make(map[string]bool, len(fetched))
+	res := make([]pipelineWork, 0, len(fetched)+len(retries))
+	for _, p := range fetched {
+		seen[p.pipeline.ID] = true
+		p.retry = retrying[p.pipeline.ID]
+		res = append(res, p)
+	}
+	for _, p := range retries {
+		if seen[p.pipeline.ID] {
+			continue
+		}
+		res = append(res, p)
+	}
+	return res
 }
 
 // mapFlakyStatus maps CircleCI test result status based on flaky markers

--- a/cci-stats/pkg/service/service_test.go
+++ b/cci-stats/pkg/service/service_test.go
@@ -2,7 +2,11 @@ package service
 
 import (
 	"errors"
+	"slices"
 	"testing"
+
+	"github.com/axelKingsley/go-circleci"
+	"github.com/ethereum-optimism/infra/cci-stats/pkg/db"
 )
 
 func TestIsNotFoundError(t *testing.T) {
@@ -126,5 +130,203 @@ func TestFlakyStatusMapping(t *testing.T) {
 				t.Errorf("mapFlakyStatus(%q, %q) = %q, want %q", tt.result, tt.message, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestIsTerminalStatus(t *testing.T) {
+	tests := []struct {
+		status   string
+		expected bool
+	}{
+		{"success", true},
+		{"failed", true},
+		{"error", true},
+		{"canceled", true},
+		{"unauthorized", true},
+		{"not_run", true},
+		{"running", false},
+		{"failing", false},
+		{"on_hold", false},
+		{"something_new", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			if got := isTerminalStatus(tt.status); got != tt.expected {
+				t.Errorf("isTerminalStatus(%q) = %v, want %v", tt.status, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPipelineComplete(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    string
+		total    int
+		statuses []string
+		expected bool
+	}{
+		{
+			name:     "all matched workflows terminal",
+			state:    "created",
+			total:    2,
+			statuses: []string{"success", "failed"},
+			expected: true,
+		},
+		{
+			name:     "terminal but not successful still completes",
+			state:    "created",
+			total:    3,
+			statuses: []string{"canceled", "not_run", "unauthorized"},
+			expected: true,
+		},
+		{
+			name:     "one workflow still running",
+			state:    "created",
+			total:    2,
+			statuses: []string{"success", "running"},
+			expected: false,
+		},
+		{
+			name:     "awaiting approval",
+			state:    "created",
+			total:    1,
+			statuses: []string{"on_hold"},
+			expected: false,
+		},
+		{
+			name:     "failing is not terminal",
+			state:    "created",
+			total:    1,
+			statuses: []string{"failing"},
+			expected: false,
+		},
+		{
+			// The workflow list is final, so a pipeline whose workflows match
+			// nothing is done with. Retrying it every run would be pure waste.
+			name:     "no matched workflows but list is final",
+			state:    "created",
+			total:    3,
+			statuses: nil,
+			expected: true,
+		},
+		{
+			// The window the state gate exists for.
+			name:     "setup succeeded but continuation has not landed",
+			state:    "pending",
+			total:    1,
+			statuses: nil,
+			expected: false,
+		},
+		{
+			name:     "setup workflow still running",
+			state:    "setup",
+			total:    1,
+			statuses: nil,
+			expected: false,
+		},
+		{
+			name:     "setup not started",
+			state:    "setup-pending",
+			total:    0,
+			statuses: nil,
+			expected: false,
+		},
+		{
+			name:     "created with no workflows yet",
+			state:    "created",
+			total:    0,
+			statuses: nil,
+			expected: false,
+		},
+		{
+			// Terminal, so it needs no workflow guard.
+			name:     "errored before any workflow existed",
+			state:    "errored",
+			total:    0,
+			statuses: nil,
+			expected: true,
+		},
+		{
+			name:     "errored after setup failed",
+			state:    "errored",
+			total:    1,
+			statuses: nil,
+			expected: true,
+		},
+		{
+			name:     "errored with a matched workflow still running",
+			state:    "errored",
+			total:    2,
+			statuses: []string{"running"},
+			expected: false,
+		},
+		{
+			name:     "unrecognised status is treated as in progress",
+			state:    "created",
+			total:    1,
+			statuses: []string{""},
+			expected: false,
+		},
+		{
+			name:     "unrecognised state is treated as in progress",
+			state:    "some-new-state",
+			total:    2,
+			statuses: []string{"success"},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pipelineComplete(tt.state, tt.total, tt.statuses); got != tt.expected {
+				t.Errorf("pipelineComplete(%q, %d, %v) = %v, want %v", tt.state, tt.total, tt.statuses, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMergePipelines(t *testing.T) {
+	fetched := []pipelineWork{
+		{pipeline: db.Pipeline{ID: "a"}, state: "created"},
+		{pipeline: db.Pipeline{ID: "b"}, state: "created"},
+	}
+	retries := []pipelineWork{
+		{pipeline: db.Pipeline{ID: "b"}},
+		{pipeline: db.Pipeline{ID: "c"}},
+	}
+
+	got := mergePipelines(fetched, retries)
+
+	var ids []string
+	for _, p := range got {
+		ids = append(ids, p.pipeline.ID)
+	}
+	want := []string{"a", "b", "c"}
+	if !slices.Equal(ids, want) {
+		t.Errorf("mergePipelines() ids = %v, want %v", ids, want)
+	}
+	// The fetched copy wins, so the duplicate keeps its already-current state
+	// instead of forcing a redundant refetch.
+	if got[1].state != "created" {
+		t.Errorf("merged duplicate state = %q, want %q", got[1].state, "created")
+	}
+	// It must still count as a retry, or the pipeline holding the high water
+	// mark loses the protection every run, since it is always listed again.
+	if !got[1].retry {
+		t.Error("a pipeline on the retry list lost its retry flag by also being listed")
+	}
+	if got[0].retry {
+		t.Error("a pipeline only this run has listed was marked as a retry")
+	}
+}
+
+func TestWorkflowStatus(t *testing.T) {
+	if got := workflowStatus(&circleci.Workflow{Status: "success"}); got != "success" {
+		t.Errorf("workflowStatus() = %q, want %q", got, "success")
+	}
+	// The client models status as an untyped field, so a non-string must not
+	// panic and must not be mistaken for a terminal state.
+	if got := workflowStatus(&circleci.Workflow{Status: 42}); got != "" {
+		t.Errorf("workflowStatus() = %q, want empty", got)
 	}
 }


### PR DESCRIPTION
Stacked on #712 — review that first; this diff is only the retry model.

`processPipeline` wrote nothing for a pipeline that still had a workflow running. The
ingest high water mark is `MAX(created_at)` over `pipelines`, and pipelines do not finish
in creation order, so a later pipeline pushed the mark past the skipped one. Those
pipelines were lost permanently.

Unfinished pipelines are now recorded with `complete = FALSE` and reindexed each run until
done, so the mark can advance safely. Only terminal workflows contribute jobs and test
results, so one slow workflow no longer discards the data for the rest of its pipeline.
Newly listed pipelines are claimed as incomplete before indexing starts, so a run that
stops part way does not strand them either.

A pipeline is complete once it will create no more workflows — state `errored`, or
`created` with at least one workflow — and every matched workflow is terminal. The state
check matters because dynamic config generation creates the real workflows through the
continuation request; CircleCI's documented flow holds the pipeline in `setup` or
`pending` until that lands. Those states come from the docs rather than observation.

`FETCH_LIMIT_DAYS` bounds both how long a pipeline stays retryable and how far back a run
reaches, so nothing is claimed that could never be reindexed. A retried pipeline that
cannot be fetched is skipped rather than failing the run. Reindexing never clears a job's
stored test results unless it has new ones to put back, because a spurious not found is
indistinguishable from a job with no tests.

The `complete` column arrives as `00002_pipeline_complete.sql`, applied at startup by the
framework in the base PR. There is no longer a step to run by hand before deploying.

Two things change for anyone querying the data. `pipelines` now holds rows with no `jobs`
children, since a pipeline whose workflows all fall outside `WORKFLOW_PATTERN` is recorded so
the mark can pass it. And `jobs.status` now includes `canceled`, `not_run` and `unauthorized`,
whose workflows previously aborted indexing of the whole pipeline, so a success percentage
needs a `WHERE` clause to stay comparable with older data.

## Testing

`pkg/service/report_test.go` drives `GenerateReport` against fakes for the client's four
interfaces, covering the cycle end to end plus each failure mode this PR addresses. Each
test was checked to fail with its fix removed.

`pkg/db` gains two migration tests against real Postgres: existing rows read as complete
once the column is added, and the baseline stays a no-op now that a second migration
follows it.

`fetchJobs` still cannot paginate, because the client's `ListWorkflowJobs` takes no options
argument — pre-existing and now documented: #710.

