### PR TITLE
fix(proxyd): evict out-of-order buckets in the sliding window

### DIFF
--- a/proxyd/pkg/avg-sliding-window/sliding.go
+++ b/proxyd/pkg/avg-sliding-window/sliding.go
@@ -147,19 +147,16 @@ func (sw *AvgSlidingWindow) advance() {
 	windowStart := now.Add(-sw.windowLength)
 	keys := sw.buckets.Keys()
 	for _, k := range keys {
+		// buckets is insertion-ordered, not key-ordered, so a newer key can
+		// precede an older one. Skip rather than stop, or stale buckets survive.
 		if k.(time.Time).After(windowStart) {
-			break
+			continue
 		}
 		val, _ := sw.buckets.Get(k)
 		b := val.(*bucket)
 		sw.buckets.Remove(k)
-		if sw.buckets.Size() > 0 {
-			sw.qty -= b.qty
-			sw.sum = sw.sum - b.sum
-		} else {
-			sw.qty = 0
-			sw.sum = 0.0
-		}
+		sw.qty -= b.qty
+		sw.sum -= b.sum
 	}
 }
 

--- a/proxyd/pkg/avg-sliding-window/sliding_test.go
+++ b/proxyd/pkg/avg-sliding-window/sliding_test.go
@@ -306,6 +306,28 @@ func TestSlidingWindow_CustomBucket(t *testing.T) {
 	require.Equal(t, 0, sw.buckets.Size())
 }
 
+func TestSlidingWindow_AdvanceEvictsOutOfOrderBuckets(t *testing.T) {
+	now := ts("2023-04-21 15:04:05")
+	clock := NewAdjustableClock(now)
+
+	// buckets is insertion-ordered, so adding an older data point after a newer
+	// one leaves the keys out of chronological order.
+	sw := NewSlidingWindow(
+		WithWindowLength(10*time.Second),
+		WithBucketSize(time.Second),
+		WithClock(clock))
+	sw.AddWithTime(ts("2023-04-21 15:04:05"), 6)
+	sw.AddWithTime(ts("2023-04-21 15:04:01"), 4)
+	sw.AddWithTime(ts("2023-04-21 15:04:02"), 5)
+
+	// Window start is 15:04:02, so only the 15:04:05 bucket survives.
+	clock.Set(ts("2023-04-21 15:04:12"))
+	require.Equal(t, 6.0, sw.Avg())
+	require.Equal(t, 6.0, sw.Sum())
+	require.Equal(t, 1, int(sw.Count()))
+	require.Equal(t, 1, sw.buckets.Size())
+}
+
 // ts is a convenient method that must parse a time.Time from a string in format `"2006-01-02 15:04:05"`
 func ts(s string) time.Time {
 	t, err := time.Parse(time.DateTime, s)


### PR DESCRIPTION
## Problem

`AvgSlidingWindow.advance()` walks the buckets and stops at the first key inside the window:

```go
keys := sw.buckets.Keys()
for _, k := range keys {
    if k.(time.Time).After(windowStart) {
        break
    }
    ...
}
```

`break` is only safe if `Keys()` comes back in chronological order. It doesn't — `sw.buckets` is a `linkedhashmap`, which preserves **insertion** order, and `AddWithTime` takes an arbitrary timestamp:

```go
func (sw *AvgSlidingWindow) AddWithTime(t time.Time, val float64)
```

So one data point added out of order puts a newer key ahead of older ones, and the loop stops on that newer key without evicting anything behind it. Expired buckets stay in the window and keep contributing to `Avg()`, `Sum()` and `Count()` — the values proxyd uses to compare backend latency and error rates.

## Fix

`continue` past in-window keys instead of stopping at them.

The size-dependent branch in the same loop goes as well:

```go
if sw.buckets.Size() > 0 {
    sw.qty -= b.qty
    sw.sum = sw.sum - b.sum
} else {
    sw.qty = 0
    sw.sum = 0.0
}
```

Zeroing whenever the map happened to empty out double-counts the last bucket's removal — it has already been subtracted from `qty`/`sum` conceptually, and the zeroing then discards any contribution that should have remained. Subtracting unconditionally is correct in both cases: removing every bucket subtracts every contribution, landing on zero on its own.

## Test

`TestSlidingWindow_AdvanceEvictsOutOfOrderBuckets` adds `15:04:05`, then `15:04:01`, then `15:04:02`, so insertion order and time order disagree. It then advances the clock to `15:04:12`, putting the window start at `15:04:02` and leaving only the `15:04:05` bucket alive.

On `main` today it fails:

```
--- FAIL: TestSlidingWindow_AdvanceEvictsOutOfOrderBuckets
    Error:  Not equal:
            expected: 6
            actual  : 5
```

`Avg()` returns 5 because the two expired buckets were never evicted. With the fix the package is green:

```
ok  github.com/ethereum-optimism/infra/proxyd/pkg/avg-sliding-window  0.745s
```

`go build ./...`, `go vet ./pkg/avg-sliding-window/...` and `gofmt -l` are all clean.