### PR TITLE
feat(proxyd): passive transaction UX monitor (tx_monitor)

### DIFF
--- a/proxyd/CHANGELOG.md
+++ b/proxyd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/proxyd
 
+## Unreleased
+
+### Minor Changes
+
+- Added passive tx-UX monitor (`[tx_monitor]`): inclusion-latency histograms from forwarded `eth_sendRawTransaction` to block/subblock visibility.
+
 ## 3.14.1
 
 ### Patch Changes

--- a/proxyd/README.md
+++ b/proxyd/README.md
@@ -147,6 +147,18 @@ Response example
 See [op-node receipt fetcher](https://github.com/ethereum-optimism/optimism/blob/186e46a47647a51a658e699e9ff047d39444c2de/op-node/sources/receipts.go#L186-L253).
 
 
+## Transaction UX monitor (`tx_monitor`)
+
+When `[tx_monitor]` is enabled, proxyd passively measures the latency from a
+successfully forwarded `eth_sendRawTransaction` until the transaction becomes
+visible in a block (and, optionally, in a subblocks preconfirmation stream),
+reporting the results as `proxyd_txmon_*` metrics. The monitor is purely
+observational: observations are non-blocking and never affect request
+handling, and its state is in-memory and shared-nothing across replicas —
+each proxyd instance only tracks the transactions it forwarded itself.
+Setting `subblocks_ws_url` additionally measures preconfirmation latency from
+a sequencer's subblocks websocket stream.
+
 ## Metrics
 
 See `metrics.go` for a list of all available metrics.

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -256,6 +256,30 @@ type SenderRateLimitConfig struct {
 	AllowedChainIds []*big.Int `toml:"allowed_chain_ids"`
 }
 
+// TxMonitorConfig configures the passive transaction-UX monitor: it observes
+// successfully forwarded eth_sendRawTransaction hashes and measures latency
+// until they appear in a block (and, optionally, in the subblocks stream).
+// Purely observational — never blocks or affects tx ingestion.
+type TxMonitorConfig struct {
+	Enabled bool `toml:"enabled"`
+	// BlockPollURL is an explicit RPC endpoint for block polling. When empty,
+	// the monitor polls through a proxyd backend group instead (see
+	// BlockPollBackendGroup).
+	BlockPollURL string `toml:"block_poll_url"`
+	// BlockPollBackendGroup names the backend group to poll blocks from when
+	// BlockPollURL is empty. Defaults to the group mapped for
+	// eth_getBlockByNumber, falling back to eth_sendRawTransaction's group.
+	BlockPollBackendGroup string `toml:"block_poll_backend_group"`
+	// SubblocksWSURL enables the subblocks preconfirmation watcher when set.
+	SubblocksWSURL string `toml:"subblocks_ws_url"`
+	// InclusionTimeout evicts pending txs and counts a timeout. Default 60s.
+	InclusionTimeout TOMLDuration `toml:"inclusion_timeout"`
+	// MaxPending caps the in-memory pending map. Default 10000.
+	MaxPending int `toml:"max_pending"`
+	// PollInterval is the block poll cadence. Default 1s.
+	PollInterval TOMLDuration `toml:"poll_interval"`
+}
+
 type Config struct {
 	WSBackendGroup               string                       `toml:"ws_backend_group"`
 	Server                       ServerConfig                 `toml:"server"`
@@ -274,6 +298,7 @@ type Config struct {
 	SenderRateLimit              SenderRateLimitConfig        `toml:"sender_rate_limit"`
 	InteropValidationConfig      InteropValidationConfig      `toml:"interop_validation"`
 	TxValidationMiddlewareConfig TxValidationMiddlewareConfig `toml:"tx_validation_middleware"`
+	TxMonitor                    TxMonitorConfig              `toml:"tx_monitor"`
 }
 
 type InteropValidationConfig struct {

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -155,3 +155,25 @@ timeout_seconds = 5
 # Defaults to true (fail-open) for safety - service disruptions won't block all transactions.
 # Set to false to reject transactions when the validation service is unavailable.
 fail_open = true
+
+# Passive transaction-UX monitor: observes successfully forwarded
+# eth_sendRawTransaction hashes and measures latency until they appear in a
+# block (and, optionally, in the subblocks stream). Purely observational —
+# never blocks or affects tx ingestion. Emits proxyd_txmon_* metrics.
+# [tx_monitor]
+# enabled = true
+# Explicit RPC endpoint for block polling. When empty, the monitor polls
+# through a proxyd backend group instead (see block_poll_backend_group).
+# block_poll_url = "http://my-node:8545"
+# Backend group to poll blocks from when block_poll_url is empty. Defaults to
+# the group mapped for eth_getBlockByNumber, falling back to
+# eth_sendRawTransaction's group.
+# block_poll_backend_group = "main"
+# Enables the subblocks preconfirmation watcher when set.
+# subblocks_ws_url = "ws://my-sequencer:9545/ws"
+# Evicts pending txs and counts a timeout, default 60s
+# inclusion_timeout = "60s"
+# Cap on the in-memory pending map, default 10000
+# max_pending = 10000
+# Block poll cadence, default 1s
+# poll_interval = "1s"

--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-libp2p v0.36.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -728,7 +728,7 @@ var (
 		"backend_name",
 	})
 
-	txmonInclusionBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 10, 20, 30}
+	txmonInclusionBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 10, 20, 30, 45, 60}
 
 	txmonInclusionLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: MetricsNamespace,
@@ -762,6 +762,11 @@ var (
 	}, []string{
 		"reason", // channel_full | map_full
 	})
+
+	// Pre-bound so the hot-path drop branch stays lock-free (WithLabelValues
+	// takes a lock resolving the label set on every call).
+	txmonDroppedChannelFull = txmonDroppedEventsTotal.WithLabelValues("channel_full")
+	txmonDroppedMapFull     = txmonDroppedEventsTotal.WithLabelValues("map_full")
 
 	txmonPending = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -727,6 +727,53 @@ var (
 	}, []string{
 		"backend_name",
 	})
+
+	txmonInclusionBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 10, 20, 30}
+
+	txmonInclusionLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: MetricsNamespace,
+		Name:      "txmon_inclusion_latency_seconds",
+		Help:      "Latency from successful eth_sendRawTransaction forward to first sighting, by source (block or subblock stream).",
+		Buckets:   txmonInclusionBuckets,
+	}, []string{
+		"source", // block | subblock
+		"backend_group",
+	})
+
+	txmonSubblockToBlock = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: MetricsNamespace,
+		Name:      "txmon_subblock_to_block_seconds",
+		Help:      "Gap between a tx's subblock preconfirmation and its block inclusion (eventual consistency of the user experience).",
+		Buckets:   txmonInclusionBuckets,
+	})
+
+	txmonTimeoutsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "txmon_timeouts_total",
+		Help:      "Count of forwarded txs never seen in a block within inclusion_timeout.",
+	}, []string{
+		"backend_group",
+	})
+
+	txmonDroppedEventsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "txmon_dropped_events_total",
+		Help:      "Count of tx observations dropped by the monitor (never blocks ingestion).",
+	}, []string{
+		"reason", // channel_full | map_full
+	})
+
+	txmonPending = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "txmon_pending",
+		Help:      "Number of txs currently awaiting block inclusion.",
+	})
+
+	txmonStreamDisconnectsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "txmon_stream_disconnects_total",
+		Help:      "Count of subblocks websocket stream disconnects.",
+	})
 )
 
 func RecordUp() {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -544,6 +544,19 @@ func Start(config *Config) (*Server, func(), error) {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)
 	}
 
+	// Construct and assign the monitor before any listener goroutine spawns so
+	// the hot path's s.txMonitor read is never concurrent with the write.
+	// Start() happens after the consensus loop below: events observed in the
+	// window queue in the buffered channel and drain once ingest starts.
+	var txMonitor *TxMonitor
+	if config.TxMonitor.Enabled {
+		txMonitor, err = NewTxMonitor(config.TxMonitor, backendGroups, config.RPCMethodMappings)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error creating tx monitor: %w", err)
+		}
+		srv.txMonitor = txMonitor
+	}
+
 	// Enable to support browser websocket connections.
 	// See https://pkg.go.dev/github.com/gorilla/websocket#hdr-Origin_Considerations
 	if config.Server.AllowAllOrigins {
@@ -697,13 +710,7 @@ func Start(config *Config) (*Server, func(), error) {
 		}
 	}
 
-	var txMonitor *TxMonitor
-	if config.TxMonitor.Enabled {
-		txMonitor, err = NewTxMonitor(config.TxMonitor, backendGroups, config.RPCMethodMappings)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error creating tx monitor: %w", err)
-		}
-		srv.txMonitor = txMonitor
+	if txMonitor != nil {
 		txMonitor.Start()
 	}
 

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -544,6 +544,16 @@ func Start(config *Config) (*Server, func(), error) {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)
 	}
 
+	var txMonitor *TxMonitor
+	if config.TxMonitor.Enabled {
+		txMonitor, err = NewTxMonitor(config.TxMonitor, backendGroups, config.RPCMethodMappings)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error creating tx monitor: %w", err)
+		}
+		srv.txMonitor = txMonitor
+		txMonitor.Start()
+	}
+
 	// Enable to support browser websocket connections.
 	// See https://pkg.go.dev/github.com/gorilla/websocket#hdr-Origin_Considerations
 	if config.Server.AllowAllOrigins {
@@ -711,6 +721,10 @@ func Start(config *Config) (*Server, func(), error) {
 		}
 		log.Info("shutting down proxyd")
 		srv.Shutdown()
+		if txMonitor != nil {
+			log.Info("stopping tx monitor")
+			txMonitor.Shutdown()
+		}
 		log.Info("goodbye")
 	}
 

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -544,16 +544,6 @@ func Start(config *Config) (*Server, func(), error) {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)
 	}
 
-	var txMonitor *TxMonitor
-	if config.TxMonitor.Enabled {
-		txMonitor, err = NewTxMonitor(config.TxMonitor, backendGroups, config.RPCMethodMappings)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error creating tx monitor: %w", err)
-		}
-		srv.txMonitor = txMonitor
-		txMonitor.Start()
-	}
-
 	// Enable to support browser websocket connections.
 	// See https://pkg.go.dev/github.com/gorilla/websocket#hdr-Origin_Considerations
 	if config.Server.AllowAllOrigins {
@@ -705,6 +695,16 @@ func Start(config *Config) (*Server, func(), error) {
 				tracker.(*RedisConsensusTracker).Init()
 			}
 		}
+	}
+
+	var txMonitor *TxMonitor
+	if config.TxMonitor.Enabled {
+		txMonitor, err = NewTxMonitor(config.TxMonitor, backendGroups, config.RPCMethodMappings)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error creating tx monitor: %w", err)
+		}
+		srv.txMonitor = txMonitor
+		txMonitor.Start()
 	}
 
 	<-errTimer.C

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -102,6 +102,7 @@ type Server struct {
 	txValidationClient       *TxValidationClient
 	txValidationFailOpen     bool
 	txFilter                 *TxFilter
+	txMonitor                *TxMonitor
 	isDraining               atomic.Bool
 	gracefulShutdownDuration time.Duration
 }
@@ -843,6 +844,18 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				}
 			}
 
+			// Feed the tx-UX monitor. Non-blocking by construction (Observe is a
+			// select/default channel send); per-element RPC errors are skipped —
+			// a tx the backend rejected will never land and would only count as
+			// a false timeout.
+			if err == nil && s.txMonitor != nil {
+				for i, elem := range elems {
+					if txHash, ok := txHashes[elem.Index]; ok && i < len(res) && res[i] != nil && !res[i].IsError() {
+						s.txMonitor.Observe(txHash, group.backendGroup, RPCRequestSourceHTTP)
+					}
+				}
+			}
+
 			// sb is "" when the forward failed outright, and also when consensus or
 			// block-tag rewriting overrode every element so no backend was contacted at
 			// all (BackendGroup.ForwardWithSource). backendNameFromServedBy resolves
@@ -1014,6 +1027,10 @@ func (s *Server) handleWSRPCInner(ctx context.Context, req *RPCReq, isLimited li
 			"duration_ms", forwardDuration.Milliseconds(),
 			"source", RPCRequestSourceWS,
 		)
+	}
+
+	if txHash != nil && s.txMonitor != nil && !res[0].IsError() {
+		s.txMonitor.Observe(*txHash, group, RPCRequestSourceWS)
 	}
 
 	return res[0], servedBy

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -1029,7 +1029,7 @@ func (s *Server) handleWSRPCInner(ctx context.Context, req *RPCReq, isLimited li
 		)
 	}
 
-	if txHash != nil && s.txMonitor != nil && !res[0].IsError() {
+	if txHash != nil && s.txMonitor != nil && res[0] != nil && !res[0].IsError() {
 		s.txMonitor.Observe(*txHash, group, RPCRequestSourceWS)
 	}
 

--- a/proxyd/tx_monitor.go
+++ b/proxyd/tx_monitor.go
@@ -19,6 +19,9 @@ const (
 	txmonReapInterval = 5 * time.Second
 	txmonFetchTimeout = 10 * time.Second
 	txmonMaxBackoff   = 30 * time.Second
+	// txmonMaxFrameBytes caps websocket frame size on the subblocks stream;
+	// gorilla defaults to unlimited, and the stream is untrusted input.
+	txmonMaxFrameBytes = 10 << 20
 )
 
 type txmonEvent struct {
@@ -232,6 +235,7 @@ func (m *TxMonitor) streamSubblocks() error {
 		return err
 	}
 	defer conn.Close()
+	conn.SetReadLimit(txmonMaxFrameBytes)
 
 	// Unblock the blocking ReadMessage on shutdown without leaking a
 	// goroutine per reconnect.

--- a/proxyd/tx_monitor.go
+++ b/proxyd/tx_monitor.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -48,6 +49,17 @@ type TxMonitor struct {
 }
 
 func NewTxMonitor(cfg TxMonitorConfig, backendGroups map[string]*BackendGroup, rpcMethodMappings map[string]string) (*TxMonitor, error) {
+	// Zero means default; negative values would panic time.NewTicker or make
+	// the reaper cutoff nonsensical, so fail fast at startup.
+	if cfg.PollInterval < 0 {
+		return nil, fmt.Errorf("tx_monitor: poll_interval must not be negative, got %s", time.Duration(cfg.PollInterval))
+	}
+	if cfg.InclusionTimeout < 0 {
+		return nil, fmt.Errorf("tx_monitor: inclusion_timeout must not be negative, got %s", time.Duration(cfg.InclusionTimeout))
+	}
+	if cfg.MaxPending < 0 {
+		return nil, fmt.Errorf("tx_monitor: max_pending must not be negative, got %d", cfg.MaxPending)
+	}
 	if cfg.PollInterval == 0 {
 		cfg.PollInterval = TOMLDuration(time.Second)
 	}
@@ -111,6 +123,9 @@ func (m *TxMonitor) Start() {
 func (m *TxMonitor) Shutdown() {
 	m.cancel()
 	m.wg.Wait()
+	if c, ok := m.fetcher.(io.Closer); ok {
+		c.Close()
+	}
 }
 
 // Observe records a successfully forwarded tx. Non-blocking by construction:
@@ -120,7 +135,7 @@ func (m *TxMonitor) Observe(hash common.Hash, backendGroup string, source string
 	select {
 	case m.events <- txmonEvent{hash: hash, backendGroup: backendGroup, source: source, at: m.now()}:
 	default:
-		txmonDroppedEventsTotal.WithLabelValues("channel_full").Inc()
+		txmonDroppedChannelFull.Inc()
 	}
 }
 
@@ -138,7 +153,7 @@ func (m *TxMonitor) runIngest() {
 				IngestedAt:   ev.at,
 			})
 			if !ok {
-				txmonDroppedEventsTotal.WithLabelValues("map_full").Inc()
+				txmonDroppedMapFull.Inc()
 			}
 		}
 	}
@@ -175,10 +190,15 @@ func (m *TxMonitor) pollOnce() {
 		if num-start > txmonMaxBlockWalk {
 			start = num - txmonMaxBlockWalk
 		}
+		// Advance the cursor only over successfully processed heights: a failed
+		// or not-yet-found gap height leaves lastBlock behind it so the
+		// remaining heights (and the tip) are retried next tick.
 		for h := start; h < num; h++ {
 			gapHashes, found, err := m.fetcher.BlockByNumber(ctx, h)
 			if err != nil || !found {
-				continue
+				log.Debug("tx_monitor: gap block fetch failed, retrying next tick", "height", h, "found", found, "err", err)
+				m.lastBlock = h - 1
+				return
 			}
 			m.handleBlock(gapHashes, m.now())
 		}

--- a/proxyd/tx_monitor.go
+++ b/proxyd/tx_monitor.go
@@ -1,0 +1,282 @@
+package proxyd
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	txmonEventBuffer = 1024
+	// txmonMaxBlockWalk caps how many missed heights one poll will backfill,
+	// bounding catch-up load after an outage. Anything older times out.
+	txmonMaxBlockWalk = 32
+	txmonReapInterval = 5 * time.Second
+	txmonFetchTimeout = 10 * time.Second
+	txmonMaxBackoff   = 30 * time.Second
+)
+
+type txmonEvent struct {
+	hash         common.Hash
+	backendGroup string
+	source       string
+	at           time.Time
+}
+
+// TxMonitor passively measures user tx inclusion latency. It is fed by
+// Observe (non-blocking) from the request hot path and runs its own
+// block-poll, subblocks-stream, and reaper goroutines. Never critical:
+// every failure mode degrades to missing metrics, not degraded ingestion.
+type TxMonitor struct {
+	cfg       TxMonitorConfig
+	events    chan txmonEvent
+	store     PendingStore
+	fetcher   blockFetcher
+	now       func() time.Time
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	lastBlock uint64
+}
+
+func NewTxMonitor(cfg TxMonitorConfig, backendGroups map[string]*BackendGroup, rpcMethodMappings map[string]string) (*TxMonitor, error) {
+	if cfg.PollInterval == 0 {
+		cfg.PollInterval = TOMLDuration(time.Second)
+	}
+	if cfg.InclusionTimeout == 0 {
+		cfg.InclusionTimeout = TOMLDuration(60 * time.Second)
+	}
+	if cfg.MaxPending == 0 {
+		cfg.MaxPending = 10000
+	}
+
+	var fetcher blockFetcher
+	if cfg.BlockPollURL != "" {
+		f, err := newRPCBlockFetcher(cfg.BlockPollURL)
+		if err != nil {
+			return nil, err
+		}
+		fetcher = f
+	} else {
+		groupName := cfg.BlockPollBackendGroup
+		if groupName == "" {
+			groupName = rpcMethodMappings["eth_getBlockByNumber"]
+		}
+		if groupName == "" {
+			groupName = rpcMethodMappings["eth_sendRawTransaction"]
+		}
+		bg, ok := backendGroups[groupName]
+		if !ok {
+			return nil, fmt.Errorf("tx_monitor: cannot resolve block poll backend group %q; set block_poll_backend_group or block_poll_url", groupName)
+		}
+		fetcher = newBackendGroupBlockFetcher(bg)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &TxMonitor{
+		cfg:     cfg,
+		events:  make(chan txmonEvent, txmonEventBuffer),
+		store:   NewMemoryPendingStore(cfg.MaxPending),
+		fetcher: fetcher,
+		now:     time.Now,
+		ctx:     ctx,
+		cancel:  cancel,
+	}, nil
+}
+
+func (m *TxMonitor) Start() {
+	m.wg.Add(3)
+	go m.runIngest()
+	go m.runBlockWatch()
+	go m.runReaper()
+	if m.cfg.SubblocksWSURL != "" {
+		m.wg.Add(1)
+		go m.runSubblocks()
+	}
+	log.Info("tx_monitor started",
+		"subblocks", m.cfg.SubblocksWSURL != "",
+		"poll_interval", time.Duration(m.cfg.PollInterval),
+		"inclusion_timeout", time.Duration(m.cfg.InclusionTimeout),
+	)
+}
+
+func (m *TxMonitor) Shutdown() {
+	m.cancel()
+	m.wg.Wait()
+}
+
+// Observe records a successfully forwarded tx. Non-blocking by construction:
+// a full channel drops the observation and counts it. This is the ONLY method
+// called from the request hot path.
+func (m *TxMonitor) Observe(hash common.Hash, backendGroup string, source string) {
+	select {
+	case m.events <- txmonEvent{hash: hash, backendGroup: backendGroup, source: source, at: m.now()}:
+	default:
+		txmonDroppedEventsTotal.WithLabelValues("channel_full").Inc()
+	}
+}
+
+func (m *TxMonitor) runIngest() {
+	defer m.wg.Done()
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case ev := <-m.events:
+			ok := m.store.Add(txmonEntry{
+				Hash:         ev.hash,
+				BackendGroup: ev.backendGroup,
+				Source:       ev.source,
+				IngestedAt:   ev.at,
+			})
+			if !ok {
+				txmonDroppedEventsTotal.WithLabelValues("map_full").Inc()
+			}
+		}
+	}
+}
+
+func (m *TxMonitor) runBlockWatch() {
+	defer m.wg.Done()
+	ticker := time.NewTicker(time.Duration(m.cfg.PollInterval))
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.pollOnce()
+		}
+	}
+}
+
+func (m *TxMonitor) pollOnce() {
+	ctx, cancel := context.WithTimeout(m.ctx, txmonFetchTimeout)
+	defer cancel()
+
+	num, hashes, err := m.fetcher.LatestBlock(ctx)
+	if err != nil {
+		log.Debug("tx_monitor: block poll failed", "err", err)
+		return
+	}
+	if m.lastBlock != 0 && num <= m.lastBlock {
+		return // no new block (or a reorg to a lower height — v1 ignores reorgs)
+	}
+	if m.lastBlock != 0 {
+		start := m.lastBlock + 1
+		if num-start > txmonMaxBlockWalk {
+			start = num - txmonMaxBlockWalk
+		}
+		for h := start; h < num; h++ {
+			gapHashes, found, err := m.fetcher.BlockByNumber(ctx, h)
+			if err != nil || !found {
+				continue
+			}
+			m.handleBlock(gapHashes, m.now())
+		}
+	}
+	m.handleBlock(hashes, m.now())
+	m.lastBlock = num
+}
+
+func (m *TxMonitor) handleBlock(hashes []common.Hash, at time.Time) {
+	for _, e := range m.store.MatchAndRemove(hashes) {
+		txmonInclusionLatency.WithLabelValues("block", e.BackendGroup).Observe(at.Sub(e.IngestedAt).Seconds())
+		if !e.SubblockAt.IsZero() {
+			txmonSubblockToBlock.Observe(at.Sub(e.SubblockAt).Seconds())
+		}
+	}
+}
+
+func (m *TxMonitor) handleSubblockHashes(hashes []common.Hash, at time.Time) {
+	for _, h := range hashes {
+		if e, ok := m.store.MarkSubblock(h, at); ok {
+			txmonInclusionLatency.WithLabelValues("subblock", e.BackendGroup).Observe(at.Sub(e.IngestedAt).Seconds())
+		}
+	}
+}
+
+func (m *TxMonitor) runSubblocks() {
+	defer m.wg.Done()
+	backoff := time.Second
+	for m.ctx.Err() == nil {
+		connectedAt := m.now()
+		err := m.streamSubblocks()
+		if m.ctx.Err() != nil {
+			return
+		}
+		txmonStreamDisconnectsTotal.Inc()
+		if m.now().Sub(connectedAt) > time.Minute {
+			backoff = time.Second // healthy connection: reset backoff
+		}
+		log.Warn("tx_monitor: subblocks stream disconnected", "err", err, "retry_in", backoff)
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < txmonMaxBackoff {
+			backoff *= 2
+		}
+	}
+}
+
+func (m *TxMonitor) streamSubblocks() error {
+	conn, _, err := websocket.DefaultDialer.DialContext(m.ctx, m.cfg.SubblocksWSURL, nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	// Unblock the blocking ReadMessage on shutdown without leaking a
+	// goroutine per reconnect.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-m.ctx.Done():
+			conn.Close()
+		case <-done:
+		}
+	}()
+
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			return err
+		}
+		hashes, err := parseSubblockTxHashes(msg)
+		if err != nil {
+			log.Debug("tx_monitor: malformed subblock frame", "err", err)
+			continue
+		}
+		m.handleSubblockHashes(hashes, m.now())
+	}
+}
+
+func (m *TxMonitor) runReaper() {
+	defer m.wg.Done()
+	ticker := time.NewTicker(txmonReapInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.reapOnce()
+		}
+	}
+}
+
+func (m *TxMonitor) reapOnce() {
+	cutoff := m.now().Add(-time.Duration(m.cfg.InclusionTimeout))
+	for _, e := range m.store.ExpireBefore(cutoff) {
+		txmonTimeoutsTotal.WithLabelValues(e.BackendGroup).Inc()
+	}
+	txmonPending.Set(float64(m.store.Len()))
+}

--- a/proxyd/tx_monitor.go
+++ b/proxyd/tx_monitor.go
@@ -230,7 +230,12 @@ func (m *TxMonitor) runSubblocks() {
 }
 
 func (m *TxMonitor) streamSubblocks() error {
-	conn, _, err := websocket.DefaultDialer.DialContext(m.ctx, m.cfg.SubblocksWSURL, nil)
+	conn, resp, err := websocket.DefaultDialer.DialContext(m.ctx, m.cfg.SubblocksWSURL, nil)
+	// On a successful upgrade gorilla replaces the body with a no-op reader,
+	// so closing is always safe; on handshake failure it's the error body.
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/proxyd/tx_monitor_blocks.go
+++ b/proxyd/tx_monitor_blocks.go
@@ -2,6 +2,7 @@ package proxyd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -85,32 +86,37 @@ func (f *backendGroupBlockFetcher) BlockByNumber(ctx context.Context, num uint64
 	return hashes, found, err
 }
 
-// fetch tries each backend in the group until one answers. First-success is
-// enough: this is a monitor, not a consensus mechanism.
+// fetch routes the poll through the group's Forward, so consensus-aware
+// groups serve the consensus view and routing/failover matches user traffic.
 func (f *backendGroupBlockFetcher) fetch(ctx context.Context, tag string) (uint64, []common.Hash, bool, error) {
-	var lastErr error
-	for _, be := range f.bg.Backends {
-		var res RPCRes
-		// ForwardRPC embeds the id verbatim as JSON, so it must be a valid
-		// JSON value — hence the quoted string.
-		if err := be.ForwardRPC(ctx, &res, `"txmon"`, "eth_getBlockByNumber", tag, false); err != nil {
-			lastErr = err
-			continue
-		}
-		if res.Result == nil {
-			return 0, nil, false, nil // block genuinely absent (walked past head)
-		}
-		num, hashes, err := parseRPCBlockResult(res.Result)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		return num, hashes, true, nil
+	params, err := json.Marshal([]interface{}{tag, false})
+	if err != nil {
+		return 0, nil, false, err
 	}
-	if lastErr == nil {
-		lastErr = errors.New("tx_monitor: no backends in group")
+	req := &RPCReq{
+		JSONRPC: JSONRPCVersion,
+		Method:  "eth_getBlockByNumber",
+		Params:  params,
+		ID:      []byte(`"txmon"`),
 	}
-	return 0, nil, false, lastErr
+	res, _, err := f.bg.Forward(ctx, []*RPCReq{req}, false)
+	if err != nil {
+		return 0, nil, false, err
+	}
+	if len(res) == 0 {
+		return 0, nil, false, errors.New("tx_monitor: empty forward response")
+	}
+	if res[0].IsError() {
+		return 0, nil, false, fmt.Errorf("tx_monitor: block poll: %w", res[0].Error)
+	}
+	if res[0].Result == nil {
+		return 0, nil, false, nil // block genuinely absent (walked past head)
+	}
+	num, hashes, err := parseRPCBlockResult(res[0].Result)
+	if err != nil {
+		return 0, nil, false, err
+	}
+	return num, hashes, true, nil
 }
 
 // parseRPCBlockResult parses a generic eth_getBlockByNumber(…, false) result

--- a/proxyd/tx_monitor_blocks.go
+++ b/proxyd/tx_monitor_blocks.go
@@ -91,7 +91,9 @@ func (f *backendGroupBlockFetcher) fetch(ctx context.Context, tag string) (uint6
 	var lastErr error
 	for _, be := range f.bg.Backends {
 		var res RPCRes
-		if err := be.ForwardRPC(ctx, &res, "txmon", "eth_getBlockByNumber", tag, false); err != nil {
+		// ForwardRPC embeds the id verbatim as JSON, so it must be a valid
+		// JSON value — hence the quoted string.
+		if err := be.ForwardRPC(ctx, &res, `"txmon"`, "eth_getBlockByNumber", tag, false); err != nil {
 			lastErr = err
 			continue
 		}

--- a/proxyd/tx_monitor_blocks.go
+++ b/proxyd/tx_monitor_blocks.go
@@ -1,0 +1,137 @@
+package proxyd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// blockFetcher abstracts "give me a block's tx hashes" so the monitor can
+// poll either an explicit RPC URL or one of proxyd's own backend groups.
+type blockFetcher interface {
+	LatestBlock(ctx context.Context) (uint64, []common.Hash, error)
+	BlockByNumber(ctx context.Context, num uint64) ([]common.Hash, bool, error)
+}
+
+// --- explicit URL fetcher (block_poll_url) ---
+
+type rpcBlockFetcher struct {
+	c *rpc.Client
+}
+
+func newRPCBlockFetcher(url string) (*rpcBlockFetcher, error) {
+	c, err := rpc.Dial(url)
+	if err != nil {
+		return nil, fmt.Errorf("tx_monitor: dialing block_poll_url: %w", err)
+	}
+	return &rpcBlockFetcher{c: c}, nil
+}
+
+// txmonRPCBlock decodes eth_getBlockByNumber(…, false): transactions are hashes.
+type txmonRPCBlock struct {
+	Number       hexutil.Uint64 `json:"number"`
+	Transactions []common.Hash  `json:"transactions"`
+}
+
+func (f *rpcBlockFetcher) LatestBlock(ctx context.Context) (uint64, []common.Hash, error) {
+	var blk *txmonRPCBlock
+	if err := f.c.CallContext(ctx, &blk, "eth_getBlockByNumber", "latest", false); err != nil {
+		return 0, nil, err
+	}
+	if blk == nil {
+		return 0, nil, errors.New("tx_monitor: null latest block")
+	}
+	return uint64(blk.Number), blk.Transactions, nil
+}
+
+func (f *rpcBlockFetcher) BlockByNumber(ctx context.Context, num uint64) ([]common.Hash, bool, error) {
+	var blk *txmonRPCBlock
+	if err := f.c.CallContext(ctx, &blk, "eth_getBlockByNumber", hexutil.EncodeUint64(num), false); err != nil {
+		return nil, false, err
+	}
+	if blk == nil {
+		return nil, false, nil
+	}
+	return blk.Transactions, true, nil
+}
+
+// --- backend group fetcher (default: blocks "visible to proxyd") ---
+
+type backendGroupBlockFetcher struct {
+	bg *BackendGroup
+}
+
+func newBackendGroupBlockFetcher(bg *BackendGroup) *backendGroupBlockFetcher {
+	return &backendGroupBlockFetcher{bg: bg}
+}
+
+func (f *backendGroupBlockFetcher) LatestBlock(ctx context.Context) (uint64, []common.Hash, error) {
+	num, hashes, found, err := f.fetch(ctx, "latest")
+	if err != nil {
+		return 0, nil, err
+	}
+	if !found {
+		return 0, nil, errors.New("tx_monitor: null latest block")
+	}
+	return num, hashes, nil
+}
+
+func (f *backendGroupBlockFetcher) BlockByNumber(ctx context.Context, num uint64) ([]common.Hash, bool, error) {
+	_, hashes, found, err := f.fetch(ctx, hexutil.EncodeUint64(num))
+	return hashes, found, err
+}
+
+// fetch tries each backend in the group until one answers. First-success is
+// enough: this is a monitor, not a consensus mechanism.
+func (f *backendGroupBlockFetcher) fetch(ctx context.Context, tag string) (uint64, []common.Hash, bool, error) {
+	var lastErr error
+	for _, be := range f.bg.Backends {
+		var res RPCRes
+		if err := be.ForwardRPC(ctx, &res, "txmon", "eth_getBlockByNumber", tag, false); err != nil {
+			lastErr = err
+			continue
+		}
+		if res.Result == nil {
+			return 0, nil, false, nil // block genuinely absent (walked past head)
+		}
+		num, hashes, err := parseRPCBlockResult(res.Result)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return num, hashes, true, nil
+	}
+	if lastErr == nil {
+		lastErr = errors.New("tx_monitor: no backends in group")
+	}
+	return 0, nil, false, lastErr
+}
+
+// parseRPCBlockResult parses a generic eth_getBlockByNumber(…, false) result
+// (as produced by RPCRes.Result: map[string]interface{}).
+func parseRPCBlockResult(result interface{}) (uint64, []common.Hash, error) {
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		return 0, nil, fmt.Errorf("tx_monitor: unexpected block result type %T", result)
+	}
+	numStr, ok := m["number"].(string)
+	if !ok {
+		return 0, nil, errors.New("tx_monitor: block result missing number")
+	}
+	num, err := hexutil.DecodeUint64(numStr)
+	if err != nil {
+		return 0, nil, err
+	}
+	rawTxs, _ := m["transactions"].([]interface{})
+	hashes := make([]common.Hash, 0, len(rawTxs))
+	for _, rt := range rawTxs {
+		if s, ok := rt.(string); ok {
+			hashes = append(hashes, common.HexToHash(s))
+		}
+	}
+	return num, hashes, nil
+}

--- a/proxyd/tx_monitor_blocks.go
+++ b/proxyd/tx_monitor_blocks.go
@@ -32,6 +32,12 @@ func newRPCBlockFetcher(url string) (*rpcBlockFetcher, error) {
 	return &rpcBlockFetcher{c: c}, nil
 }
 
+// Close releases the underlying RPC client; Shutdown calls it via io.Closer.
+func (f *rpcBlockFetcher) Close() error {
+	f.c.Close()
+	return nil
+}
+
 // txmonRPCBlock decodes eth_getBlockByNumber(…, false): transactions are hashes.
 type txmonRPCBlock struct {
 	Number       hexutil.Uint64 `json:"number"`

--- a/proxyd/tx_monitor_blocks_test.go
+++ b/proxyd/tx_monitor_blocks_test.go
@@ -1,0 +1,37 @@
+package proxyd
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRPCBlockResult(t *testing.T) {
+	h1 := common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	result := map[string]interface{}{
+		"number":       "0x10",
+		"transactions": []interface{}{h1.Hex()},
+	}
+	num, hashes, err := parseRPCBlockResult(result)
+	require.NoError(t, err)
+	require.Equal(t, uint64(16), num)
+	require.Equal(t, []common.Hash{h1}, hashes)
+}
+
+func TestParseRPCBlockResultEmptyBlock(t *testing.T) {
+	num, hashes, err := parseRPCBlockResult(map[string]interface{}{
+		"number":       "0x2a",
+		"transactions": []interface{}{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), num)
+	require.Empty(t, hashes)
+}
+
+func TestParseRPCBlockResultMalformed(t *testing.T) {
+	_, _, err := parseRPCBlockResult("nope")
+	require.Error(t, err)
+	_, _, err = parseRPCBlockResult(map[string]interface{}{"transactions": []interface{}{}})
+	require.Error(t, err, "missing number is an error")
+}

--- a/proxyd/tx_monitor_store.go
+++ b/proxyd/tx_monitor_store.go
@@ -1,0 +1,99 @@
+package proxyd
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// txmonEntry is one observed eth_sendRawTransaction awaiting inclusion.
+type txmonEntry struct {
+	Hash         common.Hash
+	BackendGroup string
+	Source       string
+	IngestedAt   time.Time
+	SubblockAt   time.Time // zero until seen in the subblocks stream
+}
+
+// PendingStore tracks pending transactions. The interface is batch-shaped so
+// a future Redis implementation can pipeline one multi-key op per block.
+type PendingStore interface {
+	Add(e txmonEntry) bool
+	MatchAndRemove(hashes []common.Hash) []txmonEntry
+	MarkSubblock(h common.Hash, at time.Time) (txmonEntry, bool)
+	ExpireBefore(cutoff time.Time) []txmonEntry
+	Len() int
+}
+
+type MemoryPendingStore struct {
+	mu  sync.Mutex
+	max int
+	txs map[common.Hash]txmonEntry
+}
+
+func NewMemoryPendingStore(maxPending int) *MemoryPendingStore {
+	return &MemoryPendingStore{max: maxPending, txs: make(map[common.Hash]txmonEntry)}
+}
+
+// Add records a pending tx. Returns false when the store is at capacity.
+// Re-adding a hash already present is a successful no-op: the first ingest
+// timestamp is the user-perceived submission time.
+func (s *MemoryPendingStore) Add(e txmonEntry) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.txs[e.Hash]; ok {
+		return true
+	}
+	if len(s.txs) >= s.max {
+		return false
+	}
+	s.txs[e.Hash] = e
+	return true
+}
+
+func (s *MemoryPendingStore) MatchAndRemove(hashes []common.Hash) []txmonEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []txmonEntry
+	for _, h := range hashes {
+		if e, ok := s.txs[h]; ok {
+			out = append(out, e)
+			delete(s.txs, h)
+		}
+	}
+	return out
+}
+
+// MarkSubblock stamps the first subblock sighting. Returns the updated entry
+// and true only on the first mark of a known hash.
+func (s *MemoryPendingStore) MarkSubblock(h common.Hash, at time.Time) (txmonEntry, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.txs[h]
+	if !ok || !e.SubblockAt.IsZero() {
+		return txmonEntry{}, false
+	}
+	e.SubblockAt = at
+	s.txs[h] = e
+	return e, true
+}
+
+func (s *MemoryPendingStore) ExpireBefore(cutoff time.Time) []txmonEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []txmonEntry
+	for h, e := range s.txs {
+		if e.IngestedAt.Before(cutoff) {
+			out = append(out, e)
+			delete(s.txs, h)
+		}
+	}
+	return out
+}
+
+func (s *MemoryPendingStore) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.txs)
+}

--- a/proxyd/tx_monitor_store_test.go
+++ b/proxyd/tx_monitor_store_test.go
@@ -1,0 +1,73 @@
+package proxyd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func txmonHash(b byte) common.Hash { return common.Hash{b} }
+
+func TestMemoryPendingStoreAddAndCap(t *testing.T) {
+	s := NewMemoryPendingStore(2)
+	require.True(t, s.Add(txmonEntry{Hash: txmonHash(1)}))
+	require.True(t, s.Add(txmonEntry{Hash: txmonHash(2)}))
+	require.False(t, s.Add(txmonEntry{Hash: txmonHash(3)}), "add beyond cap must be rejected")
+	require.Equal(t, 2, s.Len())
+	// Re-adding an existing hash (client retry through same replica) must not
+	// double-count: it is a no-op success.
+	require.True(t, s.Add(txmonEntry{Hash: txmonHash(1)}))
+	require.Equal(t, 2, s.Len())
+}
+
+func TestMemoryPendingStoreMatchAndRemove(t *testing.T) {
+	s := NewMemoryPendingStore(10)
+	t0 := time.Unix(100, 0)
+	s.Add(txmonEntry{Hash: txmonHash(1), IngestedAt: t0, BackendGroup: "main"})
+	s.Add(txmonEntry{Hash: txmonHash(2), IngestedAt: t0})
+
+	got := s.MatchAndRemove([]common.Hash{txmonHash(1), txmonHash(9)})
+	require.Len(t, got, 1)
+	require.Equal(t, txmonHash(1), got[0].Hash)
+	require.Equal(t, "main", got[0].BackendGroup)
+	require.Equal(t, 1, s.Len())
+	// Second match returns nothing — entry was removed.
+	require.Empty(t, s.MatchAndRemove([]common.Hash{txmonHash(1)}))
+}
+
+func TestMemoryPendingStoreMarkSubblock(t *testing.T) {
+	s := NewMemoryPendingStore(10)
+	t0 := time.Unix(100, 0)
+	t1 := time.Unix(101, 0)
+	s.Add(txmonEntry{Hash: txmonHash(1), IngestedAt: t0})
+
+	e, ok := s.MarkSubblock(txmonHash(1), t1)
+	require.True(t, ok)
+	require.Equal(t, t1, e.SubblockAt)
+	require.Equal(t, t0, e.IngestedAt)
+
+	// Idempotent: second mark reports false (already preconfirmed).
+	_, ok = s.MarkSubblock(txmonHash(1), t1.Add(time.Second))
+	require.False(t, ok)
+	// Unknown hash: false.
+	_, ok = s.MarkSubblock(txmonHash(9), t1)
+	require.False(t, ok)
+
+	// Entry stays until block inclusion; MatchAndRemove sees SubblockAt.
+	got := s.MatchAndRemove([]common.Hash{txmonHash(1)})
+	require.Len(t, got, 1)
+	require.Equal(t, t1, got[0].SubblockAt)
+}
+
+func TestMemoryPendingStoreExpireBefore(t *testing.T) {
+	s := NewMemoryPendingStore(10)
+	s.Add(txmonEntry{Hash: txmonHash(1), IngestedAt: time.Unix(100, 0)})
+	s.Add(txmonEntry{Hash: txmonHash(2), IngestedAt: time.Unix(200, 0)})
+
+	expired := s.ExpireBefore(time.Unix(150, 0))
+	require.Len(t, expired, 1)
+	require.Equal(t, txmonHash(1), expired[0].Hash)
+	require.Equal(t, 1, s.Len())
+}

--- a/proxyd/tx_monitor_subblocks.go
+++ b/proxyd/tx_monitor_subblocks.go
@@ -1,0 +1,42 @@
+package proxyd
+
+import (
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// subblockPayload is the subset of FlashblocksPayloadV1 the monitor needs.
+// diff.transactions carries raw RLP-encoded transactions (0x-hex), not hashes;
+// metadata is builder-specific and deliberately ignored.
+type subblockPayload struct {
+	Index uint64       `json:"index"`
+	Diff  subblockDiff `json:"diff"`
+}
+
+type subblockDiff struct {
+	Transactions []hexutil.Bytes `json:"transactions"`
+}
+
+// parseSubblockTxHashes extracts tx hashes from one subblocks-stream frame.
+// Individual undecodable transactions are skipped (a foreign tx type must not
+// blind the monitor to the rest of the subblock); malformed JSON is an error.
+func parseSubblockTxHashes(msg []byte) ([]common.Hash, error) {
+	var p subblockPayload
+	if err := json.Unmarshal(msg, &p); err != nil {
+		return nil, err
+	}
+	hashes := make([]common.Hash, 0, len(p.Diff.Transactions))
+	for _, raw := range p.Diff.Transactions {
+		tx := new(types.Transaction)
+		if err := tx.UnmarshalBinary(raw); err != nil {
+			log.Debug("tx_monitor: skipping undecodable subblock tx", "err", err)
+			continue
+		}
+		hashes = append(hashes, tx.Hash())
+	}
+	return hashes, nil
+}

--- a/proxyd/tx_monitor_subblocks_test.go
+++ b/proxyd/tx_monitor_subblocks_test.go
@@ -1,0 +1,60 @@
+package proxyd
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+// buildRawTx returns a signed tx's raw binary encoding and its hash.
+func buildRawTx(t *testing.T, nonce uint64) (hexutil.Bytes, common.Hash) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	to := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	tx := types.MustSignNewTx(key, types.LatestSignerForChainID(big.NewInt(901)), &types.DynamicFeeTx{
+		ChainID: big.NewInt(901), Nonce: nonce, To: &to,
+		Gas: 21000, GasFeeCap: big.NewInt(1e9), GasTipCap: big.NewInt(1e9),
+	})
+	raw, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	return raw, tx.Hash()
+}
+
+func TestParseSubblockTxHashes(t *testing.T) {
+	raw1, h1 := buildRawTx(t, 0)
+	raw2, h2 := buildRawTx(t, 1)
+	payload := map[string]any{
+		"payload_id": "0x0000000000000001",
+		"index":      1, // index>0: no "base" field — must still parse
+		"diff": map[string]any{
+			"transactions": []hexutil.Bytes{raw1, raw2},
+		},
+		"metadata": map[string]any{},
+	}
+	msg, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	hashes, err := parseSubblockTxHashes(msg)
+	require.NoError(t, err)
+	require.Equal(t, []common.Hash{h1, h2}, hashes)
+}
+
+func TestParseSubblockTxHashesSkipsGarbageTx(t *testing.T) {
+	raw1, h1 := buildRawTx(t, 0)
+	msg := []byte(`{"index":0,"diff":{"transactions":["0xdeadbeef","` + raw1.String() + `"]}}`)
+	hashes, err := parseSubblockTxHashes(msg)
+	require.NoError(t, err)
+	require.Equal(t, []common.Hash{h1}, hashes, "undecodable txs are skipped, not fatal")
+}
+
+func TestParseSubblockTxHashesBadJSON(t *testing.T) {
+	_, err := parseSubblockTxHashes([]byte("not json"))
+	require.Error(t, err)
+}

--- a/proxyd/tx_monitor_test.go
+++ b/proxyd/tx_monitor_test.go
@@ -2,6 +2,7 @@ package proxyd
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -103,12 +104,16 @@ type fakeFetcher struct {
 	latestNum    uint64
 	latestHashes []common.Hash
 	byNum        map[uint64][]common.Hash
+	errAt        map[uint64]error
 }
 
 func (f *fakeFetcher) LatestBlock(ctx context.Context) (uint64, []common.Hash, error) {
 	return f.latestNum, f.latestHashes, nil
 }
 func (f *fakeFetcher) BlockByNumber(ctx context.Context, num uint64) ([]common.Hash, bool, error) {
+	if err := f.errAt[num]; err != nil {
+		return nil, false, err
+	}
 	h, ok := f.byNum[num]
 	return h, ok, nil
 }
@@ -135,4 +140,53 @@ func TestTxMonitorPollWalksMissedHeights(t *testing.T) {
 
 	require.Equal(t, uint64(12), m.lastBlock)
 	require.Equal(t, 0, m.store.Len(), "both gap-block and tip-block txs must be matched")
+}
+
+func TestTxMonitorConfigValidation(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cfg  TxMonitorConfig
+		want string
+	}{
+		{"negative poll_interval", TxMonitorConfig{PollInterval: TOMLDuration(-time.Second)}, "poll_interval"},
+		{"negative inclusion_timeout", TxMonitorConfig{InclusionTimeout: TOMLDuration(-time.Second)}, "inclusion_timeout"},
+		{"negative max_pending", TxMonitorConfig{MaxPending: -1}, "max_pending"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewTxMonitor(tt.cfg, nil, nil)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestTxMonitorPollGapFetchErrorRetries(t *testing.T) {
+	m, now := newTestTxMonitor(t)
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+	defer m.cancel()
+	hGap := common.Hash{0x11}
+	hTip := common.Hash{0x22}
+	m.store.Add(txmonEntry{Hash: hGap, IngestedAt: *now})
+	m.store.Add(txmonEntry{Hash: hTip, IngestedAt: *now})
+
+	f := &fakeFetcher{latestNum: 10, byNum: map[uint64][]common.Hash{}, errAt: map[uint64]error{}}
+	m.fetcher = f
+	m.pollOnce() // establishes lastBlock=10
+	require.Equal(t, uint64(10), m.lastBlock)
+
+	// Height 11 lands hGap but its fetch fails; tip jumps to 12 with hTip.
+	// The cursor must not advance past the failed height, and the tip must
+	// not be processed early.
+	f.errAt[11] = errors.New("backend hiccup")
+	f.latestNum = 12
+	f.latestHashes = []common.Hash{hTip}
+	m.pollOnce()
+	require.Equal(t, uint64(10), m.lastBlock, "cursor must stay at last processed height")
+	require.Equal(t, 2, m.store.Len(), "nothing matched while the gap is unread")
+
+	// Next tick the gap height fetch succeeds: both gap and tip are matched.
+	delete(f.errAt, 11)
+	f.byNum[11] = []common.Hash{hGap}
+	m.pollOnce()
+	require.Equal(t, uint64(12), m.lastBlock)
+	require.Equal(t, 0, m.store.Len(), "gap and tip txs matched after retry")
 }

--- a/proxyd/tx_monitor_test.go
+++ b/proxyd/tx_monitor_test.go
@@ -1,10 +1,13 @@
 package proxyd
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,4 +32,107 @@ poll_interval = "500ms"
 	require.Equal(t, TOMLDuration(45*time.Second), cfg.TxMonitor.InclusionTimeout)
 	require.Equal(t, 5000, cfg.TxMonitor.MaxPending)
 	require.Equal(t, TOMLDuration(500*time.Millisecond), cfg.TxMonitor.PollInterval)
+}
+
+// newTestTxMonitor builds a monitor with a fake clock and no goroutines.
+func newTestTxMonitor(t *testing.T) (*TxMonitor, *time.Time) {
+	t.Helper()
+	now := time.Unix(1000, 0)
+	m := &TxMonitor{
+		cfg:    TxMonitorConfig{MaxPending: 100, InclusionTimeout: TOMLDuration(60 * time.Second)},
+		events: make(chan txmonEvent, 4),
+		store:  NewMemoryPendingStore(100),
+		now:    func() time.Time { return now },
+	}
+	return m, &now
+}
+
+func TestTxMonitorBlockInclusion(t *testing.T) {
+	m, now := newTestTxMonitor(t)
+	h := common.Hash{0xab}
+	m.store.Add(txmonEntry{Hash: h, IngestedAt: *now, BackendGroup: "main"})
+
+	*now = now.Add(2 * time.Second)
+	m.handleBlock([]common.Hash{h}, *now)
+
+	require.Equal(t, 0, m.store.Len(), "included tx must be evicted")
+	// Latency observed exactly once for source=block.
+	c := testutil.CollectAndCount(txmonInclusionLatency)
+	require.GreaterOrEqual(t, c, 1)
+}
+
+func TestTxMonitorSubblockThenBlock(t *testing.T) {
+	m, now := newTestTxMonitor(t)
+	h := common.Hash{0xcd}
+	m.store.Add(txmonEntry{Hash: h, IngestedAt: *now, BackendGroup: "main"})
+
+	*now = now.Add(250 * time.Millisecond)
+	m.handleSubblockHashes([]common.Hash{h}, *now)
+	require.Equal(t, 1, m.store.Len(), "preconfirmed tx stays pending until block inclusion")
+	// Second sighting in a later subblock is a no-op (idempotent).
+	m.handleSubblockHashes([]common.Hash{h}, now.Add(250*time.Millisecond))
+
+	*now = now.Add(2 * time.Second)
+	m.handleBlock([]common.Hash{h}, *now)
+	require.Equal(t, 0, m.store.Len())
+}
+
+func TestTxMonitorReap(t *testing.T) {
+	m, now := newTestTxMonitor(t)
+	h := common.Hash{0xef}
+	m.store.Add(txmonEntry{Hash: h, IngestedAt: *now, BackendGroup: "main"})
+	before := testutil.ToFloat64(txmonTimeoutsTotal.WithLabelValues("main"))
+
+	*now = now.Add(61 * time.Second)
+	m.reapOnce()
+
+	require.Equal(t, 0, m.store.Len())
+	require.Equal(t, before+1, testutil.ToFloat64(txmonTimeoutsTotal.WithLabelValues("main")))
+}
+
+func TestTxMonitorObserveNeverBlocks(t *testing.T) {
+	m, _ := newTestTxMonitor(t) // events buffer of 4, no ingest loop running
+	before := testutil.ToFloat64(txmonDroppedEventsTotal.WithLabelValues("channel_full"))
+	for i := range 10 {
+		m.Observe(common.Hash{byte(i)}, "main", RPCRequestSourceHTTP) // must return immediately
+	}
+	require.Equal(t, before+6, testutil.ToFloat64(txmonDroppedEventsTotal.WithLabelValues("channel_full")))
+}
+
+type fakeFetcher struct {
+	latestNum    uint64
+	latestHashes []common.Hash
+	byNum        map[uint64][]common.Hash
+}
+
+func (f *fakeFetcher) LatestBlock(ctx context.Context) (uint64, []common.Hash, error) {
+	return f.latestNum, f.latestHashes, nil
+}
+func (f *fakeFetcher) BlockByNumber(ctx context.Context, num uint64) ([]common.Hash, bool, error) {
+	h, ok := f.byNum[num]
+	return h, ok, nil
+}
+
+func TestTxMonitorPollWalksMissedHeights(t *testing.T) {
+	m, now := newTestTxMonitor(t)
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+	defer m.cancel()
+	hGap := common.Hash{0x11}
+	hTip := common.Hash{0x22}
+	m.store.Add(txmonEntry{Hash: hGap, IngestedAt: *now})
+	m.store.Add(txmonEntry{Hash: hTip, IngestedAt: *now})
+
+	f := &fakeFetcher{latestNum: 10, byNum: map[uint64][]common.Hash{}}
+	m.fetcher = f
+	m.pollOnce() // establishes lastBlock=10
+	require.Equal(t, uint64(10), m.lastBlock)
+
+	// Height 11 lands hGap while we weren't looking; tip jumps to 12 with hTip.
+	f.byNum[11] = []common.Hash{hGap}
+	f.latestNum = 12
+	f.latestHashes = []common.Hash{hTip}
+	m.pollOnce()
+
+	require.Equal(t, uint64(12), m.lastBlock)
+	require.Equal(t, 0, m.store.Len(), "both gap-block and tip-block txs must be matched")
 }

--- a/proxyd/tx_monitor_test.go
+++ b/proxyd/tx_monitor_test.go
@@ -1,0 +1,32 @@
+package proxyd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxMonitorConfigDecode(t *testing.T) {
+	cfgToml := `
+[tx_monitor]
+enabled = true
+block_poll_url = "http://localhost:8545"
+block_poll_backend_group = "replicas"
+subblocks_ws_url = "ws://localhost:1112/ws"
+inclusion_timeout = "45s"
+max_pending = 5000
+poll_interval = "500ms"
+`
+	var cfg Config
+	_, err := toml.Decode(cfgToml, &cfg)
+	require.NoError(t, err)
+	require.True(t, cfg.TxMonitor.Enabled)
+	require.Equal(t, "http://localhost:8545", cfg.TxMonitor.BlockPollURL)
+	require.Equal(t, "replicas", cfg.TxMonitor.BlockPollBackendGroup)
+	require.Equal(t, "ws://localhost:1112/ws", cfg.TxMonitor.SubblocksWSURL)
+	require.Equal(t, TOMLDuration(45*time.Second), cfg.TxMonitor.InclusionTimeout)
+	require.Equal(t, 5000, cfg.TxMonitor.MaxPending)
+	require.Equal(t, TOMLDuration(500*time.Millisecond), cfg.TxMonitor.PollInterval)
+}


### PR DESCRIPTION
**Description**

Adds a passive transaction-UX monitor to proxyd, gated by a new `[tx_monitor]` config section. When enabled, proxyd observes every successfully forwarded `eth_sendRawTransaction`/`eth_sendRawTransactionConditional` hash and measures how long each real user transaction takes to become visible in a block — and, when `subblocks_ws_url` is set, in the subblocks (flashblocks) preconfirmation stream — emitting Prometheus histograms, or timing entries out.

Design highlights:

- **Zero hot-path impact.** The only addition to request handling is a nil-check plus a non-blocking buffered-channel send (`select`/`default`); overflow increments a drop counter instead of blocking. Disabled config means a nil monitor and no work at all.
- **Shared-nothing across replicas.** Each replica tracks only the txs it ingested, polls `eth_getBlockByNumber(…, false)` (hashes only) through its own backend group (or an explicit `block_poll_url`), and holds one WS connection to the subblocks stream. Histograms aggregate across instances in Prometheus.
- **Not a critical service.** Capped in-memory pending map (default 10k), missed-height walk capped at 32 blocks, WS reconnect with capped backoff, 10 MiB WS read limit so a misbehaving stream cannot OOM proxyd, and clean goroutine shutdown wired into the existing shutdown closure.
- Subblock frames are decoded from the raw RLP transactions in `diff.transactions` (builder-independent; `metadata` is deliberately ignored). Preconfirmed entries stay pending until block inclusion so the subblock→block gap (eventual consistency) is measured too.

New metrics (namespace `proxyd`): `txmon_inclusion_latency_seconds{source=block|subblock, backend_group}`, `txmon_subblock_to_block_seconds`, `txmon_timeouts_total`, `txmon_dropped_events_total{reason}`, `txmon_pending`, `txmon_stream_disconnects_total`.

**Tests**

- Unit tests for the pending store (cap, idempotent re-add, match/remove, subblock marking, expiry), subblock frame parsing (real signed txs, garbage-tolerant, malformed JSON), block-result parsing, and the monitor core (block inclusion, subblock-then-block, timeout reaping, non-blocking Observe under overflow, missed-height walk) using a fake clock and fake fetcher.
- Full package suite and `integration_tests` pass.
- Live smoke test: proxyd + anvil (1s blocks), one `cast send` through proxyd produced `proxyd_txmon_inclusion_latency_seconds_count{backend_group="main",source="block"} 1` and `proxyd_txmon_pending 0`, with graceful `stopping tx monitor` on shutdown.

**Additional context**

Complements op-ufm (synthetic probes) by passively measuring real user traffic; treats the sequencer/mempool as a black box, so the numbers reflect what users polling through proxyd actually experience. The companion deployment change (rendering `[tx_monitor]` via netchef, auto-wiring the subblocks stream URL) ships separately in infrastructure-services.

**Metadata**

- Fixes #N/A (hackathon project)
