### PR TITLE
cci-stats: Retry transient CircleCI API failures

### DIFF
--- a/cci-stats/cmd/runner/main.go
+++ b/cci-stats/cmd/runner/main.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/axelKingsley/go-circleci"
+	"github.com/ethereum-optimism/infra/cci-stats/pkg/cci"
 	"github.com/ethereum-optimism/infra/cci-stats/pkg/config"
 	"github.com/ethereum-optimism/infra/cci-stats/pkg/db"
 	"github.com/ethereum-optimism/infra/cci-stats/pkg/service"
@@ -55,11 +55,9 @@ func run() error {
 		SlowTestThresholdSeconds: float64(slowTestThresholdSeconds),
 	}
 
-	clientCfg := circleci.DefaultConfig()
-	clientCfg.Token = cciKey
-	client, err := circleci.NewClient(clientCfg)
+	client, err := cci.NewClient(cciKey)
 	if err != nil {
-		return fmt.Errorf("failed to create circleci client: %w", err)
+		return err
 	}
 
 	errC := make(chan error)

--- a/cci-stats/pkg/cci/client.go
+++ b/cci-stats/pkg/cci/client.go
@@ -1,0 +1,45 @@
+// Package cci builds the CircleCI client this program talks to the API with.
+package cci
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/axelKingsley/go-circleci"
+)
+
+// NewClient returns a CircleCI client that retries transient API failures. It is
+// the only way this program builds a client, so no call site has to remember to
+// ask for the retries.
+func NewClient(token string) (*circleci.Client, error) {
+	return newClient(circleci.DefaultAddress, token)
+}
+
+// Bounds one attempt, so a connection CircleCI accepts but never answers cannot
+// hold the run open: the runner's context has no deadline, and the CronJob
+// forbids concurrent runs, so one hung request stops every later run too.
+//
+// On the transport rather than http.Client.Timeout, which would cover all the
+// attempts together and shrink the budget with each one.
+const responseHeaderTimeout = 30 * time.Second
+
+func newClient(address, token string) (*circleci.Client, error) {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("http.DefaultTransport is a %T, not an *http.Transport", http.DefaultTransport)
+	}
+	transport = transport.Clone()
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
+
+	cfg := circleci.DefaultConfig()
+	cfg.Address = address
+	cfg.Token = token
+	cfg.HTTPClient = &http.Client{Transport: newRetryTransport(transport)}
+
+	client, err := circleci.NewClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create circleci client: %w", err)
+	}
+	return client, nil
+}

--- a/cci-stats/pkg/cci/client_test.go
+++ b/cci-stats/pkg/cci/client_test.go
@@ -1,0 +1,42 @@
+package cci
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestClientRetriesThroughEveryCall covers the wiring rather than the retry
+// logic: any call on the client has to inherit the retries, because a new call
+// site cannot opt into them.
+func TestClientRetriesThroughEveryCall(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`{"message":"An invalid response was received from the upstream server"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"pipeline-id","number":1,"state":"created"}`))
+	}))
+	defer server.Close()
+
+	// Waits out one real backoff, which is the first delay only: sub-second.
+	client, err := newClient(server.URL, "token")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	pipeline, err := client.Pipelines.Get(context.Background(), "pipeline-id")
+	if err != nil {
+		t.Fatalf("call failed despite a retryable status: %v", err)
+	}
+	if pipeline.ID != "pipeline-id" {
+		t.Errorf("pipeline ID = %q, want pipeline-id", pipeline.ID)
+	}
+	if calls != 2 {
+		t.Errorf("server saw %d calls, want 2", calls)
+	}
+}

--- a/cci-stats/pkg/cci/retry.go
+++ b/cci-stats/pkg/cci/retry.go
@@ -1,0 +1,221 @@
+package cci
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"log/slog"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Defaults for an hourly job: CircleCI's 5xx bursts have lasted seconds, and a
+// run of a few minutes still has the rest of the hour spare.
+const (
+	defaultMaxAttempts = 5
+	defaultBaseDelay   = 500 * time.Millisecond
+	defaultMaxDelay    = 15 * time.Second
+	// Past maxDelay, because a Retry-After says when the server will serve the
+	// request. The bound only stops an absurd value stranding the run.
+	defaultMaxRetryAfter = 2 * time.Minute
+)
+
+// Draining a body to the end returns its connection to the pool. CircleCI's
+// error bodies are one JSON message, so the limit only guards against an
+// unexpectedly large one.
+const discardLimit = 64 << 10
+
+// retryTransport retries a request whose failure may not recur.
+//
+// This is the last place that still has the status code: the client turns a
+// failed response into an error carrying only the body's message, so a 502
+// reaches the caller indistinguishable from a permanent failure. Sitting here
+// also covers every call, including any added later.
+type retryTransport struct {
+	next          http.RoundTripper
+	maxAttempts   int
+	baseDelay     time.Duration
+	maxDelay      time.Duration
+	maxRetryAfter time.Duration
+	// Fields so that tests do not wait out real backoff.
+	sleep  func(ctx context.Context, d time.Duration) error
+	jitter func(d time.Duration) time.Duration
+}
+
+func newRetryTransport(next http.RoundTripper) *retryTransport {
+	return &retryTransport{
+		next:          next,
+		maxAttempts:   defaultMaxAttempts,
+		baseDelay:     defaultBaseDelay,
+		maxDelay:      defaultMaxDelay,
+		maxRetryAfter: defaultMaxRetryAfter,
+		sleep:         sleep,
+		jitter:        jitter,
+	}
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	for attempt := 1; ; attempt++ {
+		attemptReq, err := replay(req, attempt)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := t.next.RoundTrip(attemptReq)
+		last := attempt >= t.maxAttempts
+		switch {
+		case err != nil:
+			if last || !retryableErr(ctx, err) || !replayable(req) {
+				return nil, err
+			}
+			slog.Warn("retrying failed CircleCI request",
+				"url", req.URL.Path, "attempt", attempt, "err", err)
+		case !retryableStatus(resp.StatusCode):
+			return resp, nil
+		case last || !replayable(req):
+			// Handed back untouched, for the caller to read the failure off.
+			return resp, nil
+		default:
+			slog.Warn("retrying failed CircleCI request",
+				"url", req.URL.Path, "attempt", attempt, "status", resp.StatusCode)
+		}
+
+		delay := t.backoff(attempt)
+		if resp != nil {
+			delay = t.delayFor(resp, delay)
+			discard(resp)
+		}
+		if err := t.sleep(ctx, delay); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// delayFor waits at least as long as the backoff. A Retry-After on its own can
+// be zero, either because the server said so or because an HTTP-date a few
+// seconds past reads as no wait, which would resend at once and unjittered.
+func (t *retryTransport) delayFor(resp *http.Response, backoff time.Duration) time.Duration {
+	after, ok := retryAfter(resp)
+	if !ok {
+		return backoff
+	}
+	return max(min(after, t.maxRetryAfter), backoff)
+}
+
+func (t *retryTransport) backoff(attempt int) time.Duration {
+	delay := t.baseDelay
+	for range attempt - 1 {
+		delay *= 2
+		if delay >= t.maxDelay {
+			return t.jitter(t.maxDelay)
+		}
+	}
+	return t.jitter(delay)
+}
+
+// retryableStatus reports whether the same request could succeed later. A 4xx
+// describes the request itself, and 404 is routine: a job with no test metadata
+// reports as not found, once per job.
+func retryableStatus(status int) bool {
+	if status == http.StatusTooManyRequests {
+		return true
+	}
+	// 501 is permanent, unlike the rest of 5xx.
+	return status >= 500 && status != http.StatusNotImplemented
+}
+
+func retryableErr(ctx context.Context, err error) bool {
+	// The pipeline pool cancels its siblings as soon as one of them fails.
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Settled answers, so retrying only spends the budget to reach the same one.
+	var dns *net.DNSError
+	if errors.As(err, &dns) && dns.IsNotFound {
+		return false
+	}
+	var cert *tls.CertificateVerificationError
+	return !errors.As(err, &cert)
+}
+
+// replayable reports whether the request can be sent again. A body without
+// GetBody was consumed by the first attempt, so resending it would send nothing.
+// The method matters because a gateway 502 says nothing about whether the origin
+// applied the request: replaying a POST could apply it twice.
+func replayable(req *http.Request) bool {
+	if req.Body != nil && req.Body != http.NoBody && req.GetBody == nil {
+		return false
+	}
+	switch req.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace,
+		http.MethodPut, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+// replay clones the request, which RoundTrip must not modify. The first attempt
+// carries the caller's own body, so the transport underneath closes it as the
+// contract requires; later attempts get a fresh reader.
+func replay(req *http.Request, attempt int) (*http.Request, error) {
+	out := req.Clone(req.Context())
+	if attempt == 1 || req.GetBody == nil {
+		return out, nil
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	out.Body = body
+	return out, nil
+}
+
+// retryAfter reads the Retry-After header in either of its forms. A value in the
+// past reads as no wait rather than a negative one.
+func retryAfter(resp *http.Response) (time.Duration, bool) {
+	val := resp.Header.Get("Retry-After")
+	if val == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(val); err == nil {
+		return max(time.Duration(secs)*time.Second, 0), true
+	}
+	if date, err := http.ParseTime(val); err == nil {
+		return max(time.Until(date), 0), true
+	}
+	slog.Warn("ignoring unreadable Retry-After header", "value", val)
+	return 0, false
+}
+
+// discard drains and closes a response that will not be returned, so its
+// connection goes back to the pool.
+func discard(resp *http.Response) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, discardLimit))
+	_ = resp.Body.Close()
+}
+
+func sleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// jitter spreads concurrent retries over the second half of the window, so the
+// fetch pool does not resend everything at once. The floor keeps a delay from
+// collapsing to near zero.
+func jitter(d time.Duration) time.Duration {
+	return d/2 + rand.N(d/2+1)
+}

--- a/cci-stats/pkg/cci/retry_test.go
+++ b/cci-stats/pkg/cci/retry_test.go
@@ -1,0 +1,529 @@
+package cci
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// attempt is one canned outcome for fakeTransport to return.
+type attempt struct {
+	status  int
+	headers http.Header
+	err     error
+}
+
+type fakeTransport struct {
+	attempts []attempt
+	// closeRequests closes each request body, as the real transport does.
+	closeRequests bool
+	// calls records the request as each attempt saw it.
+	calls  []*http.Request
+	bodies []string
+	closed int
+}
+
+func (f *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.calls = append(f.calls, req)
+
+	body := ""
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		body = string(b)
+		if f.closeRequests {
+			if err := req.Body.Close(); err != nil {
+				return nil, err
+			}
+		}
+	}
+	f.bodies = append(f.bodies, body)
+
+	if len(f.calls) > len(f.attempts) {
+		return nil, fmt.Errorf("unexpected attempt %d", len(f.calls))
+	}
+	a := f.attempts[len(f.calls)-1]
+	if a.err != nil {
+		return nil, a.err
+	}
+
+	headers := a.headers
+	if headers == nil {
+		headers = make(http.Header)
+	}
+	return &http.Response{
+		StatusCode: a.status,
+		Header:     headers,
+		Body:       &countingBody{Reader: strings.NewReader("upstream body"), transport: f},
+	}, nil
+}
+
+// countingReader is a request body that records how often it is closed.
+type countingReader struct {
+	io.Reader
+	closed int
+}
+
+func (c *countingReader) Close() error {
+	c.closed++
+	return nil
+}
+
+type countingBody struct {
+	io.Reader
+	transport *fakeTransport
+}
+
+func (c *countingBody) Close() error {
+	c.transport.closed++
+	return nil
+}
+
+// testTransport wraps next with retries that neither sleep nor jitter, and
+// reports the delays it would have waited.
+func testTransport(next http.RoundTripper) (*retryTransport, *[]time.Duration) {
+	var delays []time.Duration
+	tr := newRetryTransport(next)
+	tr.sleep = func(_ context.Context, d time.Duration) error {
+		delays = append(delays, d)
+		return nil
+	}
+	tr.jitter = func(d time.Duration) time.Duration { return d }
+	return tr, &delays
+}
+
+func newTestRequest(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"https://circleci.com/api/v2/pipeline/abc", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	return req
+}
+
+func TestRetriesServerErrorAndReturnsTheEventualSuccess(t *testing.T) {
+	fake := &fakeTransport{attempts: []attempt{{status: 502}, {status: 503}, {status: 200}}}
+	tr, _ := testTransport(fake)
+
+	resp, err := tr.RoundTrip(newTestRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if len(fake.calls) != 3 {
+		t.Errorf("made %d attempts, want 3", len(fake.calls))
+	}
+}
+
+func TestRetriesRateLimit(t *testing.T) {
+	fake := &fakeTransport{attempts: []attempt{{status: 429}, {status: 200}}}
+	tr, _ := testTransport(fake)
+
+	resp, err := tr.RoundTrip(newTestRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestRetriesTransportError(t *testing.T) {
+	fake := &fakeTransport{attempts: []attempt{{err: errors.New("connection reset by peer")}, {status: 200}}}
+	tr, _ := testTransport(fake)
+
+	resp, err := tr.RoundTrip(newTestRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestDoesNotRetryStatusesTheRequestCannotChange(t *testing.T) {
+	for _, status := range []int{
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusNotImplemented,
+	} {
+		fake := &fakeTransport{attempts: []attempt{{status: status}, {status: 200}}}
+		tr, _ := testTransport(fake)
+
+		resp, err := tr.RoundTrip(newTestRequest(t))
+		if err != nil {
+			t.Fatalf("status %d: unexpected error: %v", status, err)
+		}
+		if resp.StatusCode != status {
+			t.Errorf("status = %d, want %d", resp.StatusCode, status)
+		}
+		if len(fake.calls) != 1 {
+			t.Errorf("status %d: made %d attempts, want 1", status, len(fake.calls))
+		}
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("failed to close body: %v", err)
+		}
+	}
+}
+
+func TestGivesUpOnTheLastResponseSoTheCallerSeesTheRealFailure(t *testing.T) {
+	fake := &fakeTransport{attempts: []attempt{{status: 502}, {status: 502}, {status: 502}}}
+	tr, _ := testTransport(fake)
+	tr.maxAttempts = 3
+
+	resp, err := tr.RoundTrip(newTestRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 502 {
+		t.Errorf("status = %d, want 502", resp.StatusCode)
+	}
+	if len(fake.calls) != 3 {
+		t.Errorf("made %d attempts, want 3", len(fake.calls))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	if string(body) != "upstream body" {
+		t.Errorf("body = %q, want the final response left readable for the client", body)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("failed to close body: %v", err)
+	}
+}
+
+func TestGivesUpOnTheLastTransportError(t *testing.T) {
+	boom := errors.New("connection reset by peer")
+	fake := &fakeTransport{attempts: []attempt{{err: boom}, {err: boom}, {err: boom}}}
+	tr, _ := testTransport(fake)
+	tr.maxAttempts = 3
+
+	resp, err := tr.RoundTrip(newTestRequest(t)) // nolint:bodyclose // asserted nil below
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want the transport error", err)
+	}
+	if resp != nil {
+		t.Errorf("returned both a response and an error")
+	}
+	if len(fake.calls) != 3 {
+		t.Errorf("made %d attempts, want 3", len(fake.calls))
+	}
+}
+
+func TestClosesEveryResponseItDiscards(t *testing.T) {
+	fake := &fakeTransport{attempts: []attempt{{status: 502}, {status: 502}, {status: 200}}}
+	tr, _ := testTransport(fake)
+
+	resp, err := tr.RoundTrip(newTestRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fake.closed != 2 {
+		t.Errorf("closed %d discarded responses, want 2", fake.closed)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("failed to close body: %v", err)
+	}
+}
+
+func TestBacksOffExponentiallyUpToTheCap(t *testing.T) {
+	fake := &fakeTransport{attempts: []attempt{{status: 502}, {status: 502}, {status: 502}, {status: 502}, {status: 200}}}
+	tr, delays := testTransport(fake)
+	tr.maxAttempts = 5
+	tr.baseDelay = 100 * time.Millisecond
+	tr.maxDelay = 300 * time.Millisecond
+
+	resp, err := tr.RoundTrip(newTestRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	want := []time.Duration{
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		300 * time.Millisecond,
+		300 * time.Millisecond,
+	}
+	if !slices.Equal(*delays, want) {
+		t.Errorf("delays = %v, want %v", *delays, want)
+	}
+}
+
+func TestHonoursRetryAfter(t *testing.T) {
+	tests := []struct {
+		name       string
+		retryAfter string
+		want       time.Duration
+	}{
+		{
+			name:       "as asked, past maxDelay",
+			retryAfter: "60",
+			want:       time.Minute,
+		},
+		{
+			name:       "capped when it would strand the run",
+			retryAfter: "3600",
+			want:       2 * time.Minute,
+		},
+		{
+			name:       "ignored when unreadable",
+			retryAfter: "soon",
+			want:       100 * time.Millisecond,
+		},
+		{
+			name:       "floored by the backoff when it asks for no wait",
+			retryAfter: "0",
+			want:       100 * time.Millisecond,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			headers := make(http.Header)
+			headers.Set("Retry-After", test.retryAfter)
+			fake := &fakeTransport{attempts: []attempt{{status: 429, headers: headers}, {status: 200}}}
+			tr, delays := testTransport(fake)
+			tr.baseDelay = 100 * time.Millisecond
+			tr.maxDelay = 15 * time.Second
+
+			resp, err := tr.RoundTrip(newTestRequest(t))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if !slices.Equal(*delays, []time.Duration{test.want}) {
+				t.Errorf("delays = %v, want [%v]", *delays, test.want)
+			}
+		})
+	}
+}
+
+func TestStopsWhenTheContextIsCancelledWhileBackingOff(t *testing.T) {
+	fake := &fakeTransport{attempts: []attempt{{status: 502}, {status: 200}}}
+	tr, _ := testTransport(fake)
+	tr.sleep = func(context.Context, time.Duration) error { return context.Canceled }
+
+	resp, err := tr.RoundTrip(newTestRequest(t)) // nolint:bodyclose // asserted nil below
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if resp != nil {
+		t.Errorf("returned both a response and an error")
+	}
+	if len(fake.calls) != 1 {
+		t.Errorf("made %d attempts, want 1", len(fake.calls))
+	}
+}
+
+func TestDoesNotRetryACancelledRequest(t *testing.T) {
+	fake := &fakeTransport{attempts: []attempt{{err: context.Canceled}, {status: 200}}}
+	tr, _ := testTransport(fake)
+
+	if _, err := tr.RoundTrip(newTestRequest(t)); !errors.Is(err, context.Canceled) { // nolint:bodyclose // no response with an error
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if len(fake.calls) != 1 {
+		t.Errorf("made %d attempts, want 1", len(fake.calls))
+	}
+}
+
+func TestReplaysARequestBody(t *testing.T) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut,
+		"https://circleci.com/api/v2/project/gh/org/repo/settings", strings.NewReader(`{"key":"value"}`))
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	fake := &fakeTransport{attempts: []attempt{{status: 503}, {status: 200}}}
+	tr, _ := testTransport(fake)
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	want := []string{`{"key":"value"}`, `{"key":"value"}`}
+	if !slices.Equal(fake.bodies, want) {
+		t.Errorf("bodies = %q, want %q", fake.bodies, want)
+	}
+}
+
+func TestDoesNotRetryABodyItCannotReplay(t *testing.T) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut,
+		"https://circleci.com/api/v2/project/gh/org/repo/settings", io.NopCloser(strings.NewReader("stream")))
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.GetBody = nil
+
+	fake := &fakeTransport{attempts: []attempt{{status: 503}, {status: 200}}}
+	tr, _ := testTransport(fake)
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 503 {
+		t.Errorf("status = %d, want the unretried 503", resp.StatusCode)
+	}
+	if len(fake.calls) != 1 {
+		t.Errorf("made %d attempts, want 1", len(fake.calls))
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("failed to close body: %v", err)
+	}
+}
+
+func TestDoesNotRetryAMethodThatMayHaveApplied(t *testing.T) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://circleci.com/api/v2/pipeline/abc/continue", strings.NewReader(`{"key":"value"}`))
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	fake := &fakeTransport{attempts: []attempt{{status: 503}, {status: 200}}}
+	tr, _ := testTransport(fake)
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 503 {
+		t.Errorf("status = %d, want the unretried 503", resp.StatusCode)
+	}
+	if len(fake.calls) != 1 {
+		t.Errorf("made %d attempts, want 1", len(fake.calls))
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("failed to close body: %v", err)
+	}
+}
+
+func TestDoesNotRetryASettledTransportError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "a name that does not resolve",
+			err:  &net.DNSError{Err: "no such host", Name: "circleci.invalid", IsNotFound: true},
+		},
+		{
+			name: "a certificate that does not verify",
+			err:  &tls.CertificateVerificationError{Err: errors.New("expired")},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeTransport{attempts: []attempt{{err: test.err}, {status: 200}}}
+			tr, _ := testTransport(fake)
+
+			if _, err := tr.RoundTrip(newTestRequest(t)); !errors.Is(err, test.err) { // nolint:bodyclose // no response with an error
+				t.Fatalf("err = %v, want %v", err, test.err)
+			}
+			if len(fake.calls) != 1 {
+				t.Errorf("made %d attempts, want 1", len(fake.calls))
+			}
+		})
+	}
+
+	// A dropped connection reads as none of the above and is still retried.
+	fake := &fakeTransport{attempts: []attempt{{err: &net.DNSError{Err: "server misbehaving"}}, {status: 200}}}
+	tr, _ := testTransport(fake)
+
+	resp, err := tr.RoundTrip(newTestRequest(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if len(fake.calls) != 2 {
+		t.Errorf("made %d attempts, want 2", len(fake.calls))
+	}
+}
+
+func TestClosesTheCallersBodyOnce(t *testing.T) {
+	// RoundTrip owns the body it is handed, and only the first attempt carries it.
+	body := &countingReader{Reader: strings.NewReader("payload")}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut,
+		"https://circleci.com/api/v2/project/gh/org/repo/settings", body)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("payload")), nil
+	}
+
+	fake := &fakeTransport{attempts: []attempt{{status: 503}, {status: 200}}, closeRequests: true}
+	tr, _ := testTransport(fake)
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if body.closed != 1 {
+		t.Errorf("the caller's body was closed %d times, want 1", body.closed)
+	}
+}
+
+func TestLeavesTheCallersRequestAlone(t *testing.T) {
+	req := newTestRequest(t)
+	fake := &fakeTransport{attempts: []attempt{{status: 502}, {status: 200}}}
+	tr, _ := testTransport(fake)
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	for i, call := range fake.calls {
+		if call == req {
+			t.Errorf("attempt %d was handed the caller's own request", i+1)
+		}
+	}
+}
+
+func TestSleepReturnsTheContextError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := sleep(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestJitterStaysWithinTheWindow(t *testing.T) {
+	for range 100 {
+		got := jitter(time.Second)
+		if got < 500*time.Millisecond || got > time.Second {
+			t.Fatalf("jitter(1s) = %v, want between 500ms and 1s", got)
+		}
+	}
+}


### PR DESCRIPTION
A 5xx from CircleCI fails the whole run: the pipeline pool cancels its siblings on the
first error, so one 502 while listing pipelines costs the rest of the run's work.

Every call now goes through `pkg/cci`, whose transport retries a rate limit, a 5xx or a
failed connection with jittered exponential backoff, honouring `Retry-After`. Settled
failures are not repeated: a 4xx, an unresolvable name, an unverifiable certificate, a
cancelled request, or a method that may already have applied.

The transport is the right place for two reasons. It is the last one that still has the
status code, since the client reports a failed response as its body's message. And every
call inherits it, including any added later.

`ResponseHeaderTimeout` bounds a single attempt. Nothing else did, and the CronJob forbids
concurrent runs, so one hung request would stop every later run too.

Unblocks ethereum-optimism/k8s#12752.