### PR TITLE
fix(op-conductor-ops): relative cert path against config's dir

### DIFF
--- a/op-conductor-ops/op_conductor_ops/config.py
+++ b/op-conductor-ops/op_conductor_ops/config.py
@@ -1,5 +1,6 @@
 from .network import Network
 from .sequencer import Sequencer
+import os
 import toml
 
 
@@ -7,9 +8,11 @@ def read_config(config_path: str) -> tuple[dict[str, Sequencer], str]:
     config = toml.load(config_path)
 
     cert_path = config.get("cert_path", "")
-    # if cert path is relative, pre-pend the config path
-    if not cert_path.startswith("/"):
-        cert_path = f"{config_path.rsplit('/', 1)[0]}/{cert_path}"
+    # Resolve relative cert paths against the config file's directory
+    # (not the config filename itself — bare names like "toss.toml" have no '/').
+    if cert_path and not os.path.isabs(cert_path):
+        config_dir = os.path.dirname(os.path.abspath(config_path))
+        cert_path = os.path.normpath(os.path.join(config_dir, cert_path))
 
     # load sequencers into a map
     sequencers = {}


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

op-conductor-ops currently breaks with --config.

<img width="1123" height="375" alt="image" src="https://github.com/user-attachments/assets/077126d0-81fe-418c-bc2a-8c95cb6c1ce0" />



A clear and concise description of the features you're adding in this pull request.

**Tests**

after this PR

<img width="1419" height="238" alt="image" src="https://github.com/user-attachments/assets/902a1bbe-f70f-4131-a113-f0ebbe05b427" />


Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
