### PR TITLE
cci-stats: Replace the test_results indexes

### DIFF
--- a/cci-stats/pkg/db/migrate_test.go
+++ b/cci-stats/pkg/db/migrate_test.go
@@ -32,7 +32,7 @@ const gooseTable = "goose_db_version"
 
 // currentSchemaVersion is the highest migration in pkg/db/migrations. Bump it
 // when adding one.
-const currentSchemaVersion = 2
+const currentSchemaVersion = 3
 
 // baselineVersion is the migration that reproduces the hand-applied schema.
 const baselineVersion = 1

--- a/cci-stats/pkg/db/migrations/00003_test_results_indexes.sql
+++ b/cci-stats/pkg/db/migrations/00003_test_results_indexes.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+CREATE INDEX test_results_job_id_status_idx ON test_results (job_id, status);
+
+DROP INDEX test_results_job_id_idx;
+DROP INDEX test_results_status_idx;
+
+-- (job_id, name) is not unique, because CircleCI reports Solidity tests without
+-- the contract that owns them, so there is no natural key to promote here.
+ALTER TABLE test_results
+    DROP CONSTRAINT test_results_pkey;
+
+ALTER TABLE test_results
+    DROP COLUMN id;
+
+-- +goose Down
+-- Restoring id rewrites the table.
+ALTER TABLE test_results
+    ADD COLUMN id SERIAL PRIMARY KEY;
+
+CREATE INDEX test_results_job_id_idx ON test_results (job_id);
+CREATE INDEX test_results_status_idx ON test_results (status);
+
+DROP INDEX test_results_job_id_status_idx;


### PR DESCRIPTION
Dashboard queries reach `test_results` through a set of jobs and then filter by status. The two single-column indexes do not serve that shape: the planner ANDs them into a bitmap and then visits the heap for `name`, so a 14-day query over the table takes 15 to 31 seconds. Forcing job-driven access returns identical rows in 1.3 to 3.4 seconds, and putting status in the index cuts the heap visits down to the matching rows.

`test_results (job_id, status)` replaces both. Its leading column also serves the `DELETE FROM test_results WHERE job_id = $1` that precedes every insert. No `INCLUDE` columns: btree deduplication does not apply to a covering index, and with 74-byte job ids and 45-byte test names that would have cost about 11 GB instead of roughly 1 GB.

The surrogate primary key goes as well: nothing reads `test_results.id`, no foreign key points at it, and writes address rows by `job_id`, so its 1.8 GB index paid for nothing. No natural key can take its place, because CircleCI reports Solidity tests without the contract that owns them and `(job_id, name)` repeats within one job -- `setUp()` appears 95 times in a single job. The table is left without a primary key, which it never needed.

Net effect is one index where there were three, and about 2.4 GB reclaimed.

## Runtime

Expect 5 to 15 minutes, dominated by the index build. A full scan of the 20 GB heap measures 117 seconds, and the sort of 76.5 million keys spills to disk because `maintenance_work_mem` is 64 MB. The other statements are catalogue-only and effectively instant.

The build holds a SHARE lock on `test_results`, which blocks writes but not reads. Migrations run at indexer startup, before it indexes anything, and the indexer is the only writer, so the cost lands on one hourly run: 5 to 15 minutes of migration plus about 12 minutes of indexing stays inside the hour, and `concurrencyPolicy: Forbid` would only skip a run if it overran.

Raising `maintenance_work_mem` for the session with `SET LOCAL` would cut the sort time. I left it out because the instance is small -- `shared_buffers` is 128 MB -- and the one-off cost is affordable.