### PR TITLE
circleci-runner-wolfi: get it to work

### DIFF
--- a/apko/circleci-runner-wolfi.yaml
+++ b/apko/circleci-runner-wolfi.yaml
@@ -21,6 +21,7 @@ contents:
     - git
     - openssh-client
     - curl
+    - sudo                  # checkout-with-mise orb runs `sudo` to set up /data/mise-data
     # Toolchain (mirrors the Dockerfile apt package set)
     - build-base            # build-essential / gcc toolchain
     - clang-19              # clang + /usr/lib/libclang.so for bindgen (reth-mdbx-sys)

--- a/apko/circleci-runner-wolfi.yaml
+++ b/apko/circleci-runner-wolfi.yaml
@@ -26,6 +26,7 @@ contents:
     - jq                    # cargo metadata | jq in several just recipes
     # Toolchain (mirrors the Dockerfile apt package set)
     - build-base            # build-essential / gcc toolchain
+    - m4                    # gmp-mpfr-sys builds GMP from source via ./configure, needs m4
     - clang-19              # clang + /usr/lib/libclang.so for bindgen (reth-mdbx-sys)
     - libclang-cpp-19       # libclang-cpp runtime
     - mold                  # faster linker used by Rust jobs

--- a/apko/circleci-runner-wolfi.yaml
+++ b/apko/circleci-runner-wolfi.yaml
@@ -22,6 +22,8 @@ contents:
     - openssh-client
     - curl
     - sudo                  # checkout-with-mise orb runs `sudo` to set up /data/mise-data
+    - openssl               # cargo-hack `just hack` shuffle: shuf --random-source=<(openssl ...)
+    - jq                    # cargo metadata | jq in several just recipes
     # Toolchain (mirrors the Dockerfile apt package set)
     - build-base            # build-essential / gcc toolchain
     - clang-19              # clang + /usr/lib/libclang.so for bindgen (reth-mdbx-sys)

--- a/apko/circleci-runner-wolfi.yaml
+++ b/apko/circleci-runner-wolfi.yaml
@@ -24,6 +24,8 @@ contents:
     - sudo                  # checkout-with-mise orb runs `sudo` to set up /data/mise-data
     - openssl               # cargo-hack `just hack` shuffle: shuf --random-source=<(openssl ...)
     - jq                    # cargo metadata | jq in several just recipes
+    - zip                   # build-superchain-go recipe archives configs via `xargs zip`
+    - unzip
     # Toolchain (mirrors the Dockerfile apt package set)
     - build-base            # build-essential / gcc toolchain
     - m4                    # gmp-mpfr-sys builds GMP from source via ./configure, needs m4

--- a/melange/circleci-runner.yaml
+++ b/melange/circleci-runner.yaml
@@ -1,7 +1,7 @@
 package:
   name: circleci-runner
   version: "2026.2.2"
-  epoch: 0
+  epoch: 1
   description: CircleCI runner tooling for Optimism CI jobs
   copyright:
     - license: MIT
@@ -19,5 +19,14 @@ environment:
 
 pipeline:
   - uses: circleci-runner/install
+
+  # cimg/base grants the circleci user passwordless sudo; the checkout-with-mise
+  # orb relies on it (sudo rm/mkdir/chown for /data/mise-data). Reproduce that.
+  - runs: |
+      set -euo pipefail
+      install -d -m 0755 "${{targets.contextdir}}/etc/sudoers.d"
+      printf 'circleci ALL=(ALL) NOPASSWD:ALL\n' \
+        > "${{targets.contextdir}}/etc/sudoers.d/circleci"
+      chmod 0440 "${{targets.contextdir}}/etc/sudoers.d/circleci"
 
   - uses: strip


### PR DESCRIPTION
## Summary

The Wolfi/apko `circleci-runner-wolfi` base image (the intended apko replacement for `ci-base-clang`) fails in CI because the `checkout-with-mise` orb runs `sudo` (rm/mkdir/chown of `/data/mise-data`) to set up the executor's mise data dir. `cimg/base` grants the `circleci` user passwordless sudo; the Wolfi image shipped neither `sudo` nor a sudoers entry, so nearly every Rust job broke.

## Changes
- Add the `sudo` package to `apko/circleci-runner-wolfi.yaml`.
- Install a passwordless sudoers drop-in for the `circleci` user (`/etc/sudoers.d/circleci`, mode 0440) via the `circleci-runner` melange package; bump its epoch.
- Assert `sudo -n true` in the image smoke test.

## Testing
Iterating the resulting image digest through the optimism monorepo's CircleCI Rust jobs.