### PR TITLE
ci-base-clang: build the orphaned CircleCI Rust base image in infra

### DIFF
--- a/.github/images.json
+++ b/.github/images.json
@@ -10,6 +10,11 @@
       "dockerfile": "Dockerfile",
       "paths": ["bailiff/**"]
     },
+    "ci-base-clang": {
+      "context": "ci-base-clang",
+      "dockerfile": "Dockerfile",
+      "paths": ["ci-base-clang/**"]
+    },
     "cci-stats": {
       "context": ".",
       "dockerfile": "cci-stats/Dockerfile",

--- a/ci-base-clang/Dockerfile
+++ b/ci-base-clang/Dockerfile
@@ -1,0 +1,44 @@
+FROM cimg/base:2026.03
+
+LABEL org.opencontainers.image.title="optimism ci-base clang"
+LABEL org.opencontainers.image.description="CircleCI base image with clang, llvm-dev, libclang-dev, and sccache preinstalled for Rust bindgen and prost/tonic build jobs"
+LABEL org.opencontainers.image.source="https://github.com/ethereum-optimism/optimism"
+
+# Pinned sccache release, preinstalled so Rust CI jobs don't install it per-job.
+# Checksums are the upstream .tar.gz.sha256 sidecars for v0.9.1; the build fails
+# if the downloaded asset does not match (content pin, not just version pin).
+ARG SCCACHE_VERSION=0.9.1
+ARG SCCACHE_SHA256_amd64=911f611db54e48dc50c32232462a99848824be5ba0f6f52cc33903712cd78715
+ARG SCCACHE_SHA256_arm64=a0f10f7daeeecb3439d6e903bc5dc4a4ccee67985b506d3daf742521efe45627
+ARG TARGETARCH
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -o Acquire::Retries=8 update \
+ && apt-get -o Acquire::Retries=8 upgrade -y \
+ && apt-get -o Acquire::Retries=8 install -y --no-install-recommends \
+      clang \
+      llvm-dev \
+      libclang-dev \
+      mold \
+ && apt clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install sccache (statically linked musl build works on glibc cimg/base).
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) ARCH_TAG="x86_64-unknown-linux-musl";  EXPECTED_SHA256="${SCCACHE_SHA256_amd64}" ;; \
+      arm64) ARCH_TAG="aarch64-unknown-linux-musl"; EXPECTED_SHA256="${SCCACHE_SHA256_arm64}" ;; \
+      *) echo "Unsupported TARGETARCH: ${TARGETARCH}"; exit 1 ;; \
+    esac; \
+    ASSET="sccache-v${SCCACHE_VERSION}-${ARCH_TAG}"; \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${ASSET}.tar.gz" -o /tmp/sccache.tgz; \
+    echo "${EXPECTED_SHA256}  /tmp/sccache.tgz" | sha256sum -c -; \
+    tar -xzf /tmp/sccache.tgz -C /tmp; \
+    install "/tmp/${ASSET}/sccache" /usr/local/bin/sccache; \
+    rm -rf /tmp/sccache.tgz "/tmp/${ASSET}"; \
+    sccache --version
+
+USER circleci

--- a/ci-base-clang/Dockerfile
+++ b/ci-base-clang/Dockerfile
@@ -2,7 +2,7 @@ FROM cimg/base:2026.03
 
 LABEL org.opencontainers.image.title="optimism ci-base clang"
 LABEL org.opencontainers.image.description="CircleCI base image with clang, llvm-dev, libclang-dev, and sccache preinstalled for Rust bindgen and prost/tonic build jobs"
-LABEL org.opencontainers.image.source="https://github.com/ethereum-optimism/optimism"
+LABEL org.opencontainers.image.source="https://github.com/ethereum-optimism/infra"
 
 # Pinned sccache release, preinstalled so Rust CI jobs don't install it per-job.
 # Checksums are the upstream .tar.gz.sha256 sidecars for v0.9.1; the build fails


### PR DESCRIPTION
## Summary

The automatic Docker builds were removed from the `optimism` monorepo, so the `ci-base-clang` CircleCI Rust base image no longer builds and can no longer be updated. CI still works only because it is pinned to an already-published digest.

This restores the build here, where a working Dockerfile pipeline already exists (`build-images.yaml` → `factory/actions/plan` → `factory/.github/workflows/docker.yaml`). Keeping the image out of the monorepo also avoids the two-monorepo-PR dance to change it.

## Changes
- Add `ci-base-clang/Dockerfile` (moved verbatim from the monorepo `ops/docker/ci-base-clang/Dockerfile`): `cimg/base` + clang/llvm-dev/libclang-dev/mold and a content-pinned sccache v0.9.1.
- Register it in `.github/images.json` (own context dir, same pattern as `bailiff`).

On merge, the pipeline publishes a multi-arch (amd64+arm64), signed `images/ci-base-clang:<sha>` to the same public registry the monorepo already consumes.

## Follow-up
This is the interim glibc image so the monorepo stays working and updatable. Separately fixing the Wolfi/apko `circleci-runner-wolfi` base image so it can replace this in CI.