### PR TITLE
chore: update op-txproxy code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,5 @@
 * @ethereum-optimism/infra-reviewers
 
-/op-txproxy @ethereum-optimism/ecosystem
-
 /.github/workflows/     @ethereum-optimism/cloud-security
 /.github/actions/       @ethereum-optimism/cloud-security
 /renovate.json          @ethereum-optimism/cloud-security


### PR DESCRIPTION
## Summary

- Remove the stale Ecosystem ownership override for `op-txproxy`.
- Let the repository-wide `infra-reviewers` ownership rule apply.

## Testing

- `git diff --check`