### PR TITLE
proxyd: start tx_monitor inclusion clock at request receipt

### DIFF
--- a/proxyd/CHANGELOG.md
+++ b/proxyd/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- Added passive tx-UX monitor (`[tx_monitor]`): inclusion-latency histograms from forwarded `eth_sendRawTransaction` to block/subblock visibility.
+- Added passive tx-UX monitor (`[tx_monitor]`): inclusion-latency histograms measured from `eth_sendRawTransaction` request receipt (covering proxyd-internal handling and the forward round-trip) to block/subblock visibility.
 
 ## 3.14.1
 

--- a/proxyd/README.md
+++ b/proxyd/README.md
@@ -149,10 +149,14 @@ See [op-node receipt fetcher](https://github.com/ethereum-optimism/optimism/blob
 
 ## Transaction UX monitor (`tx_monitor`)
 
-When `[tx_monitor]` is enabled, proxyd passively measures the latency from a
-successfully forwarded `eth_sendRawTransaction` until the transaction becomes
-visible in a block (and, optionally, in a subblocks preconfirmation stream),
-reporting the results as `proxyd_txmon_*` metrics. The monitor is purely
+When `[tx_monitor]` is enabled, proxyd passively measures the latency from
+when an `eth_sendRawTransaction` request is received until the transaction
+becomes visible in a block (and, optionally, in a subblocks preconfirmation
+stream). The clock starts at request ingress, so the measured latency
+includes proxyd-internal handling and the forward round-trip, not just the
+backend-ack-to-block window. Transactions rejected by validation or by the
+backend node (e.g. nonce too low) are never enrolled and so never counted.
+Results are reported as `proxyd_txmon_*` metrics. The monitor is purely
 observational: observations are non-blocking and never affect request
 handling, and its state is in-memory and shared-nothing across replicas —
 each proxyd instance only tracks the transactions it forwarded itself.

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1530,6 +1530,10 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 			return
 		}
 
+		// Stamp per-message arrival so the tx monitor's inclusion clock starts
+		// when this request was read, not when the (long-lived) WS connection
+		// opened. Overrides the connection-open time from populateContext.
+		recvAt := time.Now()
 		RecordWSMessage(ctx, w.backend.Name, SourceClient)
 
 		// Route control messages to the backend. These don't
@@ -1616,7 +1620,8 @@ func (w *WSProxier) clientPump(ctx context.Context, errC chan error) {
 				continue
 			}
 			// handleWSRPC records this call; do not record it here too.
-			go w.processClientRPC(ctx, msgType, req, errC)
+			msgCtx := context.WithValue(ctx, ContextKeyReqReceivedAt, recvAt) // nolint:staticcheck
+			go w.processClientRPC(msgCtx, msgType, req, errC)
 			continue
 		}
 

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -37,6 +37,7 @@ const (
 	ContextKeyXForwardedFor                         = "x_forwarded_for"
 	ContextKeyOpTxProxyAuth                         = "op_txproxy_auth"
 	ContextKeyInteropValidationStrategy             = "interop_validation_strategy"
+	ContextKeyReqReceivedAt                         = "req_received_at"
 	DefaultOpTxProxyAuthHeader                      = "X-Optimism-Signature"
 	DefaultMaxBatchRPCCallsLimit                    = 100
 	MaxBatchRPCCallsHardLimit                       = 1000
@@ -849,9 +850,10 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			// a tx the backend rejected will never land and would only count as
 			// a false timeout.
 			if err == nil && s.txMonitor != nil {
+				receivedAt := GetReqReceivedAt(ctx)
 				for i, elem := range elems {
 					if txHash, ok := txHashes[elem.Index]; ok && i < len(res) && res[i] != nil && !res[i].IsError() {
-						s.txMonitor.Observe(txHash, group.backendGroup, RPCRequestSourceHTTP)
+						s.txMonitor.Observe(txHash, group.backendGroup, RPCRequestSourceHTTP, receivedAt)
 					}
 				}
 			}
@@ -1030,7 +1032,7 @@ func (s *Server) handleWSRPCInner(ctx context.Context, req *RPCReq, isLimited li
 	}
 
 	if txHash != nil && s.txMonitor != nil && res[0] != nil && !res[0].IsError() {
-		s.txMonitor.Observe(*txHash, group, RPCRequestSourceWS)
+		s.txMonitor.Observe(*txHash, group, RPCRequestSourceWS, GetReqReceivedAt(ctx))
 	}
 
 	return res[0], servedBy
@@ -1045,6 +1047,7 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 	}
 
 	ctx := context.WithValue(r.Context(), ContextKeyXForwardedFor, xff) // nolint:staticcheck
+	ctx = context.WithValue(ctx, ContextKeyReqReceivedAt, time.Now())   // nolint:staticcheck
 
 	opTxProxyAuth := r.Header.Get(DefaultOpTxProxyAuthHeader)
 	if opTxProxyAuth != "" {
@@ -1334,6 +1337,17 @@ func GetReqID(ctx context.Context) string {
 		return ""
 	}
 	return reqId
+}
+
+// GetReqReceivedAt returns the wall-clock time the request was received at
+// ingress, stamped by populateContext (HTTP) or per-message in the WS pump.
+// It falls back to time.Now() when unset (internal or test callers) so the tx
+// monitor never records a zero start time.
+func GetReqReceivedAt(ctx context.Context) time.Time {
+	if t, ok := ctx.Value(ContextKeyReqReceivedAt).(time.Time); ok {
+		return t
+	}
+	return time.Now()
 }
 
 func GetXForwardedFor(ctx context.Context) string {

--- a/proxyd/tx_monitor.go
+++ b/proxyd/tx_monitor.go
@@ -130,10 +130,12 @@ func (m *TxMonitor) Shutdown() {
 
 // Observe records a successfully forwarded tx. Non-blocking by construction:
 // a full channel drops the observation and counts it. This is the ONLY method
-// called from the request hot path.
-func (m *TxMonitor) Observe(hash common.Hash, backendGroup string, source string) {
+// called from the request hot path. at is the request-arrival time captured at
+// ingress, so inclusion latency accounts for proxyd-internal handling and the
+// forward round-trip, not just backend-ack-to-block.
+func (m *TxMonitor) Observe(hash common.Hash, backendGroup string, source string, at time.Time) {
 	select {
-	case m.events <- txmonEvent{hash: hash, backendGroup: backendGroup, source: source, at: m.now()}:
+	case m.events <- txmonEvent{hash: hash, backendGroup: backendGroup, source: source, at: at}:
 	default:
 		txmonDroppedChannelFull.Inc()
 	}

--- a/proxyd/tx_monitor_store.go
+++ b/proxyd/tx_monitor_store.go
@@ -37,12 +37,19 @@ func NewMemoryPendingStore(maxPending int) *MemoryPendingStore {
 }
 
 // Add records a pending tx. Returns false when the store is at capacity.
-// Re-adding a hash already present is a successful no-op: the first ingest
-// timestamp is the user-perceived submission time.
+// Re-adding a hash already present keeps whichever entry has the earlier
+// IngestedAt: that is the user-perceived submission time, and because
+// IngestedAt is stamped at request ingress, a later duplicate submission may
+// be observed (enqueued) before an earlier one. Any already-set SubblockAt on
+// the retained entry is preserved.
 func (s *MemoryPendingStore) Add(e txmonEntry) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.txs[e.Hash]; ok {
+	if existing, ok := s.txs[e.Hash]; ok {
+		if e.IngestedAt.Before(existing.IngestedAt) {
+			e.SubblockAt = existing.SubblockAt
+			s.txs[e.Hash] = e
+		}
 		return true
 	}
 	if len(s.txs) >= s.max {

--- a/proxyd/tx_monitor_store_test.go
+++ b/proxyd/tx_monitor_store_test.go
@@ -22,6 +22,37 @@ func TestMemoryPendingStoreAddAndCap(t *testing.T) {
 	require.Equal(t, 2, s.Len())
 }
 
+// A duplicate submission of the same hash must retain the earliest
+// IngestedAt (the user-perceived submission time). Because IngestedAt is
+// stamped at request ingress, a later-arriving duplicate can be observed
+// first, so Add must compare timestamps rather than keep whatever landed
+// first. Any SubblockAt already recorded is preserved across the swap.
+func TestMemoryPendingStoreAddKeepsEarliest(t *testing.T) {
+	s := NewMemoryPendingStore(10)
+	early := time.Unix(100, 0)
+	late := time.Unix(200, 0)
+
+	// Later arrival observed first, then the earlier one; earliest must win.
+	require.True(t, s.Add(txmonEntry{Hash: txmonHash(1), IngestedAt: late, BackendGroup: "late"}))
+	require.True(t, s.Add(txmonEntry{Hash: txmonHash(1), IngestedAt: early, BackendGroup: "early"}))
+	require.Equal(t, 1, s.Len())
+	got := s.MatchAndRemove([]common.Hash{txmonHash(1)})
+	require.Len(t, got, 1)
+	require.Equal(t, early, got[0].IngestedAt)
+	require.Equal(t, "early", got[0].BackendGroup)
+
+	// A later duplicate after the earliest is a no-op and preserves SubblockAt.
+	sub := time.Unix(150, 0)
+	require.True(t, s.Add(txmonEntry{Hash: txmonHash(2), IngestedAt: early}))
+	_, ok := s.MarkSubblock(txmonHash(2), sub)
+	require.True(t, ok)
+	require.True(t, s.Add(txmonEntry{Hash: txmonHash(2), IngestedAt: late}))
+	got = s.MatchAndRemove([]common.Hash{txmonHash(2)})
+	require.Len(t, got, 1)
+	require.Equal(t, early, got[0].IngestedAt)
+	require.Equal(t, sub, got[0].SubblockAt, "SubblockAt must survive a no-op duplicate")
+}
+
 func TestMemoryPendingStoreMatchAndRemove(t *testing.T) {
 	s := NewMemoryPendingStore(10)
 	t0 := time.Unix(100, 0)

--- a/proxyd/tx_monitor_test.go
+++ b/proxyd/tx_monitor_test.go
@@ -95,9 +95,29 @@ func TestTxMonitorObserveNeverBlocks(t *testing.T) {
 	m, _ := newTestTxMonitor(t) // events buffer of 4, no ingest loop running
 	before := testutil.ToFloat64(txmonDroppedEventsTotal.WithLabelValues("channel_full"))
 	for i := range 10 {
-		m.Observe(common.Hash{byte(i)}, "main", RPCRequestSourceHTTP) // must return immediately
+		m.Observe(common.Hash{byte(i)}, "main", RPCRequestSourceHTTP, time.Unix(1000, 0)) // must return immediately
 	}
 	require.Equal(t, before+6, testutil.ToFloat64(txmonDroppedEventsTotal.WithLabelValues("channel_full")))
+}
+
+// Observe must record the caller-supplied arrival time as the ingest
+// timestamp, so inclusion latency starts at request receipt rather than at
+// the moment the observation is enqueued.
+func TestTxMonitorObserveUsesArrivalTime(t *testing.T) {
+	m, _ := newTestTxMonitor(t)
+	arrival := time.Unix(500, 0)
+	m.Observe(common.Hash{0x01}, "main", RPCRequestSourceHTTP, arrival)
+	ev := <-m.events
+	require.Equal(t, arrival, ev.at)
+}
+
+// GetReqReceivedAt round-trips a stamped time and falls back to a non-zero
+// time when unset, so the monitor never records a zero start.
+func TestGetReqReceivedAt(t *testing.T) {
+	require.False(t, GetReqReceivedAt(context.Background()).IsZero(), "must fall back to now when unset")
+	want := time.Unix(1234, 0)
+	ctx := context.WithValue(context.Background(), ContextKeyReqReceivedAt, want) // nolint:staticcheck
+	require.Equal(t, want, GetReqReceivedAt(ctx))
 }
 
 type fakeFetcher struct {


### PR DESCRIPTION
## What

The `tx_monitor` inclusion-latency clock now starts at **request receipt** instead of at backend-ack (post-forward success).

### Why

The previous start boundary excluded proxyd-internal handling (rate limiting, validation, batching) and the forward round-trip to the backend — precisely the latency a "tx UX" monitor exists to catch. The measured window was really "backend-ack → this-replica-notices-block," not "submit → inclusion."

The end boundary is intentionally left as poll-observation wall-clock (not the block header timestamp): it reflects when the user can actually perceive inclusion through the same infra, not when the sequencer produced the block.

### Changes

- `TxMonitor.Observe` takes an `at time.Time` (request-arrival), used directly as the ingest timestamp instead of `m.now()`.
- New `ContextKeyReqReceivedAt` + `GetReqReceivedAt(ctx)` getter (falls back to `time.Now()` when unset, so the start is never zero).
- **HTTP**: `populateContext` stamps arrival at ingress.
- **WS**: `clientPump` stamps a per-**message** arrival time and threads it through a per-message ctx (the connection ctx would otherwise yield connection-open time).

### Rejected txns need no eviction

Enrollment stays on the single success hook, so rejects are excluded structurally:
- Validation rejects return a local response and `continue` before forwarding — never observed.
- Backend rejects (nonce-too-low, underpriced, ...) come back as JSON-RPC error results, filtered by the existing `!res[i].IsError()` guard.

The store already dedups on hash and keeps the earliest arrival time, so resubmits preserve the first-seen submission time.

### Not addressed (inherent to a passive v1)

Accepted-then-dropped txns (mempool eviction, same-nonce replacement) still age out as `txmon_timeouts_total` — cannot be popped without receipt polling.

## Tests

- New `TestTxMonitorObserveUsesArrivalTime`, `TestGetReqReceivedAt`; updated `TestTxMonitorObserveNeverBlocks` for the new signature.
- `go vet ./.`, `go build ./...`, and tx-monitor tests pass.