### PR TITLE
proxyd: Add fixed-cardinality frontend rate-limit metrics

### DIFF
--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -332,6 +332,26 @@ var (
 		Help:      "Count of errors taking frontend rate limits",
 	})
 
+	frontendRateLimitedUniqueKeys = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "frontend_rate_limited_unique_keys",
+		Help: "Distinct rate-limit keys (IPs) with at least one rejected request in the last completed " +
+			"tracking window. Per-instance: summing across replicas may double-count keys that hit more than one replica.",
+	})
+
+	frontendRateLimitTrackerOverflowTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "frontend_rate_limit_tracker_overflow_total",
+		Help:      "Count of rejected requests whose keys were dropped by the rate-limit tracker because its distinct-key cap was reached.",
+	})
+
+	frontendRateLimitedRequestsPerKey = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: MetricsNamespace,
+		Name:      "frontend_rate_limited_requests_per_key",
+		Help:      "Distribution of rejected-request counts per rate-limit key (IP), observed once per key per tracking window.",
+		Buckets:   []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 5000},
+	})
+
 	consensusLatestBlock = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
 		Name:      "group_consensus_latest_block",

--- a/proxyd/rate_limit_tracker.go
+++ b/proxyd/rate_limit_tracker.go
@@ -1,0 +1,68 @@
+package proxyd
+
+import (
+	"sync"
+	"time"
+)
+
+// rateLimitTracker aggregates frontend rate-limit rejections into
+// fixed-cardinality metrics: a gauge of distinct limited keys per window and a
+// histogram of rejected-request counts per key, with no per-IP labels.
+type rateLimitTracker struct {
+	mtx     sync.Mutex
+	limited map[string]int
+	maxKeys int
+
+	done chan struct{}
+	once sync.Once
+}
+
+func newRateLimitTracker(maxKeys int) *rateLimitTracker {
+	return &rateLimitTracker{
+		limited: make(map[string]int),
+		maxKeys: maxKeys,
+		done:    make(chan struct{}),
+	}
+}
+
+func (t *rateLimitTracker) recordLimited(key string) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	if _, ok := t.limited[key]; !ok && len(t.limited) >= t.maxKeys {
+		frontendRateLimitTrackerOverflowTotal.Inc()
+		return
+	}
+	t.limited[key]++
+}
+
+func (t *rateLimitTracker) flush() {
+	t.mtx.Lock()
+	limited := t.limited
+	t.limited = make(map[string]int, len(limited))
+	t.mtx.Unlock()
+
+	frontendRateLimitedUniqueKeys.Set(float64(len(limited)))
+	for _, n := range limited {
+		frontendRateLimitedRequestsPerKey.Observe(float64(n))
+	}
+}
+
+// Start flushes the tracker every interval until Stop is called.
+func (t *rateLimitTracker) Start(interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				t.flush()
+			case <-t.done:
+				return
+			}
+		}
+	}()
+}
+
+func (t *rateLimitTracker) Stop() {
+	t.once.Do(func() { close(t.done) })
+}

--- a/proxyd/rate_limit_tracker.go
+++ b/proxyd/rate_limit_tracker.go
@@ -1,6 +1,7 @@
 package proxyd
 
 import (
+	"hash/fnv"
 	"sync"
 	"time"
 )
@@ -10,7 +11,7 @@ import (
 // histogram of rejected-request counts per key, with no per-IP labels.
 type rateLimitTracker struct {
 	mtx     sync.Mutex
-	limited map[string]int
+	limited map[uint64]int
 	maxKeys int
 
 	done chan struct{}
@@ -19,26 +20,35 @@ type rateLimitTracker struct {
 
 func newRateLimitTracker(maxKeys int) *rateLimitTracker {
 	return &rateLimitTracker{
-		limited: make(map[string]int),
+		limited: make(map[uint64]int),
 		maxKeys: maxKeys,
 		done:    make(chan struct{}),
 	}
 }
 
+// recordLimited counts a rejected request for key. The key is hashed to a
+// fixed-width value before storage so retained memory is bounded by maxKeys
+// alone, independent of the (client-controllable) key length. Keys are only
+// counted, never exported as labels, so hash collisions merely risk a slight
+// undercount of distinct keys.
 func (t *rateLimitTracker) recordLimited(key string) {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	k := h.Sum64()
+
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	if _, ok := t.limited[key]; !ok && len(t.limited) >= t.maxKeys {
+	if _, ok := t.limited[k]; !ok && len(t.limited) >= t.maxKeys {
 		frontendRateLimitTrackerOverflowTotal.Inc()
 		return
 	}
-	t.limited[key]++
+	t.limited[k]++
 }
 
 func (t *rateLimitTracker) flush() {
 	t.mtx.Lock()
 	limited := t.limited
-	t.limited = make(map[string]int, len(limited))
+	t.limited = make(map[uint64]int, len(limited))
 	t.mtx.Unlock()
 
 	frontendRateLimitedUniqueKeys.Set(float64(len(limited)))

--- a/proxyd/rate_limit_tracker_test.go
+++ b/proxyd/rate_limit_tracker_test.go
@@ -1,0 +1,89 @@
+package proxyd
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimitTrackerFlush(t *testing.T) {
+	tr := newRateLimitTracker(50000)
+	tr.recordLimited("1.2.3.4")
+	tr.recordLimited("1.2.3.4")
+	tr.recordLimited("1.2.3.4")
+	tr.recordLimited("5.6.7.8")
+
+	countBefore, sumBefore := gatherHistogram(t, "proxyd_frontend_rate_limited_requests_per_key")
+	tr.flush()
+
+	require.Equal(t, float64(2), gatherGauge(t, "proxyd_frontend_rate_limited_unique_keys"))
+	count, sum := gatherHistogram(t, "proxyd_frontend_rate_limited_requests_per_key")
+	require.Equal(t, countBefore+2, count)
+	require.Equal(t, sumBefore+4, sum)
+}
+
+func TestRateLimitTrackerResetsBetweenWindows(t *testing.T) {
+	tr := newRateLimitTracker(50000)
+	tr.recordLimited("1.2.3.4")
+	tr.flush()
+	require.Equal(t, float64(1), gatherGauge(t, "proxyd_frontend_rate_limited_unique_keys"))
+
+	countBefore, _ := gatherHistogram(t, "proxyd_frontend_rate_limited_requests_per_key")
+	tr.flush()
+
+	require.Equal(t, float64(0), gatherGauge(t, "proxyd_frontend_rate_limited_unique_keys"))
+	count, _ := gatherHistogram(t, "proxyd_frontend_rate_limited_requests_per_key")
+	require.Equal(t, countBefore, count, "an empty window must not add histogram observations")
+}
+
+func TestRateLimitTrackerCapsDistinctKeys(t *testing.T) {
+	overflowBefore := gatherCounter(t, "proxyd_frontend_rate_limit_tracker_overflow_total", nil)
+	tr := newRateLimitTracker(2)
+	tr.recordLimited("a")
+	tr.recordLimited("b")
+	tr.recordLimited("c") // over the cap: dropped, counted as overflow
+	tr.recordLimited("a") // already tracked: still counted past the cap
+
+	countBefore, sumBefore := gatherHistogram(t, "proxyd_frontend_rate_limited_requests_per_key")
+	tr.flush()
+
+	require.Equal(t, float64(2), gatherGauge(t, "proxyd_frontend_rate_limited_unique_keys"))
+	require.Equal(t, overflowBefore+1, gatherCounter(t, "proxyd_frontend_rate_limit_tracker_overflow_total", nil))
+	count, sum := gatherHistogram(t, "proxyd_frontend_rate_limited_requests_per_key")
+	require.Equal(t, countBefore+2, count)
+	require.Equal(t, sumBefore+3, sum, "a=2 and b=1 rejected requests")
+}
+
+// gatherGauge returns the current value of the label-less gauge named `name`,
+// or 0 if it has not been written yet.
+func gatherGauge(t *testing.T, name string) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		require.Len(t, mf.GetMetric(), 1)
+		return mf.GetMetric()[0].GetGauge().GetValue()
+	}
+	return 0
+}
+
+// gatherHistogram returns the sample count and sum of the label-less
+// histogram named `name`, or zeros if it has not been written yet.
+func gatherHistogram(t *testing.T, name string) (float64, float64) {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		require.Len(t, mf.GetMetric(), 1)
+		h := mf.GetMetric()[0].GetHistogram()
+		return float64(h.GetSampleCount()), h.GetSampleSum()
+	}
+	return 0, 0
+}

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -51,6 +51,7 @@ const (
 	maxRequestBodyLogLen                            = 2000
 	defaultMaxUpstreamBatchSize                     = 10
 	defaultRateLimitHeader                          = "X-Forwarded-For"
+	maxRateLimitTrackerKeys                         = 50_000
 	defaultInteropValidationStrategy                = AgreementStrategy
 	defaultInteropReqSizeLimit                      = 128 * opt.KiB
 	defaultInteropAccessListSizeLimit               = 1000
@@ -75,6 +76,7 @@ type Server struct {
 	upgrader                *websocket.Upgrader
 	mainLim                 FrontendRateLimiter
 	overrideLims            map[string]FrontendRateLimiter
+	rateLimitTracker        *rateLimitTracker
 	senderLim               FrontendRateLimiter
 	interopSenderLim        FrontendRateLimiter
 	allowedChainIds         []*big.Int
@@ -209,6 +211,16 @@ func NewServer(
 		rateLimitHeader = rateLimitConfig.IPHeaderOverride
 	}
 
+	var tracker *rateLimitTracker
+	if rateLimitConfig.BaseRate > 0 || len(overrideLims) > 0 {
+		window := time.Duration(rateLimitConfig.BaseInterval)
+		if window <= 0 {
+			window = time.Minute
+		}
+		tracker = newRateLimitTracker(maxRateLimitTrackerKeys)
+		tracker.Start(window)
+	}
+
 	var txValidationMethods TxValidationMethodSet
 	if len(txValidationConfig.Methods) == 0 {
 		txValidationMethods = defaultTxValidationMethods()
@@ -247,6 +259,7 @@ func NewServer(
 		},
 		mainLim:                  mainLim,
 		overrideLims:             overrideLims,
+		rateLimitTracker:         tracker,
 		globallyLimitedMethods:   globalMethodLims,
 		senderLim:                senderLim,
 		interopSenderLim:         interopSenderLim,
@@ -353,6 +366,9 @@ func (s *Server) Shutdown() {
 	}
 	for _, bg := range s.BackendGroups {
 		bg.Shutdown()
+	}
+	if s.rateLimitTracker != nil {
+		s.rateLimitTracker.Stop()
 	}
 }
 
@@ -1130,12 +1146,22 @@ func (s *Server) limiterForRequest(ctx context.Context, r *http.Request, bypassL
 		ok, err := lim.Take(ctx, xff)
 		if err != nil {
 			log.Warn("error taking rate limit", "err", err)
+			s.trackRateLimited(xff)
 			return true
+		}
+		if !ok {
+			s.trackRateLimited(xff)
 		}
 		return !ok
 	}
 
 	return isLimited, nil
+}
+
+func (s *Server) trackRateLimited(key string) {
+	if s.rateLimitTracker != nil {
+		s.rateLimitTracker.recordLimited(key)
+	}
 }
 
 func (s *Server) isGlobalLimit(method string) bool {

--- a/proxyd/server_test.go
+++ b/proxyd/server_test.go
@@ -117,7 +117,10 @@ func TestRateLimitedRequestIsTracked(t *testing.T) {
 	require.Empty(t, s.rateLimitTracker.limited, "allowed requests must not be tracked")
 
 	require.True(t, isLimited(""), "second request is over the limit")
-	require.Equal(t, map[string]int{"203.0.113.9": 1}, s.rateLimitTracker.limited)
+	require.Len(t, s.rateLimitTracker.limited, 1, "one distinct key tracked")
+	for _, n := range s.rateLimitTracker.limited {
+		require.Equal(t, 1, n, "one rejected request recorded for the key")
+	}
 }
 
 func TestRateLimitedRequestWithoutTracker(t *testing.T) {

--- a/proxyd/server_test.go
+++ b/proxyd/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -96,6 +97,42 @@ func TestIsValidAPIKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRateLimitedRequestIsTracked(t *testing.T) {
+	s := &Server{
+		rateLimitHeader:  defaultRateLimitHeader,
+		mainLim:          NewMemoryFrontendRateLimit(time.Minute, 1),
+		rateLimitTracker: newRateLimitTracker(10),
+	}
+	req := httptest.NewRequest("POST", "/", nil)
+	req.Header.Set(defaultRateLimitHeader, "203.0.113.9")
+	ctx := s.populateContext(httptest.NewRecorder(), req)
+	require.NotNil(t, ctx)
+
+	isLimited, err := s.limiterForRequest(ctx, req, false)
+	require.NoError(t, err)
+
+	require.False(t, isLimited(""), "first request is under the limit")
+	require.Empty(t, s.rateLimitTracker.limited, "allowed requests must not be tracked")
+
+	require.True(t, isLimited(""), "second request is over the limit")
+	require.Equal(t, map[string]int{"203.0.113.9": 1}, s.rateLimitTracker.limited)
+}
+
+func TestRateLimitedRequestWithoutTracker(t *testing.T) {
+	s := &Server{
+		rateLimitHeader: defaultRateLimitHeader,
+		mainLim:         NewMemoryFrontendRateLimit(time.Minute, 0),
+	}
+	req := httptest.NewRequest("POST", "/", nil)
+	req.Header.Set(defaultRateLimitHeader, "203.0.113.9")
+	ctx := s.populateContext(httptest.NewRecorder(), req)
+	require.NotNil(t, ctx)
+
+	isLimited, err := s.limiterForRequest(ctx, req, false)
+	require.NoError(t, err)
+	require.True(t, isLimited(""), "a nil tracker must not panic")
 }
 
 func TestPopulateContextRemoteAddrFallback(t *testing.T) {


### PR DESCRIPTION
## Description

proxyd counts rate-limited *requests* (`rpc_errors_total{error_code="-32016"}`) but has no signal for how many distinct *addresses* are being limited or how rejections are distributed across them. Getting that today requires debug-level logs or scanning Redis by hand.

This adds a small in-process tracker that aggregates frontend rate-limit rejections into fixed-cardinality metrics — no per-IP labels:

- **`proxyd_frontend_rate_limited_unique_keys`** (gauge, single series): distinct rate-limit keys (IPs) with at least one rejected request in the last completed tracking window. Per-instance; help text notes that summing across replicas may double-count keys that hit more than one pod.
- **`proxyd_frontend_rate_limited_requests_per_key`** (histogram, buckets 1–5000): one observation per limited key per window, valued at its rejected-request count. Answers "one whale or a thousand small abusers" via `histogram_quantile` / bucket ratios.
- **`proxyd_frontend_rate_limit_tracker_overflow_total`** (counter): rejections whose keys were dropped by the tracker's 50k distinct-key cap, which bounds memory against spoofed-XFF floods (already-tracked keys keep counting past the cap).

## Implementation

- New `rateLimitTracker` (`rate_limit_tracker.go`): mutex-guarded `map[key]count`, flushed by a ticker every `rate_limit.base_interval` (1m fallback when only method overrides are configured). Flush sets the gauge, observes the histogram per key, and resets the map.
- Single hook in the `isLimited` closure in `server.go`, so it covers the base limit, per-method override limits, and the treat-as-limited path when a Redis `Take` errors.
- Created in `NewServer` only when frontend rate limiting is configured; stopped in `Shutdown`. Nil tracker is a safe no-op.

## Testing

- Unit tests for the tracker: flush gauge/histogram values, window reset, cap + overflow counter behavior.
- Server tests: a rejected request is recorded under its XFF key, allowed requests are not recorded, and a nil tracker does not panic.
- `go build ./...`, `go vet ./...`, and the full proxyd suite (unit + integration) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)