### PR TITLE
circleci-runner-wolfi: Drop redundant protoc

### DIFF
--- a/.github/images.apko.json
+++ b/.github/images.apko.json
@@ -162,7 +162,7 @@
         "melange/pipelines/circleci-runner/**",
         "apko/circleci-runner-wolfi.yaml"
       ],
-      "smoke_test": "mise --version,go version,rustc --version,cargo --version,sccache --version,clang --version,mold --version,protoc --version,cc --version,pkg-config --version,git --version,bash --version"
+      "smoke_test": "mise --version,go version,rustc --version,cargo --version,sccache --version,clang --version,mold --version,cc --version,pkg-config --version,git --version,bash --version"
     }
   }
 }

--- a/apko/circleci-runner-wolfi.yaml
+++ b/apko/circleci-runner-wolfi.yaml
@@ -1,5 +1,5 @@
 # Wolfi/apko CircleCI base image. Ships the clang/libclang toolchain,
-# protobuf toolchain, sccache, and Go/Rust tools used by CI jobs.
+# sccache, and Go/Rust tools used by CI jobs.
 # Unlike a service image this is a base: no single entrypoint, and it provides
 # a non-root `circleci` user (uid 1001) and the shell/coreutils/git exec
 # environment CircleCI jobs assume in place of cimg/base.
@@ -32,8 +32,6 @@ contents:
     - clang-19              # clang + /usr/lib/libclang.so for bindgen (reth-mdbx-sys)
     - libclang-cpp-19       # libclang-cpp runtime
     - mold                  # faster linker used by Rust jobs
-    - protoc                # protobuf-compiler
-    - protobuf-dev          # libprotobuf-dev, including google/protobuf/*.proto
     - sqlite-dev            # libsqlite3-dev
     - tpm2-tss-dev          # libtss2-dev
     - pkgconf               # pkg-config
@@ -90,4 +88,4 @@ entrypoint:
 annotations:
   org.opencontainers.image.source: https://github.com/ethereum-optimism/infra
   org.opencontainers.image.title: circleci-runner-wolfi
-  org.opencontainers.image.description: CircleCI base image with clang, protobuf, sccache, mise, Go, and Rust for Optimism CI jobs
+  org.opencontainers.image.description: CircleCI base image with clang, sccache, mise, Go, and Rust for Optimism CI jobs


### PR DESCRIPTION
Remove `protoc` and `protobuf-dev` from the `circleci-runner-wolfi` apko image.

The Optimism monorepo now pins `protoc` in `mise.toml`, which supplies it for both CI and local builds and bundles the well-known type includes protoc resolves automatically. The image's `protoc`/`protobuf-dev` packages are therefore redundant for the Rust CI jobs that consume this image. No Rust crate links the C++ protobuf library; `protobuf-dev` was only present for the well-known-type includes.

Also drop `protoc --version` from the image's smoke test so the build stays green once the package is gone.

This mirrors ethereum-optimism/optimism#22439, which removed the same packages from the retired `ci-base-clang` docker image.